### PR TITLE
Rename Tables and some changes for Showback Models

### DIFF
--- a/db/migrate/20171018081206_showback_fix_and_rename.rb
+++ b/db/migrate/20171018081206_showback_fix_and_rename.rb
@@ -1,0 +1,27 @@
+class ShowbackFixAndRename < ActiveRecord::Migration[5.0]
+  def change
+    rename_table :showback_events,      :showback_data_rollups
+    rename_table :showback_charges,     :showback_data_views
+    rename_table :showback_pools,       :showback_envelopes
+    rename_table :showback_usage_types, :showback_input_measures
+
+    rename_column :showback_data_views, :showback_event_id,      :showback_data_rollup_id
+    rename_column :showback_data_views, :showback_pool_id,       :showback_envelope_id
+
+    rename_column :showback_rates,      :category,      :entity
+    rename_column :showback_rates,      :dimension,     :field
+    rename_column :showback_rates,      :measure,       :group
+    rename_column :showback_rates,      :step_variable, :tier_input_variable
+    rename_column :showback_rates,      :date,          :start_date
+
+    rename_column :showback_input_measures, :category,   :entity
+    rename_column :showback_input_measures, :dimensions, :fields
+    rename_column :showback_input_measures, :measure,    :group
+
+    rename_column :showback_data_views, :stored_data, :data_snapshot
+
+    add_column :showback_data_views, :context_snapshot, :jsonb
+    add_column :showback_data_views, :start_time,       :timestamp
+    add_column :showback_data_views, :end_time,         :timestamp
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5958,16 +5958,7 @@ shares:
 - allow_tenant_inheritance
 - created_at
 - updated_at
-showback_charges:
-- id
-- cost_subunits
-- cost_currency
-- showback_pool_id
-- showback_event_id
-- created_at
-- updated_at
-- stored_data
-showback_events:
+showback_data_rollups:
 - id
 - data
 - start_time
@@ -5977,7 +5968,19 @@ showback_events:
 - context
 - created_at
 - updated_at
-showback_pools:
+showback_data_views:
+- id
+- cost_subunits
+- cost_currency
+- showback_envelope_id
+- showback_data_rollup_id
+- created_at
+- updated_at
+- data_snapshot
+- context_snapshot
+- start_time
+- end_time
+showback_envelopes:
 - id
 - name
 - description
@@ -5988,6 +5991,14 @@ showback_pools:
 - accumulated_cost_currency
 - resource_type
 - resource_id
+- created_at
+- updated_at
+showback_input_measures:
+- id
+- entity
+- description
+- group
+- fields
 - created_at
 - updated_at
 showback_price_plans:
@@ -6001,16 +6012,16 @@ showback_price_plans:
 showback_rates:
 - id
 - calculation
-- category
-- dimension
+- entity
+- field
 - screener
-- date
+- start_date
 - concept
 - showback_price_plan_id
 - created_at
 - updated_at
-- measure
-- step_variable
+- group
+- tier_input_variable
 - uses_single_tier
 - tiers_use_full_value
 showback_tiers:
@@ -6029,14 +6040,6 @@ showback_tiers:
 - step_time_value
 - step_unit
 - showback_rate_id
-showback_usage_types:
-- id
-- category
-- description
-- measure
-- dimensions
-- created_at
-- updated_at
 snapshots:
 - id
 - uid


### PR DESCRIPTION
Change name to tables and rename some columns .

- [ ] 1. Schema https://github.com/ManageIQ/manageiq-schema/pull/96
- [ ] 2 .Consumption gem https://github.com/ManageIQ/manageiq-consumption/pull/117
- [ ] 3. ManageIQ https://github.com/ManageIQ/manageiq/pull/16309

@chargio Please review this . Maybe I am missing something.
In Usagetypes dimension is plural because this will be array so will be dimensions not dimension like rate, ok?

Now working in the PR for https://github.com/ManageIQ/manageiq-consumption changes wait until this please.