### PR TITLE
Require the activerecord extension from the pg-pglogical gem

### DIFF
--- a/lib/manageiq/schema.rb
+++ b/lib/manageiq/schema.rb
@@ -13,3 +13,6 @@ require 'reserve'
 require 'reserved_shared_mixin'
 require 'reserved_migration_mixin'
 require 'reserved_mixin'
+
+require 'pg/pglogical'
+require 'pg/pglogical/active_record_extension'

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "more_core_extensions"
   s.add_dependency "pg", "~> 0.18.2"
   s.add_dependency "rails", "~> 5.0.2"
+  s.add_dependency "pg-pglogical", "~> 2.1.1"
 
   s.add_dependency "manageiq-gems-pending"  # This is just for MiqPassword for now
 


### PR DESCRIPTION
This extension enables a patch to the drop_table migration method to first remove the table from the replication set if replication is being used.

https://bugzilla.redhat.com/show_bug.cgi?id=1508402