### PR TITLE
Adding scan_results table for ScanResult model

### DIFF
--- a/db/migrate/20170925155201_create_scan_result.rb
+++ b/db/migrate/20170925155201_create_scan_result.rb
@@ -1,0 +1,10 @@
+class CreateScanResult < ActiveRecord::Migration[5.0]
+  def change
+    create_table :scan_results do |t|
+      t.string :scan_status
+      t.string :scan_result_message
+      t.string :scan_type
+      t.belongs_to :resource, :polymorphic => true, :type => :bigint
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5817,6 +5817,13 @@ scan_items:
 - file_mtime
 - prod_default
 - mode
+scan_results:
+- id
+- scan_status
+- scan_result_message
+- scan_type
+- resource_type
+- resource_id
 schema_migrations:
 - version
 security_contexts:


### PR DESCRIPTION
To support reporting and displaying the last OpenSCAP scan result for container images, as requested in  https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/100 