### PR TITLE
Remove duplicated instance_types (added by user) from settings_changes

### DIFF
--- a/db/migrate/20170825140348_remove_amazon_custom_instance_types.rb
+++ b/db/migrate/20170825140348_remove_amazon_custom_instance_types.rb
@@ -1,0 +1,15 @@
+class RemoveAmazonCustomInstanceTypes < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time('Remove /ems/ems_amazon/additional_instance_types/* defined also in instance_types.rb') do
+      SettingsChange.where('key LIKE ?', '/ems/ems_amazon/additional_instance_types/%/name').each do |s|
+        *_rest, instance_type, _name = s.key.split('/')
+        if InstanceTypes::AVAILABLE_TYPES.include?(instance_type)
+          SettingsChange.where('key LIKE ?', "/ems/ems_amazon/additional_instance_types/#{instance_type}/%").delete_all
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20170825140348_remove_amazon_custom_instance_types_spec.rb
+++ b/spec/migrations/20170825140348_remove_amazon_custom_instance_types_spec.rb
@@ -1,0 +1,21 @@
+require_migration
+
+describe RemoveAmazonCustomInstanceTypes do
+  let(:settings_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it 'Remove /ems/ems_amazon/additional_instance_types/* defined also in instance_types.rb' do
+      settings_stub.create!(:key => '/ems/ems_amazon/additional_instance_types/dup_type/name', :value => "f2.2xfake")
+      settings_stub.create!(:key => '/ems/ems_amazon/additional_instance_types/dup_type/family', :value => "Fake type 2")
+
+      settings_stub.create!(:key => '/ems/ems_amazon/additional_instance_types/my_type/name', :value => "f3.2xfake")
+      settings_stub.create!(:key => '/ems/ems_amazon/additional_instance_types/my_type/family', :value => "Fake type 3")
+
+      stub_const("InstanceTypes::AVAILABLE_TYPES", "dup_type" => {})
+      migrate
+
+      expect(settings_stub.where('key LIKE ?', '/ems/ems_amazon/additional_instance_types/dup_type/%')).to be_empty
+      expect(settings_stub.where('key LIKE ?', '/ems/ems_amazon/additional_instance_types/my_type/%').count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
After user makes use of https://github.com/ManageIQ/manageiq-providers-amazon/pull/289 to add `instance_types`, in next releasing cycle, MIQ also add these into our code, these entries in `settings_changes` will become redundant. This migration is to remove them.