### PR TITLE
revert the addition of ems_ref to container image

### DIFF
--- a/db/migrate/20170710080149_remove_ems_ref_from_container_image.rb
+++ b/db/migrate/20170710080149_remove_ems_ref_from_container_image.rb
@@ -1,0 +1,5 @@
+class RemoveEmsRefFromContainerImage < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :container_images, :ems_ref, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -750,7 +750,6 @@ container_images:
 - old_ems_id
 - deleted_on
 - type
-- ems_ref
 container_label_tag_mappings:
 - id
 - labeled_resource_type


### PR DESCRIPTION
Following the discussion in https://github.com/ManageIQ/manageiq-schema/pull/21 we should revert the addition of `ems_ref` column to container images.