### PR TITLE
Move the db:check_schema task to the public tasks.rake file

### DIFF
--- a/lib/tasks/schema_tasks.rake
+++ b/lib/tasks/schema_tasks.rake
@@ -1,0 +1,8 @@
+namespace :db do
+  desc 'Check the current schema against the schema.yml file for inconsistencies'
+  task :check_schema => :environment do
+    message = ManageIQ::Schema::Checker.check_schema
+    raise message if message
+    puts "The local schema is consistent with schema.yml"
+  end
+end

--- a/lib/tasks_private/schema_tasks.rake
+++ b/lib/tasks_private/schema_tasks.rake
@@ -1,11 +1,4 @@
 namespace :db do
-  desc 'Check the current schema against the schema.yml file for inconsistencies'
-  task :check_schema => :environment do
-    message = ManageIQ::Schema::Checker.check_schema
-    raise message if message
-    puts "The local schema is consistent with schema.yml"
-  end
-
   desc 'Write the current schema to the schema.yml file'
   task :write_schema => :environment do
     ManageIQ::Schema::Checker.write_expected_schema


### PR DESCRIPTION
This will allow it to be used by users when attempting to correct column ordering issues after migrating.

https://bugzilla.redhat.com/show_bug.cgi?id=1508537