### PR TITLE
Archive Container Nodes

### DIFF
--- a/db/migrate/20170611130239_add_disconnection_fields_to_container_node.rb
+++ b/db/migrate/20170611130239_add_disconnection_fields_to_container_node.rb
@@ -1,0 +1,6 @@
+class AddDisconnectionFieldsToContainerNode < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_nodes, :old_ems_id, :bigint
+    add_column :container_nodes, :deleted_on, :datetime
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -795,6 +795,8 @@ container_nodes:
 - container_runtime_version
 - max_container_groups
 - created_on
+- old_ems_id
+- deleted_on
 container_port_configs:
 - id
 - ems_ref


### PR DESCRIPTION
Adding `deleted_on` and `old_ems_id` columns to `container_nodes` table.
Extracted from  https://github.com/ManageIQ/manageiq/pull/15351.

@simon3z @moolitayer 