### PR TITLE
Add an ID to the event that refer to origin system's event

### DIFF
--- a/db/migrate/20170920212535_add_event_id_to_event_streams.rb
+++ b/db/migrate/20170920212535_add_event_id_to_event_streams.rb
@@ -1,0 +1,5 @@
+class AddEventIdToEventStreams < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :ems_ref, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1263,6 +1263,7 @@ event_streams:
 - middleware_deployment_name
 - generating_ems_id
 - physical_server_id
+- ems_ref
 ext_management_systems:
 - id
 - name


### PR DESCRIPTION
This PR do:
- Add an `ems_ref` attribute. This attribute refers to the unique sequential ID for the events in the source system.