### PR TITLE
Cleanup some of the more verbose migrations by using say_with_time.

### DIFF
--- a/db/migrate/20150731025210_namespace_ems_openstack.rb
+++ b/db/migrate/20150731025210_namespace_ems_openstack.rb
@@ -42,8 +42,6 @@ class NamespaceEmsOpenstack < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Rename class references for Openstack and OpenstackInfra" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150807165254_namespace_ems_container.rb
+++ b/db/migrate/20150807165254_namespace_ems_container.rb
@@ -19,8 +19,6 @@ class NamespaceEmsContainer < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Rename class references for Kubernetes and Openshift" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150815051916_namespace_ems_microsoft.rb
+++ b/db/migrate/20150815051916_namespace_ems_microsoft.rb
@@ -11,8 +11,6 @@ class NamespaceEmsMicrosoft < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Rename class references for Microsoft SCVMM" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150815052719_fix_foreman_provider_type.rb
+++ b/db/migrate/20150815052719_fix_foreman_provider_type.rb
@@ -6,8 +6,6 @@ class FixForemanProviderType < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Rename class references for Foreman" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150822102141_fix_more_foreman_types.rb
+++ b/db/migrate/20150822102141_fix_more_foreman_types.rb
@@ -7,8 +7,6 @@ class FixMoreForemanTypes < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Rename class references for Foreman" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150823120001_namespace_ems_openstack_availability_zones_null.rb
+++ b/db/migrate/20150823120001_namespace_ems_openstack_availability_zones_null.rb
@@ -13,8 +13,6 @@ class NamespaceEmsOpenstackAvailabilityZonesNull < ActiveRecord::Migration[4.2]
 
     return if previously_migrated_as?("20151435234622")
 
-    say_with_time "Rename class references for OpenStack AZs" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150907163347_confirm_all_class_renames.rb
+++ b/db/migrate/20150907163347_confirm_all_class_renames.rb
@@ -130,8 +130,6 @@ class ConfirmAllClassRenames < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Rename class references" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150909023532_namespace_ems_azure.rb
+++ b/db/migrate/20150909023532_namespace_ems_azure.rb
@@ -12,8 +12,6 @@ class NamespaceEmsAzure < ActiveRecord::Migration[4.2]
   )]
 
   def change
-    say_with_time "Renaming class references for Azure namespace" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
   end
 end

--- a/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
+++ b/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
@@ -15,17 +15,17 @@ class AddVmwareRoDatastoresToHostsStorages < ActiveRecord::Migration[4.2]
     # the primary keys manually
     say_with_time("Add host_storages primary_key") do
       # Add an auto-increment sequence to be used by the primary key column
-      execute "CREATE SEQUENCE host_storages_id_seq START #{seq_start_value}"
+      connection.execute "CREATE SEQUENCE host_storages_id_seq START #{seq_start_value}"
 
       # Add a primary key column named id and use the previously created sequence
       # This will automatically fill in new primary keys for all existing rows
       # in the host_storages table
-      execute "ALTER TABLE host_storages ADD COLUMN id BIGINT PRIMARY KEY "\
+      connection.execute "ALTER TABLE host_storages ADD COLUMN id BIGINT PRIMARY KEY "\
               "NOT NULL DEFAULT NEXTVAL('host_storages_id_seq')"
 
       # Now update the sequence to be owned by the pkey column so that when it
       # gets deleted the sequence also is deleted
-      execute "ALTER SEQUENCE host_storages_id_seq OWNED BY host_storages.id"
+      connection.execute "ALTER SEQUENCE host_storages_id_seq OWNED BY host_storages.id"
     end
   end
 

--- a/db/migrate/20160406195810_add_id_primary_key_to_join_tables.rb
+++ b/db/migrate/20160406195810_add_id_primary_key_to_join_tables.rb
@@ -25,16 +25,16 @@ class AddIdPrimaryKeyToJoinTables < ActiveRecord::Migration[5.0]
       delete_remote_region_rows(t) if on_replication_target?
 
       say_with_time("Add primary key \"id\" to #{t}") do
-        execute <<-SQL
+        connection.execute <<-SQL
           CREATE SEQUENCE #{sequence_name(t)} START #{seq_start_value}
         SQL
 
