### PR TITLE
subclassing ContainerImage to Openshift::ContainerImage

### DIFF
--- a/db/migrate/20170613144708_add_sti_to_container_image.rb
+++ b/db/migrate/20170613144708_add_sti_to_container_image.rb
@@ -1,20 +1,6 @@
 class AddStiToContainerImage < ActiveRecord::Migration[5.0]
-  class ContainerImage < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
-  end
-
-
-  def up
+  def change
     add_column :container_images, :type, :string
     add_column :container_images, :ems_ref, :string
-    say_with_time("Updating type column for ContainerImage") do
-      ContainerImage.where(:size => nil).update_all(:type => "ContainerImage")
-      ContainerImage.where.not(:size => nil).update_all(:type => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage")
-    end
-  end
-
-  def down
-    remove_column :container_images, :type
-    remove_column :container_images, :ems_ref
   end
 end

--- a/db/migrate/20170613144708_add_sti_to_container_image.rb
+++ b/db/migrate/20170613144708_add_sti_to_container_image.rb
@@ -1,0 +1,20 @@
+class AddStiToContainerImage < ActiveRecord::Migration[5.0]
+  class ContainerImage < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+
+  def up
+    add_column :container_images, :type, :string
+    add_column :container_images, :ems_ref, :string
+    say_with_time("Updating type column for ContainerImage") do
+      ContainerImage.where(:size => nil).update_all(:type => "ContainerImage")
+      ContainerImage.where.not(:size => nil).update_all(:type => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage")
+    end
+  end
+
+  def down
+    remove_column :container_images, :type
+    remove_column :container_images, :ems_ref
+  end
+end

--- a/db/migrate/20170627135623_update_container_image_types.rb
+++ b/db/migrate/20170627135623_update_container_image_types.rb
@@ -1,0 +1,12 @@
+class UpdateContainerImageTypes < ActiveRecord::Migration[5.0]
+  class ContainerImage < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Updating type column for ContainerImage") do
+      ContainerImage.where(:size => nil).update_all(:type => "ContainerImage")
+      ContainerImage.where.not(:size => nil).update_all(:type => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage")
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -749,6 +749,8 @@ container_images:
 - created_on
 - old_ems_id
 - deleted_on
+- type
+- ems_ref
 container_label_tag_mappings:
 - id
 - labeled_resource_type

--- a/spec/migrations/20170613144708_add_sti_to_container_image_spec.rb
+++ b/spec/migrations/20170613144708_add_sti_to_container_image_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe AddStiToContainerImage do
+  let(:container_image_stub) { migration_stub(:ContainerImage) }
+
+  migration_context :up do
+    it "setting type correctly" do
+      container_image = container_image_stub.create!
+      openshift_container_image = container_image_stub.create!(:size => 12_345)
+
+      migrate
+
+      expect(container_image.reload).to have_attributes(:type => "ContainerImage")
+      expect(openshift_container_image.reload).to have_attributes(:type => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage")
+    end
+  end
+end

--- a/spec/migrations/20170627135623_update_container_image_types_spec.rb
+++ b/spec/migrations/20170627135623_update_container_image_types_spec.rb
@@ -1,6 +1,6 @@
 require_migration
 
-describe AddStiToContainerImage do
+describe UpdateContainerImageTypes do
   let(:container_image_stub) { migration_stub(:ContainerImage) }
 
   migration_context :up do


### PR DESCRIPTION
Adds type and ems_ref columns to ContainerImage and enables STI.
allow annotating only OpenshiftContainerImages
and remove annotation function from container_image


Schema changes split from https://github.com/ManageIQ/manageiq/pull/15386