### PR TITLE
Add sub_metric column to chargeback_rate_detail

### DIFF
--- a/db/migrate/20171013125651_add_sub_metric_to_chargeback_rate_detail.rb
+++ b/db/migrate/20171013125651_add_sub_metric_to_chargeback_rate_detail.rb
@@ -1,0 +1,5 @@
+class AddSubMetricToChargebackRateDetail < ActiveRecord::Migration[5.0]
+  def change
+    add_column :chargeback_rate_details, :sub_metric, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -218,6 +218,7 @@ chargeback_rate_details:
 - chargeback_rate_detail_measure_id
 - chargeback_rate_detail_currency_id
 - chargeable_field_id
+- sub_metric
 chargeback_rates:
 - id
 - guid


### PR DESCRIPTION
This is for implementation for chargeback of storage (cloud volume) type.

Metric for allocated storage is now divided according to storage types and we need to store cloud volume type for the ChargebackRateDetail (the be able get metric value and then calculate cost)

So generally: it is adding posibility to divide metric to the small pieces - so this is the why I am calling it 'sub metric'.

In rate editor:

![screen shot 2017-10-13 at 15 31 41](https://user-images.githubusercontent.com/14937244/31549104-68b8f55e-b02d-11e7-85cf-d2cc4a99574c.png)

(gp2, .. - are cloud volume storage types)


cc @gtanzillo 

@miq-bot assign @Fryguy 