### PR TITLE
Remove the limits from the tables in sorted order

### DIFF
--- a/db/migrate/20171109225052_remove_string_column_limits.rb
+++ b/db/migrate/20171109225052_remove_string_column_limits.rb
@@ -1,6 +1,6 @@
 class RemoveStringColumnLimits < ActiveRecord::Migration[5.0]
   def up
-    connection.tables.each do |t|
+    connection.tables.sort.each do |t|
       connection.columns(t).each do |col|
         next unless col.type == :string && !col.limit.nil?
         change_column t, col.name, :string, :limit => nil


### PR DESCRIPTION
This will prevent us from trying to alter an inherited column in a table like metrics_01 or similar.

Without this change a migration can fail with the following output:
```plain
When launching rake db:migrate we get the following error:
-- change_column("metric_rollups_01", "resource_type", :string, {:limit=>nil})
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::InvalidTableDefinition: ERROR:  cannot alter inherited column "resource_type"
: ALTER TABLE "metric_rollups_01" ALTER COLUMN "resource_type" TYPE character varying
```