### PR TITLE
This attribute is no longer used.

### DIFF
--- a/db/migrate/20170621204151_drop_miq_queue_for_user.rb
+++ b/db/migrate/20170621204151_drop_miq_queue_for_user.rb
@@ -1,0 +1,11 @@
+class DropMiqQueueForUser < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :miq_queue, :for_user
+    remove_column :miq_queue, :for_user_id
+  end
+
+  def down
+    add_column :miq_queue, :for_user,    :string
+    add_column :miq_queue, :for_user_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5015,8 +5015,6 @@ miq_queue:
 - msg_timeout
 - handler_id
 - handler_type
-- for_user
-- for_user_id
 - expires_on
 - tracking_label
 miq_regions:


### PR DESCRIPTION
To be honest I can't really find when it was ever used.
I was able to track down the individual commit that introduced it, but did not find code that used it

moved from https://github.com/ManageIQ/manageiq/pull/15424