### PR TITLE
Add unique_set_size for servers and workers

### DIFF
--- a/db/migrate/20171130164503_add_unique_set_size_to_miq_servers_miq_workers.rb
+++ b/db/migrate/20171130164503_add_unique_set_size_to_miq_servers_miq_workers.rb
@@ -1,0 +1,6 @@
+class AddUniqueSetSizeToMiqServersMiqWorkers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_servers, :unique_set_size, :decimal, :precision => 20, :scale => 0
+    add_column :miq_workers, :unique_set_size, :decimal, :precision => 20, :scale => 0
+  end
+end


### PR DESCRIPTION
Why?  USS is a more reliable mechanism for tracking workers with runaway
memory growth.  PSS is great, until the server process that forks new
processes grows large. As each new worker is forked, it inherits a share
of the large amount of the parent process' memory and therefore starts
with a large PSS, possibly exceeding our limits before doing any work.
USS only measures a process' private memory and is a better indicator
when a process is responsible for allocating too much memory without
freeing it.

This is needed for PR: https://github.com/ManageIQ/manageiq/pull/16569