### PR TITLE
Cleanup the spec wording for clarity

### DIFF
--- a/spec/api/attributes_spec.rb
+++ b/spec/api/attributes_spec.rb
@@ -1,4 +1,4 @@
-describe "all tables" do
+describe "API" do
   let(:connection) { ApplicationRecord.connection }
 
   def api_invalid_tables_message(invalid_tables, attr)
@@ -11,14 +11,14 @@ The "#{attr}" attribute is reserved for the ManageIQ API.
 EOS
   end
 
-  it "do not have an attribute called href" do
+  it "no table has an attribute named href" do
     href_tables = connection.tables.select do |t|
       !%w(schema_migrations ar_internal_metadata).include?(t) && connection.columns(t).any? { |c| c.name == "href" }
     end
     expect(href_tables.size).to eq(0), api_invalid_tables_message(href_tables, "href")
   end
 
-  it "do not have an attribute called href_slug" do
+  it "no table has an attribute named href_slug" do
     href_slug_tables = connection.tables.select do |t|
       !%w(schema_migrations ar_internal_metadata).include?(t) && connection.columns(t).any? { |c| c.name == "href_slug" }
     end

--- a/spec/replication/util/migration_order_spec.rb
+++ b/spec/replication/util/migration_order_spec.rb
@@ -1,4 +1,4 @@
-describe "migration order" do
+describe "Replication" do
   let(:current_release_migrations) do
     File.read(File.join(__dir__, 'data/released_migrations')).split.map(&:to_i).sort
   end
@@ -31,7 +31,7 @@ newly created ones where all the migrations are run in timestamp order.
 EOS
   end
 
-  it "is correct" do
+  it "migration order is correct" do
     incorrect_migration_time_stamps = []
     new_migrations.each do |m|
       incorrect_migration_time_stamps << m if m < last_released_migration

--- a/spec/replication/util/primary_key_spec.rb
+++ b/spec/replication/util/primary_key_spec.rb
@@ -1,4 +1,4 @@
-describe "all tables" do
+describe "Replication" do
   let(:connection) { ApplicationRecord.connection }
 
   def invalid_primary_key_message(no_pk)
@@ -14,7 +14,7 @@ describe "all tables" do
     EOS
   end
 
-  it "have a primary key called id" do
+  it "all tables have a primary key called id" do
     no_pk = []
     connection.tables.each do |t|
       next if ManageIQ::Schema::Checker::SYSTEM_TABLES.include?(t)

--- a/spec/replication/util/schema_structure_spec.rb
+++ b/spec/replication/util/schema_structure_spec.rb
@@ -1,4 +1,4 @@
-describe "database schema" do
+describe "Replication" do
   def invalid_schema_message(message)
     <<-EOS.gsub!(/^ +/, "")
       #{Rails.configuration.database_configuration[Rails.env]["database"]} is not structured as expected.
@@ -7,7 +7,7 @@ describe "database schema" do
     EOS
   end
 
-  it "is structured as expected" do
+  it "database schema is structured as expected" do
     message = ManageIQ::Schema::Checker.check_schema
 
     expect(message).to be_nil, invalid_schema_message(message)


### PR DESCRIPTION
Previously a number of specs had `describe "all tables"` at the top which was weird when viewed in documentation format.  This cleans up those various  areas so that the outer describe shows the general rationale.

@chessbyte Please review.