### PR TITLE
Add schema support for LXCA config patterns

### DIFF
--- a/db/migrate/20170905210626_create_configuration_templates.rb
+++ b/db/migrate/20170905210626_create_configuration_templates.rb
@@ -2,7 +2,7 @@ class CreateConfigurationTemplates < ActiveRecord::Migration[5.0]
   def change
     create_table :configuration_templates do |t|
       t.bigint :ems_id
-      t.string :external_id
+      t.string :ems_ref
       t.string :name
       t.string :description
       t.boolean :user_defined

--- a/db/migrate/20170905210626_create_configuration_templates.rb
+++ b/db/migrate/20170905210626_create_configuration_templates.rb
@@ -1,0 +1,12 @@
+class CreateConfigurationTemplates < ActiveRecord::Migration[5.0]
+  def change
+    create_table :configuration_templates do |t|
+      t.bigint :ems_id
+      t.string :external_id
+      t.string :name
+      t.string :description
+      t.boolean :user_defined
+      t.boolean :in_use
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -572,7 +572,7 @@ configuration_tags_configured_systems:
 configuration_templates:
 - id
 - ems_id
-- external_id
+- ems_ref
 - name
 - description
 - user_defined

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -569,6 +569,13 @@ configuration_tags_configured_systems:
 - configured_system_id
 - configuration_tag_id
 - id
+configuration_templates:
+- ems_id
+- external_id
+- name
+- description
+- user_defined
+- in_use
 configured_systems:
 - id
 - type

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -570,6 +570,7 @@ configuration_tags_configured_systems:
 - configuration_tag_id
 - id
 configuration_templates:
+- id
 - ems_id
 - external_id
 - name


### PR DESCRIPTION
This PR adds schema support for Lenovo XClarity Administrator (LXCA) configuration patterns which can be thought of as templates describing the configuration of physical systems. These "templates" are used by LXCA to configure hardware such as servers, switches, and storage.