### PR TITLE
Add stored_data column to showback_event model

### DIFF
--- a/db/migrate/20170707155809_add_stored_data_to_showback_charge.rb
+++ b/db/migrate/20170707155809_add_stored_data_to_showback_charge.rb
@@ -1,0 +1,5 @@
+class AddStoredDataToShowbackCharge < ActiveRecord::Migration[5.0]
+  def change
+    add_column :showback_charges, :stored_data, :jsonb, :comment => 'Snapshot of the data of showbackevent'
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5930,6 +5930,7 @@ showback_charges:
 - showback_event_id
 - created_at
 - updated_at
+- stored_data
 showback_events:
 - id
 - data


### PR DESCRIPTION
We need to add a stored_data column to save the data of the event when the charge changes. @sergio-ocon 
![img_2017-07-07 18 06 58](https://user-images.githubusercontent.com/3019213/27966317-201de18c-633f-11e7-8e2b-d935b55aa663.jpg)
