### PR TITLE
Add object_labels to Container Template

### DIFF
--- a/db/migrate/20170705074637_add_object_labels_to_container_templates.rb
+++ b/db/migrate/20170705074637_add_object_labels_to_container_templates.rb
@@ -1,0 +1,5 @@
+class AddObjectLabelsToContainerTemplates < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_templates, :object_labels, :text
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -884,6 +884,7 @@ container_templates:
 - objects
 - created_at
 - updated_at
+- object_labels
 - type
 container_volumes:
 - id


### PR DESCRIPTION
Adding `object_labels` column to `container_templates` table. 

Related PR: https://github.com/ManageIQ/manageiq/pull/15406

@miq-bot add_label enhancement

cc @simon3z @lfu