### PR TITLE
Remove the configuration_templates table

### DIFF
--- a/db/migrate/20171009173946_remove_configuration_templates_table.rb
+++ b/db/migrate/20171009173946_remove_configuration_templates_table.rb
@@ -1,0 +1,5 @@
+class RemoveConfigurationTemplatesTable < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :configuration_templates
+  end
+end

--- a/db/migrate/20171009173946_remove_configuration_templates_table.rb
+++ b/db/migrate/20171009173946_remove_configuration_templates_table.rb
@@ -1,5 +1,12 @@
 class RemoveConfigurationTemplatesTable < ActiveRecord::Migration[5.0]
   def change
-    drop_table :configuration_templates
+    drop_table :configuration_templates do |t|
+      t.bigint :ems_id
+      t.string :ems_ref
+      t.string :name
+      t.string :description
+      t.boolean :user_defined
+      t.boolean :in_use
+    end
   end
 end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -569,14 +569,6 @@ configuration_tags_configured_systems:
 - configured_system_id
 - configuration_tag_id
 - id
-configuration_templates:
-- id
-- ems_id
-- ems_ref
-- name
-- description
-- user_defined
-- in_use
 configured_systems:
 - id
 - type


### PR DESCRIPTION
This PR removes the configuration_templates table because it is no longer used.