### PR TITLE
Fixed possible NumericValueOutOfRange error on hardwares.memory_mb column

### DIFF
--- a/db/migrate/20170711210740_change_memory_mb_in_hardwares_table_to_bigint.rb
+++ b/db/migrate/20170711210740_change_memory_mb_in_hardwares_table_to_bigint.rb
@@ -1,0 +1,9 @@
+class ChangeMemoryMbInHardwaresTableToBigint < ActiveRecord::Migration[5.0]
+  def up
+    change_column :hardwares, :memory_mb, :bigint
+  end
+
+  def down
+    change_column :hardwares, :memory_mb, :integer
+  end
+end


### PR DESCRIPTION
Custom report was throwing error when trying to convert value from`memory_mb` to bytes

https://bugzilla.redhat.com/show_bug.cgi?id=1464154

@miq-bot add-label bug

\cc @gtanzillo  