### PR TITLE
Change dialog field description to text field to accomodate larger sizes

### DIFF
--- a/db/migrate/20170922162503_change_dialog_field_description_from_string_to_text.rb
+++ b/db/migrate/20170922162503_change_dialog_field_description_from_string_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeDialogFieldDescriptionFromStringToText < ActiveRecord::Migration[5.0]
+  def up
+    change_column :dialog_fields, :description, :text
+  end
+
+  def down
+    change_column :dialog_fields, :description, :string
+  end
+end


### PR DESCRIPTION
Text type allows us to use dialog field descriptions for help text and eventually, longer messages and maybe even links.