### PR TITLE
Add Fibre Channel properties to guest_devices

### DIFF
--- a/db/migrate/20180104160843_add_fibre_channel_properties_to_guest_devices.rb
+++ b/db/migrate/20180104160843_add_fibre_channel_properties_to_guest_devices.rb
@@ -1,0 +1,8 @@
+class AddFibreChannelPropertiesToGuestDevices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :guest_devices, :storage_node_wwn,  :string
+    add_column :guest_devices, :storage_port_type, :string
+    add_column :guest_devices, :storage_port_wwn,  :string
+    add_column :guest_devices, :storage_speed,     :int
+  end
+end


### PR DESCRIPTION
Fibre Channel HBAs have additional properties that we are not
collecting:
* Node World Wide Name
* Port Type
* Port World Wide Name
* Speed

[ref] https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.host.FibreChannelHba.html

Related https://github.com/ManageIQ/manageiq-providers-vmware/pull/169
https://bugzilla.redhat.com/show_bug.cgi?id=1525971
  
  