### PR TITLE
Remove all VMware MKS console-related records from SettingSchanges

### DIFF
--- a/db/migrate/20180130165200_drop_webmks.rb
+++ b/db/migrate/20180130165200_drop_webmks.rb
@@ -1,0 +1,10 @@
+class DropWebmks < ActiveRecord::Migration[5.0]
+  class MiqServer < ActiveRecord::Base; end
+  class SettingsChange < ActiveRecord::Base; end
+
+  def up
+    say_with_time "Remove all VMware MKS console-related records from settings" do
+      SettingsChange.where(:key => '/server/remote_console_type', :value => 'MKS').delete_all
+    end
+  end
+end

--- a/spec/migrations/20180130165200_drop_webmks_spec.rb
+++ b/spec/migrations/20180130165200_drop_webmks_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe DropWebmks do
+  let(:server_stub)   { migration_stub(:MiqServer) }
+  let(:settings_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    let(:server) { server_stub.create }
+
+    it 'resets the remote_console_type to default' do
+      settings_stub.create(:resource_id => server.id, :resource_type => server.class, :key => '/server/remote_console_type', :value => 'MKS')
+      migrate
+
+      expect(settings_stub.where(:key => '/server/remote_console_type', :value => 'MKS')).not_to exist
+    end
+  end
+end


### PR DESCRIPTION
This feature has been dropped in [fine](https://github.com/ManageIQ/manageiq-ui-classic/pull/1052) and [later](https://github.com/ManageIQ/manageiq-ui-classic/pull/979), however, the migration was missing. There's also a PR for EUWE: https://github.com/ManageIQ/manageiq/pull/16909

https://bugzilla.redhat.com/show_bug.cgi?id=1513592

@miq-bot assign @bdunne 
@miq-bot add_label fine/yes, gaprindashvili/yes