### PR TITLE
Ensure EMS relationships are established

### DIFF
--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -3,41 +3,45 @@ class EnsureCloudManagers < ActiveRecord::Migration[5.0]
   class BaseManager < ExtManagementSystem; end
   class Settings < ActiveRecord::Base; end
 
-  class CloudManager < ActiveRecord::Base
-    def ensure_managers
-      build_network_manager unless network_manager
-      network_manager.name = "#{name} Network Manager"
+  class ManageIQ
+    class Providers
+      class CloudManager < ActiveRecord::Base
+        def ensure_managers
+          build_network_manager unless network_manager
+          network_manager.name = "#{name} Network Manager"
 
-      build_ebs_storage_manager unless ebs_storage_manager
-      ebs_storage_manager.name = "#{name} EBS Storage Manager"
+          build_ebs_storage_manager unless ebs_storage_manager
+          ebs_storage_manager.name = "#{name} EBS Storage Manager"
 
-      if Settings.prototype.amazon.s3
-        build_s3_storage_manager unless s3_storage_manager
-        s3_storage_manager.name = "#{name} S3 Storage Manager"
-      end
+          if Settings.prototype.amazon.s3
+            build_s3_storage_manager unless s3_storage_manager
+            s3_storage_manager.name = "#{name} S3 Storage Manager"
+          end
 
-      ensure_managers_zone_and_provider_region
-    end
+          ensure_managers_zone_and_provider_region
+        end
 
-    def ensure_managers_zone_and_provider_region
-      if network_manager
-        network_manager.zone_id         = zone_id
-        network_manager.provider_region = provider_region
-      end
+        def ensure_managers_zone_and_provider_region
+          if network_manager
+            network_manager.zone_id         = zone_id
+            network_manager.provider_region = provider_region
+          end
 
-      if ebs_storage_manager
-        ebs_storage_manager.zone_id         = zone_id
-        ebs_storage_manager.provider_region = provider_region
-      end
+          if ebs_storage_manager
+            ebs_storage_manager.zone_id         = zone_id
+            ebs_storage_manager.provider_region = provider_region
+          end
 
-      if s3_storage_manager
-        s3_storage_manager.zone_id         = zone_id
-        s3_storage_manager.provider_region = provider_region
+          if s3_storage_manager
+            s3_storage_manager.zone_id         = zone_id
+            s3_storage_manager.provider_region = provider_region
+          end
+        end
       end
     end
   end
 
   def up
-    CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
+    ManageIQ::Providers::CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
   end
 end

--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -1,5 +1,39 @@
+class ManageIQ::Providers::CloudManager
+  def ensure_managers
+    build_network_manager unless network_manager
+    network_manager.name = "#{name} Network Manager"
+
+    build_ebs_storage_manager unless ebs_storage_manager
+    ebs_storage_manager.name = "#{name} EBS Storage Manager"
+
+    if ::Settings.prototype.amazon.s3
+      build_s3_storage_manager unless s3_storage_manager
+      s3_storage_manager.name = "#{name} S3 Storage Manager"
+    end
+
+    ensure_managers_zone_and_provider_region
+  end
+
+  def ensure_managers_zone_and_provider_region
+    if network_manager
+      network_manager.zone_id         = zone_id
+      network_manager.provider_region = provider_region
+    end
+
+    if ebs_storage_manager
+      ebs_storage_manager.zone_id         = zone_id
+      ebs_storage_manager.provider_region = provider_region
+    end
+
+    if s3_storage_manager
+      s3_storage_manager.zone_id         = zone_id
+      s3_storage_manager.provider_region = provider_region
+    end
+  end
+end
+
 class EnsureCloudManagers < ActiveRecord::Migration[5.0]
-  def change
+  def up
     ManageIQ::Providers::CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
   end
 end

--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -5,7 +5,7 @@ class EnsureCloudManagers < ActiveRecord::Migration[5.0]
 
   class ManageIQ
     class Providers
-      class CloudManager < ActiveRecord::Base
+      class CloudManager < BaseManager
         def ensure_managers
           build_network_manager unless network_manager
           network_manager.name = "#{name} Network Manager"

