### PR TITLE
Add user_id,group_id,tenant_id to MiqQueue

### DIFF
--- a/db/migrate/20171002181644_add_userid_groupid_tenantid_to_miq_queue.rb
+++ b/db/migrate/20171002181644_add_userid_groupid_tenantid_to_miq_queue.rb
@@ -1,0 +1,7 @@
+class AddUseridGroupidTenantidToMiqQueue < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_queue, :user_id, :bigint
+    add_column :miq_queue, :group_id, :bigint
+    add_column :miq_queue, :tenant_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -899,8 +899,8 @@ container_templates:
 - objects
 - created_at
 - updated_at
-- type
 - object_labels
+- type
 container_volumes:
 - id
 - parent_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -899,8 +899,8 @@ container_templates:
 - objects
 - created_at
 - updated_at
-- object_labels
 - type
+- object_labels
 container_volumes:
 - id
 - parent_id
@@ -5057,6 +5057,9 @@ miq_queue:
 - handler_type
 - expires_on
 - tracking_label
+- user_id
+- group_id
+- tenant_id
 miq_regions:
 - id
 - region


### PR DESCRIPTION
This is needed so that the Queue can run commands in the context of the user, group and tenant.