### PR TITLE
Fix typo is should be derived_vm_numvcpu_cores

### DIFF
--- a/db/migrate/20171026103833_add_cores_allocated_rate_detail.rb
+++ b/db/migrate/20171026103833_add_cores_allocated_rate_detail.rb
@@ -16,7 +16,7 @@ class AddCoresAllocatedRateDetail < ActiveRecord::Migration[5.0]
   end
 
   def up
-    chargeable_field = ChargeableField.find_or_create_by(:metric      => "derived_vm_numvcpus_cores",
+    chargeable_field = ChargeableField.find_or_create_by(:metric      => "derived_vm_numvcpu_cores",
                                                          :description => "Allocated CPU Cores",
                                                          :group       => "cpu_cores",
                                                          :source      => "allocated")


### PR DESCRIPTION
there is `s`  in cpus in addition

https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/chargeback_rates.yml#L38


@miq-bot assign @Fryguy 
cc @zeari 