--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -1,7 +1,10 @@
 class EnsureCloudManagers < ActiveRecord::Migration[5.0]
-  class ExtManagementSystem < ActiveRecord::Base; end
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
   class BaseManager < ExtManagementSystem; end
-  class Settings < ActiveRecord::Base; end
+  class Settings; end
 
   class ManageIQ
     class Providers

--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -1,7 +1,9 @@
 class EnsureCloudManagers < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base; end
+  class BaseManager < ExtManagementSystem; end
   class Settings < ActiveRecord::Base; end
 
-  class ManageIQ::Providers::CloudManager < ActiveRecord::Base
+  class CloudManager < ActiveRecord::Base
     def ensure_managers
       build_network_manager unless network_manager
       network_manager.name = "#{name} Network Manager"
@@ -36,6 +38,6 @@ class EnsureCloudManagers < ActiveRecord::Migration[5.0]
   end
 
   def up
-    ManageIQ::Providers::CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
+    CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
   end
 end

--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -1,38 +1,40 @@
-class ManageIQ::Providers::CloudManager
-  def ensure_managers
-    build_network_manager unless network_manager
-    network_manager.name = "#{name} Network Manager"
-
-    build_ebs_storage_manager unless ebs_storage_manager
-    ebs_storage_manager.name = "#{name} EBS Storage Manager"
-
-    if ::Settings.prototype.amazon.s3
-      build_s3_storage_manager unless s3_storage_manager
-      s3_storage_manager.name = "#{name} S3 Storage Manager"
-    end
-
-    ensure_managers_zone_and_provider_region
-  end
-
-  def ensure_managers_zone_and_provider_region
-    if network_manager
-      network_manager.zone_id         = zone_id
-      network_manager.provider_region = provider_region
-    end
-
-    if ebs_storage_manager
-      ebs_storage_manager.zone_id         = zone_id
-      ebs_storage_manager.provider_region = provider_region
-    end
-
-    if s3_storage_manager
-      s3_storage_manager.zone_id         = zone_id
-      s3_storage_manager.provider_region = provider_region
-    end
-  end
-end
-
 class EnsureCloudManagers < ActiveRecord::Migration[5.0]
+  class Settings < ActiveRecord::Base; end
+
+  class ManageIQ::Providers::CloudManager < ActiveRecord::Base
+    def ensure_managers
+      build_network_manager unless network_manager
+      network_manager.name = "#{name} Network Manager"
+
+      build_ebs_storage_manager unless ebs_storage_manager
+      ebs_storage_manager.name = "#{name} EBS Storage Manager"
+
+      if Settings.prototype.amazon.s3
+        build_s3_storage_manager unless s3_storage_manager
+        s3_storage_manager.name = "#{name} S3 Storage Manager"
+      end
+
+      ensure_managers_zone_and_provider_region
+    end
+
+    def ensure_managers_zone_and_provider_region
+      if network_manager
+        network_manager.zone_id         = zone_id
+        network_manager.provider_region = provider_region
+      end
+
+      if ebs_storage_manager
+        ebs_storage_manager.zone_id         = zone_id
+        ebs_storage_manager.provider_region = provider_region
+      end
+
+      if s3_storage_manager
+        s3_storage_manager.zone_id         = zone_id
+        s3_storage_manager.provider_region = provider_region
+      end
+    end
+  end
+
   def up
     ManageIQ::Providers::CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
   end

--- a/db/migrate/20171023170841_ensure_cloud_managers.rb
+++ b/db/migrate/20171023170841_ensure_cloud_managers.rb
@@ -1,0 +1,5 @@
+class EnsureCloudManagers < ActiveRecord::Migration[5.0]
+  def change
+    ManageIQ::Providers::CloudManager.all.each { |x| x.send(:ensure_managers); x.save!; }
+  end
+end


### PR DESCRIPTION
This addresses an issue, originally on the Amazon provider side, where the EMS relationships were not established when a StorageManager was added.

Originally brought to our attention via https://bugzilla.redhat.com/show_bug.cgi?id=1480629, but 5.7 -> 5.8 will be handled with a `self.seed` method.