-        execute <<-SQL
+        connection.execute <<-SQL
           ALTER TABLE #{t} ADD COLUMN id BIGINT PRIMARY KEY
           DEFAULT NEXTVAL('#{sequence_name(t)}')
         SQL
 
-        execute <<-SQL
+        connection.execute <<-SQL
           ALTER SEQUENCE #{sequence_name(t)} OWNED BY #{t}.id
         SQL
       end

--- a/db/migrate/20160829134746_remove_atomic_container_providers.rb
+++ b/db/migrate/20160829134746_remove_atomic_container_providers.rb
@@ -37,9 +37,7 @@ class RemoveAtomicContainerProviders < ActiveRecord::Migration[5.0]
   class MiqQueue < ActiveRecord::Base; end
 
   def up
-    say_with_time "Rename class references for Atomic and AtomicEnterprise" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
 
     say_with_time "Rename Atomic to Openshift in Authentication:name" do
       Authentication.update_all("name = replace(name, 'ManageIQ::Providers::Atomic', 'ManageIQ::Providers::Openshift')")

--- a/db/migrate/20170222105117_remove_openshift_enterprise_provider.rb
+++ b/db/migrate/20170222105117_remove_openshift_enterprise_provider.rb
@@ -26,9 +26,7 @@ class RemoveOpenshiftEnterpriseProvider < ActiveRecord::Migration[5.0]
   class MiqQueue < ActiveRecord::Base; end
 
   def up
-    say_with_time "Rename class references for Openshift and OpenshiftEnterprise" do
-      rename_class_references(NAME_MAP)
-    end
+    rename_class_references(NAME_MAP)
 
     say_with_time "Rename Openshift to Openshift in Authentication:name" do
       Authentication.update_all("name = replace(name, 'ManageIQ::Providers::OpenshiftEnterprise', 'ManageIQ::Providers::Openshift')")

--- a/lib/migration_helper.rb
+++ b/lib/migration_helper.rb
@@ -127,21 +127,28 @@ module MigrationHelper
       condition_list = mapping.keys.map { |s| connection.quote(s) }.join(',')
       when_clauses = mapping.map { |before, after| "WHEN #{connection.quote before} THEN #{connection.quote after}" }.join(' ')
 
-      type_columns_query = <<-SQL
-        SELECT pg_class.oid::regclass::text, quote_ident(attname)
-        FROM pg_class JOIN pg_attribute ON pg_class.oid = attrelid
-        WHERE relkind = 'r'
-          AND (attname = 'type' OR attname LIKE '%\\_type')
-          AND atttypid IN ('text'::regtype, 'varchar'::regtype)
-        ORDER BY relname, attname
-      SQL
+      say "Renaming class references:\n#{mapping.pretty_inspect}"
 
-      select_rows(type_columns_query).each do |quoted_table, quoted_column|
-        execute <<-SQL
-          UPDATE #{quoted_table}
-          SET #{quoted_column} = CASE #{quoted_column} #{when_clauses} END
-          WHERE #{quoted_column} IN (#{condition_list})
-        SQL
+      rows = say_with_time("Determining tables and columns for update") do
+        connection.select_rows(<<-SQL
+          SELECT pg_class.oid::regclass::text, quote_ident(attname)
+          FROM pg_class JOIN pg_attribute ON pg_class.oid = attrelid
+          WHERE relkind = 'r'
+            AND (attname = 'type' OR attname LIKE '%\\_type')
+            AND atttypid IN ('text'::regtype, 'varchar'::regtype)
+          ORDER BY relname, attname
+          SQL
+        )
+      end
+
+      rows.each do |quoted_table, quoted_column|
+        say_with_time("Renaming class reference in #{quoted_table}.#{quoted_column}") do
+          connection.execute <<-SQL
+            UPDATE #{quoted_table}
+            SET #{quoted_column} = CASE #{quoted_column} #{when_clauses} END
+            WHERE #{quoted_column} IN (#{condition_list})
+          SQL
+        end
       end
     end
   end


### PR DESCRIPTION
Additionally, calling .execute directly in a migration causes it to be
output even if wrapped in say_with_time, so qualify it with
connection.execute to make it less verbose.

@chessbyte @gtanzillo Please review

cc @agrare @carbonin 

Closes #1 