### PR TITLE
Add deleted_on (with index) to container_quotas, container_quota_items

### DIFF
--- a/db/migrate/20171026114327_add_deleted_on_to_container_quota_and_items.rb
+++ b/db/migrate/20171026114327_add_deleted_on_to_container_quota_and_items.rb
@@ -1,0 +1,10 @@
+class AddDeletedOnToContainerQuotaAndItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_quotas, :deleted_on, :datetime
+    add_index :container_quotas, :deleted_on
+
+    add_timestamps :container_quota_items
+    add_column :container_quota_items, :deleted_on, :datetime
+    add_index :container_quota_items, :deleted_on
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -806,6 +806,9 @@ container_quota_items:
 - quota_desired
 - quota_enforced
 - quota_observed
+- created_at
+- updated_at
+- deleted_on
 container_quotas:
 - id
 - name
@@ -815,6 +818,7 @@ container_quotas:
 - container_project_id
 - ems_id
 - created_on
+- deleted_on
 container_replicators:
 - id
 - ems_ref


### PR DESCRIPTION
We need to store history of quotas during project lifetime.
Reporting needs unclear yet, for now just want to store it.
https://bugzilla.redhat.com/show_bug.cgi?id=1504560

As discussed with @gtanzillo @bazulay @zeari, we are going to (ab)use archiving to store history in same tables — not just when user deletes quota in kubernetes but also when it's changed!

(Not yet clear if when only a container_quota_item changes, we'll archive and create only new item, or archive whole quota "snapshot" and create new quota with children.  Want to keep door open to both designs in z-streams, so need them in both tables...)

Added same indexes on `deleted_on` as other archived container items (#18).

## Impact on table churn/size

There are O(1) container_quotas rows per container_project, and most users change them rarely and manually.  That's why we'll store these only on change, not periodically as in metrics/rollups/vim_performance_states.

However `container_quota_items.quota_observed` column may change each refresh.
At this stage, we don't plan to archive when solely `quota_observed` changes, but that may change.

=> I don't expect these tables to become huge.  Should stay significantly smaller than `container_groups`.

(P.S. quota scopes coming in separate PR.)

@miq-bot add-label enhancement

@zeari @gtanzillo @Fryguy please review, want to get at least schema before freeze.