### PR TITLE
Add miq_task_id column to miq_queue table

### DIFF
--- a/db/migrate/20180213204846_link_queue_and_task.rb
+++ b/db/migrate/20180213204846_link_queue_and_task.rb
@@ -1,0 +1,5 @@
+class LinkQueueAndTask < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :miq_queue, :miq_task, :type => "bigint", :index => true
+  end
+end

--- a/db/migrate/20180213204846_link_queue_and_task.rb
+++ b/db/migrate/20180213204846_link_queue_and_task.rb
@@ -1,5 +1,5 @@
 class LinkQueueAndTask < ActiveRecord::Migration[5.0]
   def change
-    add_reference :miq_queue, :miq_task, :type => "bigint", :index => true
+    add_reference :miq_queue, :miq_task, :type => :bigint
   end
 end


### PR DESCRIPTION
Linking `miq_queue` and `miq_tasks` table will:
- allow to add miq_task_id to the list of arguments when message deliver
- simplify activating task (https://bugzilla.redhat.com/show_bug.cgi?id=1543289)

blocking https://github.com/ManageIQ/manageiq/pull/17015

\cc @Fryguy 