### PR TITLE
Add vm_ems_ref to event_streams

### DIFF
--- a/db/migrate/20180313135925_add_vm_ems_ref_to_event_streams.rb
+++ b/db/migrate/20180313135925_add_vm_ems_ref_to_event_streams.rb
@@ -1,0 +1,6 @@
+class AddVmEmsRefToEventStreams < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :vm_ems_ref,      :string
+    add_column :event_streams, :dest_vm_ems_ref, :string
+  end
+end


### PR DESCRIPTION
Early events in a VM's lifecycle don't contain the vmPathName yet which
is used to connect events which were processed before the VM gets
created by EmsRefresh.  These events do however contain the ems_ref of
the VM which can be used for more reliable event -> vm association.

https://bugzilla.redhat.com/show_bug.cgi?id=1428797