### PR TITLE
[WIP] Add missing index on handler_id and type

### DIFF
--- a/db/migrate/20171019173933_add_index_on_type_and_id_on_miq_queue.rb
+++ b/db/migrate/20171019173933_add_index_on_type_and_id_on_miq_queue.rb
@@ -1,0 +1,5 @@
+class AddIndexOnTypeAndIdOnMiqQueue < ActiveRecord::Migration[5.0]
+  def change
+    add_index :miq_queue, [:handler_id, :handler_type]
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1504287

Queries on a 1 million+ row miq_queue table using handlers is slow due
to a missing index.

miq_worker.rb has various messages methods that scope the miq_queue where
it is the "handler",
see: https://github.com/ManageIQ/manageiq/blob/aba53d3d633fe4af7a59a44e3b7058e343d92c2c/app/models/miq_worker.rb#L9-L12

When a server is not responding, the master server will deactivate this
server and destroy any activate queue messags being worked on by workers
on this not responding server, here:
https://github.com/ManageIQ/manageiq/blob/aba53d3d633fe4af7a59a44e3b7058e343d92c2c/app/models/miq_server/server_monitor.rb#L15

Additionally, when we want to destroy worker rows, we hit the
before_destroy, calling log_destroy_of_worker_messages here:
https://github.com/ManageIQ/manageiq/blob/aba53d3d633fe4af7a59a44e3b7058e343d92c2c/app/models/miq_worker.rb#L6

This method loops through ready_messages and processed_messages for this
worker, logs a message and cleans them up here:
https://github.com/ManageIQ/manageiq/blob/aba53d3d633fe4af7a59a44e3b7058e343d92c2c/app/models/miq_worker.rb#L455-L464

Summary: 1.4 million row no data miq_queue with 62 workers goes from
16.5 seconds to 4.2 seconds to loop through the workers and
clean_active_messages on them.

Before:
```
$ bin/rails r 'time1 = Time.now; MiqServer.all.each { |s| s.miq_workers.all.each(&:clean_active_messages)}; puts Time.now - time1; puts "Messages: #{MiqQueue.count}"; puts "workers: #{MiqWorker.count}"'
** override_gem: manageiq-schema, [{:path=>"/Users/joerafaniello/Code/manageiq-schema"}], caller: /Users/joerafaniello/Code/manageiq/bundler.d/Gemfile.dev.rb
** Using session_store: ActionDispatch::Session::MemCacheStore
16.503509
272
Messages: 1400000
workers: 62
```

```
$ ~/Code/manageiq (master) (2.4.2) + bin/rake db:migrate
== 20171019173933 AddIndexOnTypeAndIdOnMiqQueue: migrating ====================
-- add_index(:miq_queue, [:handler_id, :handler_type])
   -> 2.8617s
== 20171019173933 AddIndexOnTypeAndIdOnMiqQueue: migrated (2.8618s) ===========
```

After:
```
$ bin/rails r 'time1 = Time.now; MiqServer.all.each { |s| s.miq_workers.all.each(&:clean_active_messages)}; puts Time.now - time1; puts "Messages: #{MiqQueue.count}"; puts "workers: #{MiqWorker.count}"'
4.275245
Messages: 1400000
workers: 62
```