### PR TITLE
Change container_quota_items float columns to decimals

### DIFF
--- a/db/migrate/20180118131417_change_container_quota_items_to_decimals.rb
+++ b/db/migrate/20180118131417_change_container_quota_items_to_decimals.rb
@@ -1,0 +1,13 @@
+class ChangeContainerQuotaItemsToDecimals < ActiveRecord::Migration[5.0]
+  def up
+    %i(quota_desired quota_enforced quota_observed).each do |column|
+      change_column :container_quota_items, column, :decimal, :scale => 3, :precision => 30
+    end
+  end
+
+  def down
+    %i(quota_desired quota_enforced quota_observed).each do |column|
+      change_column :container_quota_items, column, :float
+    end
+  end
+end


### PR DESCRIPTION
@Fryguy @agrare @Ladas @moolitayer @zeari @bazulay
I'm told this might still be possible **for gaprindashvili**?!

Fixes https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/208
Kubernetes quotas are mostly integers but cpu-related quotas are
in "millicores", multiples of 0.001.
With decimal columns, we'll be able to round-trip quotas exactly to DB
and back to Ruby, so refresh can determine whether they changed or not.
(requires couple more code changes, but this fixes the deep root problem)

https://bugzilla.redhat.com/show_bug.cgi?id=1504560

Let's not merge until I have all pieces together, but this does allow the exact fraction to come back to Ruby.

TODO: tests demonstrating what happens to existing values.

TODO: benchmark on lots of data.

### Alternative: fixed-point integer column (5 would mean 5milli) ?

Some of you said that'd simpler and faster.
We wouldn't want all quotas scaled (memory in millibytes, number of pods in millipods...) but only scale CPU in millicores.

- However it'd need data migration.  Hmm, I suppose if we can do this in gaprindashvili, then data migration is possible too?
- I'm concerned at this point we'd be likely to introduce unit mismatch bugs.