### PR TITLE
Convert containers hawkular Endpoints port=nil to port=443

### DIFF
--- a/db/migrate/20171030131403_fix_hawkular_endpoints_with_port_nil.rb
+++ b/db/migrate/20171030131403_fix_hawkular_endpoints_with_port_nil.rb
@@ -1,0 +1,25 @@
+class FixHawkularEndpointsWithPortNil < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Endpoint < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    container_hawkular_endpoints.where(:port => nil).update_all(:port => 443)
+  end
+
+  def container_hawkular_endpoints
+    ems_container_ids = ExtManagementSystem.where(
+      :type => %w(ManageIQ::Providers::Openshift::ContainerManager ManageIQ::Providers::Kubernetes::ContainerManager)
+    ).pluck(:id)
+
+    Endpoint.where(
+      :resource_type => 'ExtManagementSystem',
+      :resource_id   => ems_container_ids,
+      :role          => 'hawkular'
+    )
+  end
+end

--- a/spec/migrations/20171030131403_fix_hawkular_endpoints_with_port_nil_spec.rb
+++ b/spec/migrations/20171030131403_fix_hawkular_endpoints_with_port_nil_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe FixHawkularEndpointsWithPortNil do
+  let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+
+  migration_context :up do
+    it 'Modifies hawkular endpoints with nil port' do
+      ems = ext_management_system_stub.create!(
+        :name => 'container',
+        :type => 'ManageIQ::Providers::Openshift::ContainerManager'
+      )
+      hawk = endpoint_stub.create!(
+        :role          => "hawkular",
+        :hostname      => "hawkname",
+        :port          => nil,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+
+      migrate
+
+      expect(hawk.reload.port).to eq(443)
+    end
+
+    it 'Does not modify non-nil port, or non-containers-hawkular endpoints' do
+      ems = ext_management_system_stub.create!(
+        :name => 'container',
+        :type => 'ManageIQ::Providers::Openshift::ContainerManager'
+      )
+      hawk = endpoint_stub.create!(
+        :role          => "hawkular",
+        :hostname      => "hawkname",
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+      main = endpoint_stub.create!(
+        :role          => "default",
+        :hostname      => "hostname",
+        :port          => nil,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+
+      other_ems = ext_management_system_stub.create!(
+        :name => 'container',
+        :type => 'ManageIQ::Providers::Amazon::CloudManager'
+      )
+      other = endpoint_stub.create!(
+        :role          => "unrelated",
+        :hostname      => "neverwhere",
+        :port          => nil,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => other_ems.id
+      )
+
+      migrate
+
+      expect(hawk.reload.port).to eq(123)
+      expect(main.reload.port).to eq(nil)
+      expect(other.reload.port).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
For a time (before https://github.com/ManageIQ/manageiq-ui-classic/pull/1172), it was possible in UI to save containers provider with blank hawkular port, which got saved as port = nil.
Then it'd be impossible to edit the provider, as UI would crash:

![manageiq containers providers port nil](https://user-images.githubusercontent.com/273688/31744532-d33a9eda-b467-11e7-8a30-55d31f2b5d96.png)

On fine this was fixed by https://github.com/ManageIQ/manageiq-ui-classic/pull/1565 adding special case in UI to tolerate nil.
On master, @AparnaKarve [asked](https://github.com/ManageIQ/manageiq-ui-classic/pull/1305#issuecomment-309489658) to not introduce special cases but do a migration.
Better late than never :-)

After investigating, @yaacov @moolitayer and me concluded such provider does connect to hawkular with port 443 (it builds a url without port, confirmed experimentally).
This migration normalizes such endpoints to port 443, works same but possible to edit in UI:

![manageiq containers providers port 443](https://user-images.githubusercontent.com/273688/32183551-44961526-bda2-11e7-846d-0465257357cc.png)

Tested by checking out fine-1, creating such provider, migrating all the way to master, it was still broken, and fixed by this migration.  That's how I took above screenshots.
(in some cases such endpoints might have already been deleted by https://github.com/ManageIQ/manageiq/pull/14990 migration.  But not if hostname was autodetected from route => this is still sometimes needed.)

https://bugzilla.redhat.com/show_bug.cgi?id=1432070

@miq-bot add-label bug, data
@moolitayer @AparnaKarve please review