### PR TITLE
Set ActiveRecord::Migrator.migrations_paths correctly

### DIFF
--- a/lib/manageiq/schema/engine.rb
+++ b/lib/manageiq/schema/engine.rb
@@ -8,6 +8,7 @@ module ManageIQ
           config.paths["db/migrate"].expanded.each do |expanded_path|
             app.config.paths["db/migrate"] << expanded_path
           end
+          ActiveRecord::Migrator.migrations_paths = app.config.paths["db/migrate"]
         end
       end
     end


### PR DESCRIPTION
Not having this path was causing `ActiveRecord::Migrator.needs_migration?` to return false always.

We use this in the `evm:deployment_status` task in manageiq to determine if we should run the migrations in the container upgrade scenario.

Without this change upgrades in containers will not run.

@miq-bot assign @Fryguy 
@miq-bot add_label bug