### PR TITLE
Update orchestration template types

### DIFF
--- a/db/migrate/20170821085511_update_type_of_orchestration_template.rb
+++ b/db/migrate/20170821085511_update_type_of_orchestration_template.rb
@@ -1,0 +1,45 @@
+class UpdateTypeOfOrchestrationTemplate < ActiveRecord::Migration[5.0]
+  class OrchestrationTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Updating type column for OrchestrationTemplate") do
+      OrchestrationTemplate
+        .where(:type => 'OrchestrationTemplateCfn')
+        .update_all(:type => 'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate')
+
+      OrchestrationTemplate
+        .where(:type => 'OrchestrationTemplateHot')
+        .update_all(:type => 'ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate')
+
+      OrchestrationTemplate
+        .where(:type => 'OrchestrationTemplateVnfd')
+        .update_all(:type => 'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate')
+
+      OrchestrationTemplate
+        .where(:type => 'OrchestrationTemplateAzure')
+        .update_all(:type => 'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate')
+    end
+  end
+
+  def down
+    say_with_time("Reverting type column for OrchestrationTemplate") do
+      OrchestrationTemplate
+        .where(:type => 'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate')
+        .update_all(:type => 'OrchestrationTemplateCfn')
+
+      OrchestrationTemplate
+        .where(:type => 'ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate')
+        .update_all(:type => 'OrchestrationTemplateHot')
+
+      OrchestrationTemplate
+        .where(:type => 'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate')
+        .update_all(:type => 'OrchestrationTemplateVnfd')
+
+      OrchestrationTemplate
+        .where(:type => 'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate')
+        .update_all(:type => 'OrchestrationTemplateAzure')
+    end
+  end
+end

--- a/spec/migrations/20170821085511_update_type_of_orchestration_template_spec.rb
+++ b/spec/migrations/20170821085511_update_type_of_orchestration_template_spec.rb
@@ -1,0 +1,57 @@
+require_migration
+
+describe UpdateTypeOfOrchestrationTemplate do
+  let(:orchestration_template_klass) { migration_stub(:OrchestrationTemplate) }
+
+  migration_context :up do
+    it "sets new type for cfn template" do
+      orchestration_template = orchestration_template_klass.create!(:type => 'OrchestrationTemplateCfn')
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate")
+    end
+
+    it "sets new type for hot template" do
+      orchestration_template = orchestration_template_klass.create!(:type => 'OrchestrationTemplateHot')
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate")
+    end
+
+    it "sets new type for vnfd template" do
+      orchestration_template = orchestration_template_klass.create!(:type => 'OrchestrationTemplateVnfd')
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => "ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate")
+    end
+
+    it "sets new type for azure template" do
+      orchestration_template = orchestration_template_klass.create!(:type => 'OrchestrationTemplateAzure')
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => "ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate")
+    end
+  end
+
+  migration_context :down do
+    it "reverts type to cfn template" do
+      orchestration_template = orchestration_template_klass.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate")
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => 'OrchestrationTemplateCfn')
+    end
+
+    it "reverts type to hot template" do
+      orchestration_template = orchestration_template_klass.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate")
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => 'OrchestrationTemplateHot')
+    end
+
+    it "reverts type to vnfd template" do
+      orchestration_template = orchestration_template_klass.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate")
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => 'OrchestrationTemplateVnfd')
+    end
+
+    it "reverts type to azure template" do
+      orchestration_template = orchestration_template_klass.create!(:type => "ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate")
+      migrate
+      expect(orchestration_template.reload).to have_attributes(:type => 'OrchestrationTemplateAzure')
+    end
+  end
+end


### PR DESCRIPTION
Migrate 
`OrchestrationTemplateCfn` to `ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate`
`OrchestrationTemplateHot` to `ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate`
`OrchestrationTemplateAzure` to `ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate`
`OrchestrationTemplateVnfd` to `ManagerIQ::Provders::Openstack::CloudManager::VnfdTemplate`

https://bugzilla.redhat.com/show_bug.cgi?id=1417021

It has dependencies on ~~https://github.com/ManageIQ/manageiq-providers-azure/pull/111~~, ~~https://github.com/ManageIQ/manageiq-providers-openstack/pull/76~~, ~~https://github.com/ManageIQ/manageiq-providers-amazon/pull/286~~