### PR TITLE
[WIP] Renames dialog label to name

### DIFF
--- a/db/migrate/20171204191404_fix_dialog_label_name.rb
+++ b/db/migrate/20171204191404_fix_dialog_label_name.rb
@@ -1,0 +1,5 @@
+class FixDialogLabelName < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :dialogs, :label, :name
+  end
+end


### PR DESCRIPTION
We're using `label` to refer to the dialog name and we call it `name` in the UI (and we're aliasing the darn thing here: https://github.com/ManageIQ/manageiq/blob/master/app/models/dialog.rb#L17) so it kinda made sense to just name the thing `name`. 

## Related to:
~~https://github.com/ManageIQ/manageiq/pull/16507~~ (merged)
https://github.com/ManageIQ/manageiq/pull/16600
  