### PR TITLE
Replace Thread.exclusive deprecated method with Mutex

### DIFF
--- a/lib/migration_helper.rb
+++ b/lib/migration_helper.rb
@@ -18,6 +18,8 @@ module MigrationHelper
 
   def say_batch_started(count)
     say "Processing #{count} rows", :subitem
+    require 'thread'
+    @batch_mutex ||= Mutex.new
     @batch_total_started = Time.now.utc
     @batch_started = Time.now.utc
     @batch_total = count
@@ -25,7 +27,7 @@ module MigrationHelper
   end
 
   def say_batch_processed(count)
-    Thread.exclusive do
+    @batch_mutex.synchronize do
       if count > 0
         @batch_count += count
 


### PR DESCRIPTION
As of Ruby 2.3.0, Thread.exclusive is deprecated, with Mutex being the alternative.

@chessbyte @gtanzillo Please review.