### PR TITLE
Add lan info to a guest_device (port)

### DIFF
--- a/db/migrate/20180202194924_add_vlan_info_to_guest_devices.rb
+++ b/db/migrate/20180202194924_add_vlan_info_to_guest_devices.rb
@@ -1,0 +1,6 @@
+class AddVlanInfoToGuestDevices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :guest_devices, :vlan_key, :string
+    add_column :guest_devices, :vlan_enabled, :boolean
+  end
+end


### PR DESCRIPTION
Adding vlan info to a guest_device when it assume a logical port function