### PR TITLE
Add user_id,group_id,tenant_id to EventStream.

### DIFF
--- a/db/migrate/20171016192352_add_user_to_event_stream.rb
+++ b/db/migrate/20171016192352_add_user_to_event_stream.rb
@@ -1,0 +1,7 @@
+class AddUserToEventStream < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :user_id, :bigint
+    add_column :event_streams, :group_id, :bigint
+    add_column :event_streams, :tenant_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1253,6 +1253,9 @@ event_streams:
 - ems_ref
 - middleware_domain_id
 - middleware_domain_name
+- user_id
+- group_id
+- tenant_id
 ext_management_systems:
 - id
 - name


### PR DESCRIPTION
Add user_id,group_id,tenant_id to EventStream.

User wants to get the event initiator from MiqEvent and uses it in automate code.
Blocks https://github.com/ManageIQ/manageiq/pull/16179.

https://bugzilla.redhat.com/show_bug.cgi?id=1487749

cc @kbrock @Fryguy @mkanoor 