### PR TITLE
Add an 'Allocated cpu cores' chargeback rate detail to existing chargeback rates

### DIFF
--- a/db/migrate/20171026103833_add_cores_allocated_rate_detail.rb
+++ b/db/migrate/20171026103833_add_cores_allocated_rate_detail.rb
@@ -1,0 +1,43 @@
+class AddCoresAllocatedRateDetail < ActiveRecord::Migration[5.0]
+  class ChargebackRate < ActiveRecord::Base
+    has_many :chargeback_rate_details, :class_name => 'AddCoresAllocatedRateDetail::ChargebackRateDetail'
+  end
+
+  class ChargebackTier < ActiveRecord::Base
+    FORM_ATTRIBUTES = %i(fixed_rate variable_rate start finish).freeze
+  end
+
+  class ChargeableField < ActiveRecord::Base; end
+
+  class ChargebackRateDetail < ActiveRecord::Base
+    belongs_to :chargeback_rate, :class_name => 'AddCoresAllocatedRateDetail::ChargebackRate'
+    belongs_to :chargeable_field
+    has_many   :chargeback_tiers, :class_name => 'AddCoresAllocatedRateDetail::ChargebackTier'
+  end
+
+  def up
+    chargeable_field = ChargeableField.find_or_create_by(:metric      => "derived_vm_numvcpus_cores",
+                                                         :description => "Allocated CPU Cores",
+                                                         :group       => "cpu_cores",
+                                                         :source      => "allocated")
+
+    rate_detail_template = ChargebackRateDetail.where(:description => "Allocated CPU Count").first
+    return if rate_detail_template.nil? # No rates that need this detail.
+    rate_detail_template = rate_detail_template.dup
+    rate_detail_template.chargeable_field = chargeable_field
+    rate_detail_template.description = "Allocated CPU Cores"
+    rate_detail_template.per_unit = "cpu core"
+    tier_template = {:start => 0, :finish => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 0.0}
+
+    # Add to cb rates that do not have the "Allocated CPU Cores" cb detail
+    ChargebackRate.where(:rate_type => "Compute").where.not(:id => ChargebackRateDetail.where(:description => "Allocated CPU Cores").select(:chargeback_rate_id)).each do |rate|
+      new_rate_detail = rate_detail_template.dup
+      new_rate_detail.chargeback_tiers << ChargebackTier.new(tier_template.slice(*ChargebackTier::FORM_ATTRIBUTES))
+      rate.chargeback_rate_details << new_rate_detail
+    end
+  end
+
+  def down
+    ChargebackRateDetail.where(:description => "Allocated CPU Cores").destroy_all
+  end
+end

--- a/spec/migrations/20171026103833_add_cores_allocated_rate_detail_spec.rb
+++ b/spec/migrations/20171026103833_add_cores_allocated_rate_detail_spec.rb
@@ -1,0 +1,46 @@
+require_migration
+
+describe AddCoresAllocatedRateDetail do
+  let(:rate_stub) { migration_stub(:ChargebackRate) }
+  let(:detail_stub) { migration_stub(:ChargebackRateDetail) }
+  let(:field_stub) { migration_stub(:ChargeableField) }
+  let(:measure_stub) { migration_stub(:ChargebackRateDetailMeasure) }
+
+  let(:default_rate) { rate_stub.create!(:rate_type => 'Compute', :default => :true) }
+  let(:custom_rate) { rate_stub.create!(:rate_type => 'Compute') }
+
+  let(:rate_details) do
+    [
+      {:metric => 'cpu_usagemhz_rate_average', :group => 'cpu', :source => 'used', :description => 'Used CPU'},
+      {:metric => 'derived_vm_numvcpus', :group => 'cpu', :source => 'allocated', :description => 'Allocated CPU Count'},
+      {:metric => 'disk_usage_rate_average', :group => 'disk_io', :source => 'used', :description => 'Used Disk I/O'}
+    ]
+  end
+
+  let(:allocated_cores) { {:metric => 'derived_vm_numvcpus_cores', :group => 'cpu cores', :source => 'allocated', :description => 'Allocated CPU Cores'} }
+
+  migration_context :up do
+    it 'Adds a "Allocated CPU Cores" rate detail to existing details' do
+      rate_details.each do |field|
+        detail_stub.create!(field.merge(:chargeback_rate_id => default_rate.id))
+        detail_stub.create!(field.merge(:chargeback_rate_id => custom_rate.id))
+      end
+
+      migrate
+
+      expect(default_rate.reload.chargeback_rate_details.where(:description => "Allocated CPU Cores").count).to eq(1)
+      expect(custom_rate.reload.chargeback_rate_details.where(:description => "Allocated CPU Cores").count).to eq(1)
+    end
+  end
+
+  migration_context :down do
+    it 'Removes all "Allocated CPU Cores" rate details' do
+      detail_stub.create!(allocated_cores.merge(:chargeback_rate_id => default_rate.id))
+      detail_stub.create!(allocated_cores.merge(:chargeback_rate_id => custom_rate.id))
+
+      migrate
+
+      expect(detail_stub.where(:description => "Allocated CPU Cores").count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Adds the rate detail used in https://github.com/ManageIQ/manageiq/pull/15616 to existing chargeback rates
@lpichler Please review
cc @moolitayer @cben @simon3z 