### PR TITLE
Use subqueries to avoid n + 1 in migration UnifyContainerDefinitionAndContainer

### DIFF
--- a/db/migrate/20170718111834_unify_container_definition_and_container.rb
+++ b/db/migrate/20170718111834_unify_container_definition_and_container.rb
@@ -40,9 +40,8 @@ class UnifyContainerDefinitionAndContainer < ActiveRecord::Migration[5.0]
     add_column :containers, :capabilities_drop,  :string
     add_column :containers, :command,            :text
 
-    containers = Arel::Table.new(:containers)
-    definitions = Arel::Table.new(:container_definitions)
     db_connection = ActiveRecord::Base.connection
+
     say_with_time("Copying over columns from container_definition to container") do
       %w(image image_pull_policy memory cpu_cores container_group_id privileged
          run_as_user run_as_non_root capabilities_add capabilities_drop command).each do |column|

--- a/db/migrate/20170718111834_unify_container_definition_and_container.rb
+++ b/db/migrate/20170718111834_unify_container_definition_and_container.rb
@@ -42,35 +42,61 @@ class UnifyContainerDefinitionAndContainer < ActiveRecord::Migration[5.0]
 
     containers = Arel::Table.new(:containers)
     definitions = Arel::Table.new(:container_definitions)
+    db_connection = ActiveRecord::Base.connection
     say_with_time("Copying over columns from container_definition to container") do
       %w(image image_pull_policy memory cpu_cores container_group_id privileged
          run_as_user run_as_non_root capabilities_add capabilities_drop command).each do |column|
-        join_sql = definitions.project(definitions[column.to_sym])
-                              .where(definitions[:id].eq(containers[:container_definition_id])).to_sql
-        Container.update_all("#{column} = (#{join_sql})")
+        subquery = <<-SQL
+          SELECT id, #{column} FROM container_definitions
+        SQL
+
+        db_connection.execute <<-SQL
+          UPDATE containers SET #{column} = subquery.#{column}
+          FROM (#{subquery}) AS subquery
+          WHERE subquery.id = containers.container_definition_id
+        SQL
       end
     end
 
     say_with_time("switch container_definition_id with container_id for container_port_configs") do
-      port_configs = Arel::Table.new(:container_port_configs)
-      join_sql = containers.project(containers[:id])
-                           .where(containers[:container_definition_id].eq(port_configs[:container_definition_id])).to_sql
-      ContainerPortConfig.update_all("container_definition_id = (#{join_sql})")
+      subquery = <<-SQL
+        SELECT id, container_definition_id FROM containers
+      SQL
+
+      db_connection.execute <<-SQL
+        UPDATE container_port_configs
+        SET container_definition_id = subquery.id
+        FROM (#{subquery}) AS subquery
+        WHERE subquery.container_definition_id = container_port_configs.container_definition_id
+      SQL
     end
 
     say_with_time("switch container_definition_id with container_id for container_port_configs") do
-      env_vars = Arel::Table.new(:container_env_vars)
-      join_sql = containers.project(containers[:id])
-                           .where(containers[:container_definition_id].eq(env_vars[:container_definition_id])).to_sql
-      ContainerEnvVar.update_all("container_definition_id = (#{join_sql})")
+      subquery = <<-SQL
+        SELECT id, container_definition_id FROM containers
+      SQL
+
+      db_connection.execute <<-SQL
+        UPDATE container_env_vars SET container_definition_id = subquery.id
+        FROM (#{subquery}) AS subquery
+        WHERE subquery.container_definition_id = container_env_vars.container_definition_id
+      SQL
     end
 
     say_with_time("switch resource_id with container_id, resource_type to 'Container' for security_contexts") do
-      security_contexts = Arel::Table.new(:security_contexts)
-      join_sql = containers.project(containers[:id])
-                           .where(containers[:container_definition_id].eq(security_contexts[:resource_id])
-                           .and(security_contexts[:resource_type].eq(Arel::Nodes::Quoted.new('ContainerDefinition')))).to_sql
-      SecurityContext.where(:resource_type => 'ContainerDefinition').update_all("resource_type = 'Container', resource_id = (#{join_sql})")
+      subquery = <<-SQL
+        SELECT id, container_definition_id FROM containers
+      SQL
+
+      container_value = db_connection.quote('Container')
+      container_definition_value = db_connection.quote('ContainerDefinition')
+
+      db_connection.execute <<-SQL
+        UPDATE security_contexts
+        SET resource_type = #{container_value}, resource_id = subquery.id
+        FROM (#{subquery}) AS subquery
+        WHERE subquery.container_definition_id = security_contexts.resource_id AND security_contexts.resource_type = #{container_definition_value}
+      SQL
     end
 
     MiqQueue.where(:method_name => "purge_timer", :class_name => 'ContainerDefinition').destroy_all


### PR DESCRIPTION
I just got euwe DB with these counts of objetcts used in migration:
```
Container.count => 19811
ContainerDefinition.count => 20540
SecurityContext.count => 20540
ContainerEnvVar.count => 394082
ContainerPortConfig.count => 5503
```
and this migration was running for 1 hour and it didn`t ends.
after this changes it is about few seconds.

it is beacause there is N+1 in progress thanks to such queries:
```ruby
     containers = Arel::Table.new(:containers)
      port_configs = Arel::Table.new(:container_port_configs)
      join_sql = containers.project(containers[:id])
                           .where(containers[:container_definition_id].eq(port_configs[:container_definition_id])).to_sql
      ContainerPortConfig.update_all("container_definition_id = (#{join_sql})")
```
in sql:
```SQL
UPDATE container_port_configs 
SET container_definition_id = 
  (SELECT "containers"."id" FROM "containers" 
   WHERE "containers"."container_definition_id" = "container_port_configs"."container_definition_id"
 )
```
so I am using postgres subqueries, which are performed one time in the query:
```SQL
UPDATE container_port_configs
SET container_definition_id = subquery.id
FROM (SELECT id, container_definition_id FROM containers) AS subquery
WHERE subquery.container_definition_id = container_port_configs.container_definition_id
```

All related queries are changed by this way in up direction. Some specs are missing in down direction so I am leaving it for other PR, I don't want to broke anything.

@miq-bot assign @Fryguy
please review @zeari 
cc  @gtanzillo @kbrock 

thanks @Ladas 


