### PR TITLE
Add status to ext_management_system

### DIFF
--- a/db/migrate/20171130231127_add_status_to_ext_management_system.rb
+++ b/db/migrate/20171130231127_add_status_to_ext_management_system.rb
@@ -1,0 +1,5 @@
+class AddStatusToExtManagementSystem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ext_management_systems, :status, :string
+  end
+end


### PR DESCRIPTION
Adds a status column to ext_management_system to track when the EMS has
been marked for deletion.  This will allow it to be displayed to the
user as being in the process of being deleted and we can prevent the
user from re-enabling an EMS which is in the process of deletion.

Related: https://github.com/ManageIQ/manageiq/pull/16574