### PR TITLE
Migrate the roles that we live migrate at startup

### DIFF
--- a/db/migrate/20170829220132_migrate_database_role_in_settings.rb
+++ b/db/migrate/20170829220132_migrate_database_role_in_settings.rb
@@ -1,0 +1,16 @@
+class MigrateDatabaseRoleInSettings < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Convert old 'database' role to 'database_operations'") do
+      SettingsChange.where(:key => "/server/role").each do |s|
+        s.value.gsub!(/\bdatabase\b/, 'database_operations')
+        s.save!
+      end
+    end
+  end
+
+  # No down migration, because there was a runtime migration at server
+  # startup that would have corrected this anyway.
+end

--- a/spec/migrations/20170829220132_migrate_database_role_in_settings_spec.rb
+++ b/spec/migrations/20170829220132_migrate_database_role_in_settings_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe MigrateDatabaseRoleInSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "converts the old data" do
+      setting_changed = settings_change_stub.create!(:key => "/server/role", :value => "database,event,reporting")
+      setting_ignored = settings_change_stub.create!(:key => "/other/settings", :value => "database")
+
+      migrate
+
+      expect(setting_changed.reload.value).to eq("database_operations,event,reporting")
+      expect(setting_ignored.reload.value).to eq("database")
+    end
+
+    it "ignores already converted data" do
+      setting_changed = settings_change_stub.create!(:key => "/server/role", :value => "database_operations,event,reporting")
+
+      migrate
+
+      expect(setting_changed.reload.value).to eq("database_operations,event,reporting")
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/15905 which removes the "live" migration at startup.

@jrafanie Please review.