### PR TITLE
single sequence for all metrics sub tables

### DIFF
--- a/db/migrate/20170809191203_metrics_sequences.rb
+++ b/db/migrate/20170809191203_metrics_sequences.rb
@@ -1,0 +1,29 @@
+class MetricsSequences < ActiveRecord::Migration[5.0]
+  include MigrationHelper
+  def up
+    change_sequences("metrics", 0..23, false)
+    change_sequences("metric_rollups", 1..12, false)
+  end
+
+  def down
+    change_sequences("metrics", 0..23, true)
+    change_sequences("metric_rollups", 1..12, true)
+  end
+
+  # @param table_name [String] base table name to inherit from
+  # @param range [Range] range of subtables
+  # @param unique [Boolean] true if each table gets a unique sequence,
+  #                         false if they use the base table's sequence
+  def change_sequences(table_name, range, unique = true)
+    range.each do |n|
+      s = subtable_name(table_name, n)
+      execute("CREATE SEQUENCE #{s}_id_seq") if unique
+      change_column_default(s, :id, -> { "nextval('#{unique ? s : table_name}_id_seq')" })
+      execute("DROP SEQUENCE #{s}_id_seq") unless unique
+    end
+  end
+
+  def subtable_name(inherit_from, index)
+    "#{inherit_from}_#{index.to_s.rjust(2, '0')}"
+  end
+end


### PR DESCRIPTION
**Before:**
Every `metrics_**` table had a different sequence.
So inserting directly into a subtable would result in overlapping `id` values.
We currently insert into the base `metrics` table, so this is not a problem.

```
 Column |  Type  |                           Modifiers                            
--------+--------+---------------------------------------------------------------
 id     | bigint | not null default nextval('metric_rollups_01_id_seq'::regclass)
```

**After:**
Every`metrics` subtable uses the same sequence.
So inserting into any of the metrics tables will get a unique id.

```
 Column |  Type  |                           Modifiers                            
--------+--------+---------------------------------------------------------------
 id     | bigint | not null default nextval('metric_rollups_id_seq'::regclass)
```

Rollback does bring back to the previous value

```
 Column |  Type  |                           Modifiers                            
--------+--------+---------------------------------------------------------------
 id     | bigint | not null default nextval('metric_rollups_01_id_seq'::regclass)
```


This change allows us to insert directly into the subtable, which is 10x faster than inserting into the common parent table.

/cc @chrisarcand @Fryguy 