### PR TITLE
Updating switches data

### DIFF
--- a/db/migrate/20180126144529_add_extra_information_to_switches.rb
+++ b/db/migrate/20180126144529_add_extra_information_to_switches.rb
@@ -1,0 +1,13 @@
+class AddExtraInformationToSwitches < ActiveRecord::Migration[5.0]
+  def change
+    add_column :switches, :ems_id, :bigint
+    add_column :switches, :type, :string
+    add_column :switches, :health_state, :string
+    add_column :switches, :power_state, :string
+    add_column :switches, :product_name, :string
+    add_column :switches, :part_number, :string
+    add_column :switches, :serial_number, :string
+    add_column :switches, :description, :string
+    add_column :switches, :manufacturer, :string
+  end
+end

--- a/db/migrate/20180206140653_add_switch_id_to_hardwares.rb
+++ b/db/migrate/20180206140653_add_switch_id_to_hardwares.rb
@@ -1,0 +1,5 @@
+class AddSwitchIdToHardwares < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hardwares, :switch_id, :bigint
+  end
+end

--- a/db/migrate/20180306194651_add_peer_mac_address_to_guest_devices.rb
+++ b/db/migrate/20180306194651_add_peer_mac_address_to_guest_devices.rb
@@ -1,0 +1,5 @@
+class AddPeerMacAddressToGuestDevices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :guest_devices, :peer_mac_address, :string
+  end
+end


### PR DESCRIPTION
This PR updates the Switches table and adds the switch id to the hardwares table in order to allow us to parse physical infra switches.