### PR TITLE
Change migration to use batch output instead of print "."

### DIFF
--- a/db/migrate/20150806211453_rename_ems_event_table_to_event_stream.rb
+++ b/db/migrate/20150806211453_rename_ems_event_table_to_event_stream.rb
@@ -2,7 +2,7 @@ class RenameEmsEventTableToEventStream < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   include MigrationHelper
 
-  BATCH_SIZE = 1000
+  BATCH_SIZE = 25_000
 
   class EventStream < ActiveRecord::Base
     self.inheritance_column = :_type_disabled

--- a/spec/migrations/20150806211453_rename_ems_event_table_to_event_stream_spec.rb
+++ b/spec/migrations/20150806211453_rename_ems_event_table_to_event_stream_spec.rb
@@ -5,7 +5,7 @@ describe RenameEmsEventTableToEventStream do
   let(:event_stream_stub)   { migration_stub(:EventStream) }
 
   migration_context :up do
-    it 'adds two cloumns' do
+    it 'adds two columns' do
       ems_event_stub.create!
 
       migrate
@@ -14,10 +14,23 @@ describe RenameEmsEventTableToEventStream do
       expect(event_stream.type).to eq('EmsEvent')
       expect(event_stream.target_id).to be_nil
     end
+
+    it 'updates in batches' do
+      stub_const("#{described_class}::BATCH_SIZE", 5)
+
+      ems_event_stub.transaction do
+        14.times { ems_event_stub.create! }
+      end
+
+      migrate
+
+      expect(event_stream_stub.distinct.pluck(:type)).to      eq ["EmsEvent"]
+      expect(event_stream_stub.distinct.pluck(:target_id)).to eq [nil]
+    end
   end
 
   migration_context :down do
-    it 'deletes two cloumns' do
+    it 'deletes two columns' do
       event_stream_stub.create!
 
       migrate


### PR DESCRIPTION
@chessbyte @gtanzillo Please review.

This also changes the batch size from 1000 to 25000 because 1000 is WAY too chatty, particular for this table where millions of rows is not unexpected.   I was going to make it 100000, but on my machine it took about 5 seconds to do 100000 rows, so I thought worst case that could be 10 seconds on a customer's machine which might be too long.  25000 was a little over 1 second on my machine.

cc @lfu 

Closes #2 