### PR TITLE
Added options to MiqAeMethod table

### DIFF
--- a/db/migrate/20171024144122_add_options_to_miq_ae_method.rb
+++ b/db/migrate/20171024144122_add_options_to_miq_ae_method.rb
@@ -1,0 +1,5 @@
+class AddOptionsToMiqAeMethod < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_ae_methods, :options, :text
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4820,6 +4820,7 @@ miq_ae_methods:
 - updated_by
 - updated_by_user_id
 - embedded_methods
+- options
 miq_ae_namespaces:
 - id
 - parent_id


### PR DESCRIPTION
With the addition of newer Method types like Ansible Playbook,
Expression Methods we need to store custom options hash for each of
these method types.