### PR TITLE
Add type to ContainerTemplate to allow subclassing.

### DIFF
--- a/db/migrate/20170706220336_add_sti_to_container_template.rb
+++ b/db/migrate/20170706220336_add_sti_to_container_template.rb
@@ -1,0 +1,5 @@
+class AddStiToContainerTemplate < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_templates, :type, :string
+  end
+end

--- a/db/migrate/20170707150520_update_container_template_types.rb
+++ b/db/migrate/20170707150520_update_container_template_types.rb
@@ -1,0 +1,11 @@
+class UpdateContainerTemplateTypes < ActiveRecord::Migration[5.0]
+  class ContainerTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Updating type column for ContainerTemplate") do
+      ContainerTemplate.update_all(:type => "ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate")
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -902,6 +902,7 @@ container_templates:
 - objects
 - created_at
 - updated_at
+- type
 container_volumes:
 - id
 - parent_id

--- a/spec/migrations/20170707150520_update_container_template_types_spec.rb
+++ b/spec/migrations/20170707150520_update_container_template_types_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe UpdateContainerTemplateTypes do
+  let(:container_template_stub) { migration_stub(:ContainerTemplate) }
+
+  migration_context :up do
+    it "setting type correctly" do
+      container_template = container_template_stub.create!
+
+      migrate
+
+      expect(container_template.reload).to have_attributes(:type => "ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate")
+    end
+  end
+end


### PR DESCRIPTION
Part of refactoring kube/openshift specific template code into its own provider directory.

Part of https://github.com/ManageIQ/manageiq/pull/15523.

@miq-bot add_label refactoring