### PR TITLE
Fix db:migrate:reset by setting DatabaseTasks.migrations_paths

### DIFF
--- a/lib/manageiq/schema/engine.rb
+++ b/lib/manageiq/schema/engine.rb
@@ -9,6 +9,7 @@ module ManageIQ
             app.config.paths["db/migrate"] << expanded_path
           end
           ActiveRecord::Migrator.migrations_paths = app.config.paths["db/migrate"]
+          ActiveRecord::Tasks::DatabaseTasks.migrations_paths = app.config.paths["db/migrate"].to_a
         end
       end
     end


### PR DESCRIPTION
The task `db:migrate:reset` is something that is included in rails, and is effectively a `rake db:drop db:create db:migrate`.

Explanation
-----------

The definition of `rake db:drop` however looks like this:

```ruby
 # From active_record/railties/databases.rake

task :load_config do
  puts Rails.application.__id__
  ActiveRecord::Base.configurations       = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
  ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
end

 # ...

desc 'Drops the database from DATABASE_URL ....'
task :drop => [:load_config, :check_protected_environments] do
  puts Rails.application.__id__
  db_namespace["drop:_unsafe"].invoke
end
```

Importantly, the `db:drop` command doesn't require the Rails application to be initialized, thus the `.migrations_paths` module method of `ActiveRecord::Tasks::DatabaseTasks` is called prior to the rails environment being loaded, and that method is memoized.  This means that the defaults for rails are what are set for the `.migrations_paths` of `ActiveRecord::Tasks::DatabaseTasks`, and not what we configure in the `manageiq-schema` initializer.

This fix makes sure that we redefine this attribute when the `:environment` task is called.


Alternative solution
--------------------

What might make more sense is to instead have this path changing to a method, and have it be called out to in `config/application.rb` in the main app.  This would then prevent the need for the line:

```ruby
ActiveRecord::Migrator.migrations_paths = app.config.paths["db/migrate"]
```

from being necessary.  This might not be possible, so for this fix, I just did what was already in place, but figured I would bring this up as a discussion topic.