### PR TITLE
Add Resource to OpenSCAP results

### DIFF
--- a/db/migrate/20170717084208_add_resource_to_open_scap_result.rb
+++ b/db/migrate/20170717084208_add_resource_to_open_scap_result.rb
@@ -1,0 +1,6 @@
+class AddResourceToOpenScapResult < ActiveRecord::Migration[5.0]
+  def change
+    add_column :openscap_results, :resource_id,   :bigint
+    add_column :openscap_results, :resource_type, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5415,6 +5415,8 @@ openscap_results:
 - id
 - container_image_id
 - created_at
+- resource_id
+- resource_type
 openscap_rule_results:
 - id
 - openscap_result_id


### PR DESCRIPTION
Adding resource_id and resource_type fields to openscap_results table
to allow assigning OpenSCAPResult to OpenStack VMs and later also
other inventory.

Existing container_id association is not touched in this PR, but it could
be migrated to the polymorphic resource association in future.