### PR TITLE
Add parent/child support for lans, as well as subnets

### DIFF
--- a/db/migrate/20170919211256_add_parent_id_to_lans.rb
+++ b/db/migrate/20170919211256_add_parent_id_to_lans.rb
@@ -1,0 +1,5 @@
+class AddParentIdToLans < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lans, :parent_id, :bigint
+  end
+end

--- a/db/migrate/20170919211745_create_subnets.rb
+++ b/db/migrate/20170919211745_create_subnets.rb
@@ -1,0 +1,11 @@
+class CreateSubnets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :subnets do |t|
+      t.string :ems_ref
+      t.string :name
+      t.string :cidr
+      t.string :type
+      t.bigint :lan_id
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1617,6 +1617,7 @@ lans:
 - computed_allow_promiscuous
 - computed_forged_transmits
 - computed_mac_changes
+- parent_id
 ldap_domains:
 - id
 - name
@@ -6099,6 +6100,13 @@ storages_vms_and_templates:
 - storage_id
 - vm_or_template_id
 - id
+subnets:
+- id
+- ems_ref
+- name
+- cidr
+- type
+- lan_id
 switches:
 - id
 - name


### PR DESCRIPTION
This adds a `parent_id` column to the `lans` table which will be used to support VM networks for SCVMM and possibly other providers. A VM network will be represented as a child of a LAN.

It also adds a `vm_subnets` table with a FK to the `lans` table. The plan is for the AR model to scope the linkage.