### PR TITLE
Fix issue where mutiple JSON libraries were loading causing warnings.

### DIFF
--- a/lib/tasks_private/spec_migrations.rake
+++ b/lib/tasks_private/spec_migrations.rake
@@ -48,7 +48,9 @@ namespace :spec do
 
       cmd = "bundle exec rake #{rake_command}"
       cmd << " --trace" if Rake.application.options.trace
-      _pid, status = Process.wait2(Kernel.spawn(env, cmd))
+      _pid, status = Bundler.with_clean_env do
+        Process.wait2(Kernel.spawn(env, cmd))
+      end
       exit(status.exitstatus) if status.exitstatus != 0
     end
   end


### PR DESCRIPTION
Bundler somehow messes with the env causing rake to use the pure stdlib
json, but activerecord to use the json gem.  Telling Bundler to clear
its env allows the child process to do a clean `bundle exec`.

Fixes #11 

@jrafanie Please review.