### PR TITLE
Drop BinaryBlobPart#md5 and #size

### DIFF
--- a/db/migrate/20180112171348_drop_unnecessary_blob_parts_md5.rb
+++ b/db/migrate/20180112171348_drop_unnecessary_blob_parts_md5.rb
@@ -1,0 +1,22 @@
+class DropUnnecessaryBlobPartsMd5 < ActiveRecord::Migration[5.0]
+  class BinaryBlobPart < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    remove_column :binary_blob_parts, :md5
+    remove_column :binary_blob_parts, :size
+  end
+
+  def down
+    add_column :binary_blob_parts, :md5,  :string
+    add_column :binary_blob_parts, :size, :decimal, :precision => 20, :scale => 0
+
+    say_with_time("Calculating md5 and size of all BinaryBlobParts") do
+      require 'digest'
+      BinaryBlobPart.in_my_region.find_each do |part|
+        part.update_attributes(:md5 => Digest::MD5.hexdigest(part.data), :size => part.data.bytesize)
+      end
+    end
+  end
+end

--- a/spec/migrations/20180112171348_drop_unnecessary_blob_parts_md5_spec.rb
+++ b/spec/migrations/20180112171348_drop_unnecessary_blob_parts_md5_spec.rb
@@ -1,0 +1,18 @@
+require_migration
+
+describe DropUnnecessaryBlobPartsMd5 do
+  let(:binary_blob_part_stub) { migration_stub :BinaryBlobPart }
+
+  migration_context :down do
+    it "restores the md5 sum and size of all records" do
+      binary_blob_part_stub.create!(:data => "A test string")
+
+      migrate
+
+      expect(binary_blob_part_stub.first).to have_attributes(
+        :md5  => "99ce4dbdc6db1ab876443113ae24b816",
+        :size => 13,
+      )
+    end
+  end
+end


### PR DESCRIPTION
The database should ensure that the object returned is the same as that stored, making this column unnecessary.

Based on https://github.com/ManageIQ/manageiq/pull/16812