### PR TITLE
add MiqQueue#tracking_label

### DIFF
--- a/db/migrate/20170622210452_create_miq_queues_work_label.rb
+++ b/db/migrate/20170622210452_create_miq_queues_work_label.rb
@@ -1,0 +1,5 @@
+class CreateMiqQueuesWorkLabel < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_queue, :tracking_label, :string, :comment => 'label to track requests through the system'
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5018,6 +5018,7 @@ miq_queue:
 - for_user
 - for_user_id
 - expires_on
+- tracking_label
 miq_regions:
 - id
 - region


### PR DESCRIPTION
The tracking label will help us track work flowing
through the system, even across the queue

related to:
- ManageIQ/manageiq#15224
- ManageIQ/manageiq-gems-pending#183