### PR TITLE
Remove all instances of ManageIQ::Providers::Hawkular::MiddlewareManager from ext_management_systems

### DIFF
--- a/db/migrate/20180129152935_remove_hawkular_ems.rb
+++ b/db/migrate/20180129152935_remove_hawkular_ems.rb
@@ -1,0 +1,11 @@
+class RemoveHawkularEms < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Removing Hawkular MiddlewareManagers") do
+      ExtManagementSystem.where(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager').delete_all
+    end
+  end
+end

--- a/spec/migrations/20180129152935_remove_hawkular_ems_spec.rb
+++ b/spec/migrations/20180129152935_remove_hawkular_ems_spec.rb
@@ -1,0 +1,28 @@
+require_migration
+
+describe RemoveHawkularEms do
+  let(:ems_stub) { migration_stub :ExtManagementSystem }
+
+  migration_context :up do
+    before do
+      ems_stub.create!(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager',
+                       :name => 'bad')
+      ems_stub.create!(:type => 'ManageIQ::Providers::Redhat::InfraManager',
+                       :name => 'good_1')
+      ems_stub.create!(:type => 'ManageIQ::Providers::Openshift::ContainerManager',
+                       :name => 'good_2')
+      ems_stub.create!(:type => 'ManageIQ::Providers::Amazon::NetworkManager',
+                       :name => 'good_3')
+
+      migrate
+    end
+
+    it "deletes hawkular records" do
+      expect(ems_stub.pluck(:name)).not_to include('bad')
+    end
+
+    it "doesn't delete unrelated records" do
+      expect(ems_stub.pluck(:name).sort).to eq(%w(good_1 good_2 good_3))
+    end
+  end
+end


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq/pull/16834, there's no longer an entity called `ManageIQ::Providers::Hawkular::MiddlewareManager`.

This should remove those...

(Not sure if we should be trying to remove references, etc.?)