### PR TITLE
Drop blueprints and blueprint_id in dialogs and service_templates

### DIFF
--- a/db/migrate/20171026152944_drop_blueprints.rb
+++ b/db/migrate/20171026152944_drop_blueprints.rb
@@ -1,0 +1,24 @@
+class DropBlueprints < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :blueprints
+    remove_column :dialogs,           :blueprint_id, :bigint
+    remove_column :service_templates, :blueprint_id, :bigint
+  end
+
+  def down
+    create_table :blueprints do |t|
+      t.string :name
+      t.string :description
+      t.string :status
+      t.string :version
+      t.jsonb  :ui_properties
+
+      t.timestamps
+    end
+    add_index :blueprints, :name
+    add_index :blueprints, :status
+
+    add_column :dialogs,           :blueprint_id, :bigint
+    add_column :service_templates, :blueprint_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -157,15 +157,6 @@ blacklisted_events:
 - enabled
 - created_at
 - updated_at
-blueprints:
-- id
-- name
-- description
-- status
-- version
-- ui_properties
-- created_at
-- updated_at
 bottleneck_events:
 - id
 - timestamp
@@ -1104,7 +1095,6 @@ dialogs:
 - created_at
 - updated_at
 - label
-- blueprint_id
 direct_configuration_profiles_configuration_tags:
 - configuration_profile_id
 - configuration_tag_id
@@ -5918,7 +5908,6 @@ service_templates:
 - service_template_catalog_id
 - long_description
 - tenant_id
-- blueprint_id
 - generic_subtype
 services:
 - id


### PR DESCRIPTION
The usage has been removed in API and core model. This is the last step to clean up in schema.

https://github.com/ManageIQ/manageiq-api/pull/139
https://github.com/ManageIQ/manageiq/pull/16268