### PR TITLE
Retroactive fix to broken #110

### DIFF
--- a/db/migrate/20171026114327_add_deleted_on_to_container_quota_and_items.rb
+++ b/db/migrate/20171026114327_add_deleted_on_to_container_quota_and_items.rb
@@ -1,12 +1,31 @@
 class AddDeletedOnToContainerQuotaAndItems < ActiveRecord::Migration[5.0]
   class ContainerQuota < ActiveRecord::Base; end
-  class ContainerQuotaItem < ActiveRecord::Base; end
+  class ContainerQuotaItem < ActiveRecord::Base
+    belongs_to :container_quota, :class_name => "AddDeletedOnToContainerQuotaAndItems::ContainerQuota"
+  end
 
   def change
     add_column :container_quotas, :deleted_on, :datetime
     add_index :container_quotas, :deleted_on
 
-    add_timestamps :container_quota_items
+    add_timestamps :container_quota_items, :null => true # temporarily for backfilling, then disallow nulls
+    reversible do |dir|
+      dir.up do
+        say_with_time("Backfilling container_quota_items timestamps from parent quotas") do
+          # All quota items SHOULD have a parent quota, which SHOULD have deleted_on
+          # but just in case, fallback to current time.
+          now = Time.zone.now
+          ContainerQuotaItem.includes(:container_quota).find_each do |item|
+            # This also sets updated_at to migration time.
+            item.update_attributes(:created_at => item.container_quota.try(:created_on) || now)
+          end
+        end
+      end
+      # down: unnecessary, created_at/updated_at columns get deleted.
+    end
+    change_column_null :container_quota_items, :created_at, false
+    change_column_null :container_quota_items, :updated_at, false
+
     add_column :container_quota_items, :deleted_on, :datetime
     add_index :container_quota_items, :deleted_on
   end

--- a/db/migrate/20171026114327_add_deleted_on_to_container_quota_and_items.rb
+++ b/db/migrate/20171026114327_add_deleted_on_to_container_quota_and_items.rb
@@ -1,4 +1,7 @@
 class AddDeletedOnToContainerQuotaAndItems < ActiveRecord::Migration[5.0]
+  class ContainerQuota < ActiveRecord::Base; end
+  class ContainerQuotaItem < ActiveRecord::Base; end
+
   def change
     add_column :container_quotas, :deleted_on, :datetime
     add_index :container_quotas, :deleted_on

--- a/spec/migrations/20171026114327_add_deleted_on_to_container_quota_and_items_spec.rb
+++ b/spec/migrations/20171026114327_add_deleted_on_to_container_quota_and_items_spec.rb
@@ -33,7 +33,7 @@ describe AddDeletedOnToContainerQuotaAndItems do
       migrate
       item.reload
 
-      expect(item.deleted_on).to eq(nil)
+      expect(item.created_at).to eq(quota.created_on)
       expect(item.updated_at).not_to eq(nil)
     end
 

