### PR TITLE
Update ResourceGroup type for Azure

### DIFF
--- a/db/migrate/20171117201519_update_resource_group_type_for_azure.rb
+++ b/db/migrate/20171117201519_update_resource_group_type_for_azure.rb
@@ -1,0 +1,17 @@
+class UpdateResourceGroupTypeForAzure < ActiveRecord::Migration[5.0]
+  class ResourceGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Update Azure resource group type") do
+      ResourceGroup.update_all(:type => 'ManageIQ::Providers::Azure::ResourceGroup')
+    end
+  end
+
+  def down
+    say_with_time("Set Azure resource group type to base value") do
+      ResourceGroup.update_all(:type => 'ResourceGroup')
+    end
+  end
+end

--- a/spec/migrations/20171117201519_update_resource_group_type_for_azure_spec.rb
+++ b/spec/migrations/20171117201519_update_resource_group_type_for_azure_spec.rb
@@ -1,0 +1,45 @@
+require_migration
+
+describe UpdateResourceGroupTypeForAzure do
+  let(:resource_group_stub) { migration_stub :ResourceGroup }
+  let(:expected_type) { 'ManageIQ::Providers::Azure::ResourceGroup' }
+  let(:base_type) { 'ResourceGroup' }
+
+  migration_context :up do
+    it 'Sets the type column to the expected value' do
+      first_group  = resource_group_stub.create!(:name => 'foo', :type => 'Alpha')
+      second_group = resource_group_stub.create!(:name => 'bar', :type => 'ResourceGroup')
+      third_group  = resource_group_stub.create!(:name => 'baz', :type => 'ManageIQ::Providers::Azure::ResourceGroup')
+
+      migrate
+
+      first_group.reload
+      expect(first_group.type).to eql(expected_type)
+
+      second_group.reload
+      expect(second_group.type).to eql(expected_type)
+
+      third_group.reload
+      expect(third_group.type).to eql(expected_type)
+    end
+  end
+
+  migration_context :down do
+    it 'Sets the type column to the base ResourceGroup type' do
+      first_group  = resource_group_stub.create!(:name => 'foo', :type => 'Alpha')
+      second_group = resource_group_stub.create!(:name => 'bar', :type => 'ResourceGroup')
+      third_group  = resource_group_stub.create!(:name => 'baz', :type => 'ManageIQ::Providers::Azure::ResourceGroup')
+
+      migrate
+
+      first_group.reload
+      expect(first_group.type).to eql(base_type)
+
+      second_group.reload
+      expect(second_group.type).to eql(base_type)
+
+      third_group.reload
+      expect(third_group.type).to eql(base_type)
+    end
+  end
+end


### PR DESCRIPTION
This sets the `:type` column of the ResourceGroup table to the appropriate type. Since Azure is the only provider using this table at this time, we update all records.

This is a continuation of https://github.com/ManageIQ/manageiq-schema/pull/123.

One of several PR's that goes towards fixing:

https://bugzilla.redhat.com/show_bug.cgi?id=1503295