### PR TITLE
Adding product details columns to asset_details table

### DIFF
--- a/db/migrate/20180319113755_add_product_details_columns_to_asset_details.rb
+++ b/db/migrate/20180319113755_add_product_details_columns_to_asset_details.rb
@@ -1,0 +1,10 @@
+class AddProductDetailsColumnsToAssetDetails < ActiveRecord::Migration[5.0]
+  def change
+    add_column :asset_details, :product_name,           :string
+    add_column :asset_details, :manufacturer,           :string
+    add_column :asset_details, :machine_type,           :string
+    add_column :asset_details, :model,                  :string
+    add_column :asset_details, :serial_number,          :string
+    add_column :asset_details, :field_replaceable_unit, :string
+  end
+end


### PR DESCRIPTION
__This PR is able to:__
- Add product details columns to `asset_details` table.

__Goal:__
This PR aims to centralize some common informations of products (i.e. physical servers, switches etc) on the `asset_details` table.