### PR TITLE
Downcase ems_ref for Azure resource groups

### DIFF
--- a/db/migrate/20171117201600_downcase_resource_group_ems_ref_for_azure.rb
+++ b/db/migrate/20171117201600_downcase_resource_group_ems_ref_for_azure.rb
@@ -1,0 +1,9 @@
+class DowncaseResourceGroupEmsRefForAzure < ActiveRecord::Migration[5.0]
+  class ResourceGroup < ActiveRecord::Base; end
+
+  def up
+    say_with_time("Downcase ems_ref for Azure resource groups") do
+      ResourceGroup.update_all("ems_ref = lower(ems_ref)")
+    end
+  end
+end

--- a/spec/migrations/20171117201600_downcase_resource_group_ems_ref_for_azure_spec.rb
+++ b/spec/migrations/20171117201600_downcase_resource_group_ems_ref_for_azure_spec.rb
@@ -1,0 +1,44 @@
+require_migration
+
+describe DowncaseResourceGroupEmsRefForAzure do
+  let(:resource_group_stub) { migration_stub :ResourceGroup }
+
+  let!(:uppercase_stub) do
+    resource_group_stub.create!(
+      :name    => 'UPPER',
+      :ems_ref => '/subscriptions/xyz/resourceGroups/UPPER'
+    )
+  end
+
+  let!(:mixedcase_stub) do
+    resource_group_stub.create!(
+      :name    => 'MiXeD',
+      :ems_ref => '/subscriptions/xyz/resourceGroups/MiXeD'
+    )
+  end
+
+  let!(:lowercase_stub) do
+    resource_group_stub.create!(
+      :name    => 'lower',
+      :ems_ref => '/subscriptions/xyz/resourceGroups/lower'
+    )
+  end
+
+  migration_context :up do
+    it 'Downcases the resource group ems_ref column' do
+      migrate
+
+      uppercase_stub.reload
+      expect(uppercase_stub.ems_ref).to eql('/subscriptions/xyz/resourcegroups/upper')
+      expect(uppercase_stub.name).to eql('UPPER')
+
+      mixedcase_stub.reload
+      expect(mixedcase_stub.ems_ref).to eql('/subscriptions/xyz/resourcegroups/mixed')
+      expect(mixedcase_stub.name).to eql('MiXeD')
+
+      lowercase_stub.reload
+      expect(lowercase_stub.ems_ref).to eql('/subscriptions/xyz/resourcegroups/lower')
+      expect(lowercase_stub.name).to eql('lower')
+    end
+  end
+end


### PR DESCRIPTION
This is a migration that corresponds with https://github.com/ManageIQ/manageiq-providers-azure/pull/156.

In short, the ems_ref for an Azure resource group should always be lower case because we cannot guarantee the case of the resource group returned by the Azure REST API.

Marked as a WIP for now because my local env seems to be in a bad state.