--- a/spec/migrations/20171026114327_add_deleted_on_to_container_quota_and_items_spec.rb
+++ b/spec/migrations/20171026114327_add_deleted_on_to_container_quota_and_items_spec.rb
@@ -1,0 +1,101 @@
+require_migration
+
+describe AddDeletedOnToContainerQuotaAndItems do
+  let(:container_quota_stub) { migration_stub(:ContainerQuota) }
+  let(:container_quota_item_stub) { migration_stub(:ContainerQuotaItem) }
+
+  let(:quota_data) do
+    {
+      :name             => "compute-resources",
+      # This is a real example, quota existed in openshift 2 month before
+      # provider was even added and refresh created DB record.
+      :created_on       => "2017-10-19 09:07:28 UTC",
+      :ems_created_on   => "2017-08-09 11:56:21 UTC",
+      :ems_ref          => "c2a9805e-7cf9-11e7-8ac6-001a4a162683",
+      :resource_version => "5553729",
+      # omitted ems_id, container_project_id.
+    }
+  end
+  let(:item_data) do
+    {
+      :resource       => "cpu",
+      :quota_desired  => 0.02,
+      :quota_enforced => 0.02,
+      :quota_observed => 0.0,
+    }
+  end
+
+  migration_context :up do
+    it "works with a container_quota_item" do
+      quota = container_quota_stub.create!(quota_data)
+      item = container_quota_item_stub.create!(:container_quota_id => quota.id, **item_data)
+
+      migrate
+      item.reload
+
+      expect(item.deleted_on).to eq(nil)
+      expect(item.updated_at).not_to eq(nil)
+    end
+
+    # really improbable but just in case
+    it "works with an item whose quota.created_on is null" do
+      quota = container_quota_stub.create!(quota_data)
+      quota.update_columns(:created_on => nil)
+      expect(quota.reload.created_on).to eq(nil) # verify we convinced rails to clear the timestamp
+
+      item = container_quota_item_stub.create!(:container_quota_id => quota.id, **item_data)
+
+      migrate
+      item.reload
+
+      expect(item.deleted_on).to eq(nil)
+      expect(item.created_at).not_to eq(nil)
+      expect(item.updated_at).not_to eq(nil)
+    end
+
+    it "works with an orphan item that has no parent quota" do
+      item = container_quota_item_stub.create!(:container_quota_id => nil, **item_data)
+
+      migrate
+      item.reload
+
+      expect(item.deleted_on).to eq(nil)
+      expect(item.created_at).not_to eq(nil)
+      expect(item.updated_at).not_to eq(nil)
+    end
+  end
+
+  migration_context :down do
+    let(:quota_data_with_timestamps) do
+      quota_data.merge(:deleted_on => "2017-11-15 15:55:55 UTC")
+    end
+    let(:item_data_with_timestamps) do
+      item_data.merge(:created_at => "2017-10-21 11:11:11 UTC",
+                      :updated_at => "2017-10-22 22:22:22 UTC",
+                      :deleted_on => "2017-10-23 23:33:33 UTC")
+    end
+
+    it "works with a container_quota_item" do
+      quota = container_quota_stub.create!(quota_data_with_timestamps)
+      container_quota_item_stub.create!(:container_quota_id => quota.id, **item_data_with_timestamps)
+
+      migrate
+    end
+
+    it "works with an item whose quota.created_on is null" do
+      quota = container_quota_stub.create!(quota_data_with_timestamps)
+      quota.update_columns(:created_on => nil)
+      expect(quota.reload.created_on).to eq(nil) # verify we convinced rails to clear the timestamp
+
+      container_quota_item_stub.create!(:container_quota_id => quota.id, **item_data_with_timestamps)
+
+      migrate
+    end
+
+    it "works with an orphan item that has no parent quota" do
+      container_quota_item_stub.create!(:container_quota_id => nil, **item_data_with_timestamps)
+
+      migrate
+    end
+  end
+end


### PR DESCRIPTION
So #110 migration `20171026114327_add_deleted_on_to_container_quota_and_items` failed for people that had container providers :-(
[`add_timestamps` sets NOT NULL](https://makandracards.com/makandra/19325-your-database-tables-should-always-have-timestamps), which existing records violate:

    PG::NotNullViolation: ERROR:  column "created_at" contains null values

It was also semantically wrong, we'll want all records to have `created_at` timestamps so we can rely on `created_at`..`deleted_on` ranges in future reports.

This PR must converge to same outcome in two scenarios:

Timeline Z
----------

Some people with zero records in `container_quota_items` successfully run original #110 migration and will not re-execute changes I do here.

They end up with:

    t.datetime "created_at",         null: false
    t.datetime "updated_at",         null: false

and zero records, future records will get both timestamps filled.

Timeline Q
----------

People that had 1 or more `container_quota_items` got stuck before the broken migration ("An error has occurred, this and all later migrations canceled").
**I can't just append a new migration because these people can't get past the broken one.
They will re-execute these changes once they're merged.**

@miq-bot add-label bug
@zeari @zakiva @Fryguy please review (carefully!)

- [x] added tests for original breakage
- [x] run the two scenarios on separate DBs and compared resulting schema.rb — same