### PR TITLE
Add container_project_id to persistent_volume_claims

### DIFF
--- a/db/migrate/20170904130801_add_project_id_to_persistent_volume_claims.rb
+++ b/db/migrate/20170904130801_add_project_id_to_persistent_volume_claims.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToPersistentVolumeClaims < ActiveRecord::Migration[5.0]
+  def change
+    add_column :persistent_volume_claims, :container_project_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5584,6 +5584,7 @@ persistent_volume_claims:
 - capacity
 - created_at
 - updated_at
+- container_project_id
 physical_servers:
 - id
 - ems_id


### PR DESCRIPTION
needed for https://github.com/ManageIQ/manageiq/pull/15932 so we can add a `belongs_to :container_projects` relation to  persistent_volume_claims

@zakiva Please review
cc @simon3z @cben @moolitayer 

