### PR TITLE
Move Openstack refresh settings under the root where they belong

### DIFF
--- a/db/migrate/20171213223553_move_ems_refresh_openstack_settings.rb
+++ b/db/migrate/20171213223553_move_ems_refresh_openstack_settings.rb
@@ -1,0 +1,13 @@
+class MoveEmsRefreshOpenstackSettings < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time('Move ems_refresh Openstack provider refresher settings under the root') do
+      SettingsChange.where('key LIKE ?', '/ems/ems_refresh/openstack%').each do |s|
+        s.key = s.key.sub('/ems/ems_refresh', '/ems_refresh')
+        s.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20171213223553_move_ems_refresh_openstack_settings_spec.rb
+++ b/spec/migrations/20171213223553_move_ems_refresh_openstack_settings_spec.rb
@@ -1,0 +1,27 @@
+require_migration
+
+describe MoveEmsRefreshOpenstackSettings do
+  let(:settings_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it 'Move ems_refresh Openstack provider refresher settings under the root' do
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack/inventory_object_refresh', :value => true)
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack/heat/is_global_admin', :value => true)
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack/is_admin', :value => true)
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack/allow_targeted_refresh', :value => true)
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack_network/inventory_object_refresh', :value => true)
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack_network/is_admin', :value => true)
+      settings_stub.create!(:key => '/ems/ems_refresh/openstack_network/allow_targeted_refresh', :value => true)
+
+      migrate
+
+      expect(settings_stub.where(:key => '/ems_refresh/openstack/inventory_object_refresh').count).to eq(1)
+      expect(settings_stub.where(:key => '/ems_refresh/openstack/heat/is_global_admin').count).to eq(1)
+      expect(settings_stub.where(:key => '/ems_refresh/openstack/is_admin').count).to eq(1)
+      expect(settings_stub.where(:key => '/ems_refresh/openstack/allow_targeted_refresh').count).to eq(1)
+      expect(settings_stub.where(:key => '/ems_refresh/openstack_network/inventory_object_refresh').count).to eq(1)
+      expect(settings_stub.where(:key => '/ems_refresh/openstack_network/is_admin').count).to eq(1)
+      expect(settings_stub.where(:key => '/ems_refresh/openstack_network/allow_targeted_refresh').count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Openstack refresh settings are mistakenly nested under `ems.ems_refresh.openstack*`, but `ems_refresh` is supposed to be a top level key. Should be merged along with https://github.com/ManageIQ/manageiq-providers-openstack/pull/175