### PR TITLE
Remove the limit from string columns in all tables

### DIFF
--- a/db/migrate/20171109225052_remove_string_column_limits.rb
+++ b/db/migrate/20171109225052_remove_string_column_limits.rb
@@ -1,0 +1,10 @@
+class RemoveStringColumnLimits < ActiveRecord::Migration[5.0]
+  def up
+    connection.tables.each do |t|
+      connection.columns(t).each do |col|
+        next unless col.type == :string && !col.limit.nil?
+        change_column t, col.name, :string, :limit => nil
+      end
+    end
+  end
+end

--- a/spec/migrations/20171109225052_remove_string_column_limits_spec.rb
+++ b/spec/migrations/20171109225052_remove_string_column_limits_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe RemoveStringColumnLimits do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:table_name) { "remove_string_column_limits" }
+
+  migration_context :up do
+    it "removes the limit from string columns" do
+      connection.execute(<<-SQL)
+        CREATE TABLE #{table_name} (id bigint, string varchar(255), other_string varchar(36), more_string varchar)
+      SQL
+
+      migrate
+
+      columns_by_name = connection.columns(table_name).each_with_object({}) do |col, hash|
+        hash[col.name] = col
+      end
+
+      expect(columns_by_name["id"].limit).to eq(8)
+      expect(columns_by_name["string"].limit).to be_nil
+      expect(columns_by_name["other_string"].limit).to be_nil
+      expect(columns_by_name["more_string"].limit).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
In older versions of activerecord "t.string" columns without an explicit limit were limited to 255 by default.

In newer versions that limit has been removed.

This is creating a discrepancy between databases which have been migrated through the older versions of activerecord and ones which were newly created.

This causes difficult to diagnose bugs for no reason.

https://bugzilla.redhat.com/show_bug.cgi?id=1510605