### PR TITLE
Delete all EmsRefresh.refresh MiqQueue items

### DIFF
--- a/db/migrate/20171025122732_delete_ems_refresh_queue_items.rb
+++ b/db/migrate/20171025122732_delete_ems_refresh_queue_items.rb
@@ -1,0 +1,9 @@
+class DeleteEmsRefreshQueueItems < ActiveRecord::Migration[5.0]
+  class MiqQueue < ActiveRecord::Base; end
+
+  def up
+    say_with_time('Delete EmsRefresh.refresh Queue Items') do
+      MiqQueue.where(:class_name => 'EmsRefresh', :method_name => 'refresh').delete_all
+    end
+  end
+end


### PR DESCRIPTION
Alternative to https://github.com/ManageIQ/manageiq-schema/pull/107
Instead of migrating the columns just delete all refresh queue items when upgrading.