### PR TITLE
Create container_quota_scopes table

### DIFF
--- a/db/migrate/20171026142653_create_container_quota_scopes.rb
+++ b/db/migrate/20171026142653_create_container_quota_scopes.rb
@@ -1,0 +1,10 @@
+class CreateContainerQuotaScopes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :container_quota_scopes do |t|
+      t.bigint :container_quota_id
+      t.string :scope
+      t.timestamps
+      t.datetime :deleted_on
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -809,6 +809,13 @@ container_quota_items:
 - created_at
 - updated_at
 - deleted_on
+container_quota_scopes:
+- id
+- container_quota_id
+- scope
+- created_at
+- updated_at
+- deleted_on
 container_quotas:
 - id
 - name


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-scopes
We don't yet store them, but should.
ContainerQuota has_many scopes, each a string (currently enum with 4 possible values `Terminating`, `NotTerminating`, `BestEffort`, `NotBestEffort`).

Didn't see any reason to choose clever serialized/json representation so went with standard has_many to new table.

See #110 for motivation having created_at/deleted_on.

https://bugzilla.redhat.com/show_bug.cgi?id=1504560
