### PR TITLE
Updating details for physical switches

### DIFF
--- a/db/migrate/20180323204738_add_part_number_to_asset_details.rb
+++ b/db/migrate/20180323204738_add_part_number_to_asset_details.rb
@@ -1,0 +1,5 @@
+class AddPartNumberToAssetDetails < ActiveRecord::Migration[5.0]
+  def change
+    add_column :asset_details, :part_number, :string
+  end
+end

--- a/db/migrate/20180323204821_remove_switch_details_from_switches.rb
+++ b/db/migrate/20180323204821_remove_switch_details_from_switches.rb
@@ -1,0 +1,9 @@
+class RemoveSwitchDetailsFromSwitches < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :switches, :product_name,  :string
+    remove_column :switches, :part_number,   :string
+    remove_column :switches, :serial_number, :string
+    remove_column :switches, :description,   :string
+    remove_column :switches, :manufacturer,  :string
+  end
+end


### PR DESCRIPTION
Removes details from switches table, since [due to later changes](https://github.com/ManageIQ/manageiq-schema/pull/181/files) we can now use `asset_details` table to store the same information. We also add the `part_number` column to the asset details and rename the relationship in the hardwares table, since we will use physical_switches as the model in the [core PR](https://github.com/ManageIQ/manageiq/pull/16948).