### PR TITLE
Add compliance information

### DIFF
--- a/db/migrate/20180209180035_add_compliance_information_to_physical_servers.rb
+++ b/db/migrate/20180209180035_add_compliance_information_to_physical_servers.rb
@@ -1,0 +1,6 @@
+class AddComplianceInformationToPhysicalServers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_servers, :ems_compliance_name, :string
+    add_column :physical_servers, :ems_compliance_status, :string
+  end
+end


### PR DESCRIPTION
This PR is able to :
* Change the `physical_servers` table to store compliance information of the physical server.