### PR TITLE
Add hash_expression to MiqAlert

### DIFF
--- a/db/migrate/20170703094235_add_hash_expression_to_miq_alert.rb
+++ b/db/migrate/20170703094235_add_hash_expression_to_miq_alert.rb
@@ -1,0 +1,30 @@
+class AddHashExpressionToMiqAlert < ActiveRecord::Migration[5.0]
+  class MiqAlert < ActiveRecord::Base
+  end
+
+  def up
+    add_column :miq_alerts, :hash_expression, :text
+
+    say_with_time('Add hash expression to MiqAlert for existing alerts') do
+      MiqAlert.where("expression NOT LIKE ?", "--- !ruby/object:MiqExpression%").each do |alert|
+        alert.hash_expression = alert.expression
+        alert.expression = nil
+        alert.save
+      end
+    end
+
+    rename_column :miq_alerts, :expression, :miq_expression
+  end
+
+  def down
+    say_with_time('Remove hash expression from MiqAlert for existing alerts') do
+      MiqAlert.where.not(:hash_expression => nil).each do |alert|
+        alert.miq_expression = alert.hash_expression
+        alert.save
+      end
+    end
+
+    remove_column :miq_alerts, :hash_expression
+    rename_column :miq_alerts, :miq_expression, :expression
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4881,10 +4881,11 @@ miq_alerts:
 - updated_on
 - options
 - db
-- expression
+- miq_expression
 - responds_to_events
 - enabled
 - read_only
+- hash_expression
 miq_approvals:
 - id
 - description

--- a/spec/migrations/20170703094235_add_hash_expression_to_miq_alert_spec.rb
+++ b/spec/migrations/20170703094235_add_hash_expression_to_miq_alert_spec.rb
@@ -1,0 +1,69 @@
+require_migration
+
+describe AddHashExpressionToMiqAlert do
+  migration_context :up do
+    let(:miq_alert_stub) { migration_stub(:MiqAlert) }
+
+    it 'alert with hash expression has nil miq_expression and hash_expression is set' do
+      hash_expression = '---\n:mode: internal\n'
+      alert = miq_alert_stub.create!(:description => 'Test Alert', :expression => hash_expression)
+
+      migrate
+
+      alert.reload
+      expect(alert.hash_expression).to eq(hash_expression)
+      expect(alert.miq_expression).to be_nil
+      expect { alert.expression }.to raise_error(NoMethodError)
+    end
+
+    it 'alert with non hash expression has nil hash_expression and miq_expression is set' do
+      expression = '--- !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Vm-platform
+          value: windows
+      '
+      alert = miq_alert_stub.create!(:description => 'Test Alert', :expression => expression)
+
+      migrate
+
+      alert.reload
+      expect(alert.hash_expression).to be_nil
+      expect(alert.miq_expression).to eq(expression)
+      expect { alert.expression }.to raise_error(NoMethodError)
+    end
+  end
+
+  migration_context :down do
+    let(:miq_alert_stub) { migration_stub(:MiqAlert) }
+
+    it 'expression is set for alert with hash expression' do
+      hash_expression = '---\n:mode: internal\n'
+      alert = miq_alert_stub.create!(:description => 'Test Alert', :hash_expression => hash_expression)
+
+      migrate
+
+      alert.reload
+      expect(alert.expression).to eq(hash_expression)
+      expect { alert.hash_expression }.to raise_error(NoMethodError)
+      expect { alert.miq_expression }.to raise_error(NoMethodError)
+    end
+
+    it 'expression is set for alert with non hash expression' do
+      expression = '--- !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Vm-platform
+          value: windows
+      '
+      alert = miq_alert_stub.create!(:description => 'Test Alert', :miq_expression => expression)
+
+      migrate
+
+      alert.reload
+      expect(alert.expression).to eq(expression)
+      expect { alert.hash_expression }.to raise_error(NoMethodError)
+      expect { alert.miq_expression }.to raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
Related PR: https://github.com/ManageIQ/manageiq/pull/15315
* Adding `hash_expression` column to `miq_alerts` table. 
* Renaming `expression` column to `miq_expression`. 
