### PR TITLE
Rename applies_to_exp to visibility_expression

### DIFF
--- a/db/migrate/20170713083836_rename_applies_to_visibility_expression.rb
+++ b/db/migrate/20170713083836_rename_applies_to_visibility_expression.rb
@@ -1,0 +1,5 @@
+class RenameAppliesToVisibilityExpression < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :custom_buttons, :applies_to_exp, :visibility_expression
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -985,7 +985,7 @@ custom_buttons:
 - guid
 - description
 - applies_to_class
-- applies_to_exp
+- visibility_expression
 - options
 - userid
 - wait_for_complete


### PR DESCRIPTION
`applies_to_exp` is unused and we can use it for storing
MiqExpression which can say whether the button will be
displayed or not. 
I think that it is better-named regard to feature but I am open for other ideas how to name it.

## Links 
https://www.pivotaltracker.com/n/projects/1608513/stories/147780727
cc @gtanzillo 

@miq-bot assign @Fryguy 

@miq-bot  add_label gapridashvili
