### PR TITLE
Change the table used for LXCA config patterns

### DIFF
--- a/db/migrate/20170922172113_rename_provisioning_manager_id_to_manager_id_in_customization_scripts.rb
+++ b/db/migrate/20170922172113_rename_provisioning_manager_id_to_manager_id_in_customization_scripts.rb
@@ -1,0 +1,5 @@
+class RenameProvisioningManagerIdToManagerIdInCustomizationScripts < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :customization_scripts, :provisioning_manager_id, :manager_id
+  end
+end

--- a/db/migrate/20170922205258_add_config_pattern_fields_to_customization_scripts.rb
+++ b/db/migrate/20170922205258_add_config_pattern_fields_to_customization_scripts.rb
@@ -1,0 +1,7 @@
+class AddConfigPatternFieldsToCustomizationScripts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :customization_scripts, :description, :string
+    add_column :customization_scripts, :user_defined, :boolean
+    add_column :customization_scripts, :in_use, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1011,11 +1011,14 @@ custom_buttons:
 customization_scripts:
 - id
 - name
-- provisioning_manager_id
+- manager_id
 - manager_ref
 - type
 - created_at
 - updated_at
+- description
+- user_defined
+- in_use
 customization_scripts_operating_system_flavors:
 - customization_script_id
 - operating_system_flavor_id


### PR DESCRIPTION
Recently, a new table named _configuration_templates_ was created to hold data related to configuration patterns. Based on feedback received from Red Hat, this PR updates an existing table, _customization_scripts_, to hold configuration pattern data instead.