### PR TITLE
Update provider_region to nil for Google provider

### DIFF
--- a/db/migrate/20180405145642_remove_provider_region_for_google_provider.rb
+++ b/db/migrate/20180405145642_remove_provider_region_for_google_provider.rb
@@ -1,0 +1,11 @@
+class RemoveProviderRegionForGoogleProvider < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Removing provider_region from ManageIQ::Providers::Google::CloudManager") do
+      ExtManagementSystem.where(:type => 'ManageIQ::Providers::Google::CloudManager').update_all(:provider_region => nil)
+    end
+  end
+end

--- a/db/migrate/20180405145642_remove_provider_region_for_google_provider.rb
+++ b/db/migrate/20180405145642_remove_provider_region_for_google_provider.rb
@@ -7,5 +7,8 @@ class RemoveProviderRegionForGoogleProvider < ActiveRecord::Migration[5.0]
     say_with_time("Removing provider_region from ManageIQ::Providers::Google::CloudManager") do
       ExtManagementSystem.where(:type => 'ManageIQ::Providers::Google::CloudManager').update_all(:provider_region => nil)
     end
+    say_with_time("Removing provider_region from ManageIQ::Providers::Google::NetworkManager") do
+      ExtManagementSystem.where(:type => 'ManageIQ::Providers::Google::NetworkManager').update_all(:provider_region => nil)
+    end
   end
 end

--- a/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
+++ b/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
@@ -15,11 +15,21 @@ describe RemoveProviderRegionForGoogleProvider do
                        :provider_region => 42)
       ems_stub.create!(:type            => 'ManageIQ::Providers::Vmware::CloudManager',
                        :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Google::NetworkManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Openstack::NetworkManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Azure::NetworkManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Amazon::NetworkManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Vmware::NetworkManager',
+                       :provider_region => 42)
 
       migrate
 
-      expect(ems_stub.where(:provider_region => nil).count).to eq 1
-      expect(ems_stub.where(:provider_region => 42).count).to eq 4
+      expect(ems_stub.where(:provider_region => nil).count).to eq 2
+      expect(ems_stub.where(:provider_region => 42).count).to eq 8
     end
   end
 end

--- a/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
+++ b/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
@@ -1,0 +1,20 @@
+require_migration
+
+describe RemoveProviderRegionForGoogleProvider do
+  let(:ems_stub) { migration_stub :ExtManagementSystem }
+
+  migration_context :up do
+    before do
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Google::CloudManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Amazon::CloudManager',
+                       :provider_region => 42)
+
+      migrate
+    end
+
+    it 'sets provider_region to nil for ManageIQ::Providers::Google::CloudManager' do
+      expect(ems_stub.where(:provider_region => nil).count).to eq 1
+    end
+  end
+end

--- a/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
+++ b/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
@@ -1,10 +1,10 @@
 require_migration
 
 describe RemoveProviderRegionForGoogleProvider do
-  let(:ems_stub) { migration_stub :ExtManagementSystem }
-
   migration_context :up do
-    before do
+    let(:ems_stub) { migration_stub :ExtManagementSystem }
+
+    it 'does sets provider_region to nil only to Google provider' do
       ems_stub.create!(:type            => 'ManageIQ::Providers::Google::CloudManager',
                        :provider_region => 42)
       ems_stub.create!(:type            => 'ManageIQ::Providers::Amazon::CloudManager',
@@ -17,13 +17,8 @@ describe RemoveProviderRegionForGoogleProvider do
                        :provider_region => 42)
 
       migrate
-    end
 
-    it 'sets provider_region to nil for ManageIQ::Providers::Google::CloudManager' do
       expect(ems_stub.where(:provider_region => nil).count).to eq 1
-    end
-
-    it 'does not set provider_region to nil for other providers' do
       expect(ems_stub.where(:provider_region => 42).count).to eq 4
     end
   end

--- a/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
+++ b/spec/migrations/20180405145642_remove_provider_region_for_google_provider_spec.rb
@@ -9,12 +9,22 @@ describe RemoveProviderRegionForGoogleProvider do
                        :provider_region => 42)
       ems_stub.create!(:type            => 'ManageIQ::Providers::Amazon::CloudManager',
                        :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Azure::CloudManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Openstack::CloudManager',
+                       :provider_region => 42)
+      ems_stub.create!(:type            => 'ManageIQ::Providers::Vmware::CloudManager',
+                       :provider_region => 42)
 
       migrate
     end
 
     it 'sets provider_region to nil for ManageIQ::Providers::Google::CloudManager' do
       expect(ems_stub.where(:provider_region => nil).count).to eq 1
+    end
+
+    it 'does not set provider_region to nil for other providers' do
+      expect(ems_stub.where(:provider_region => 42).count).to eq 4
     end
   end
 end


### PR DESCRIPTION
Fixes UI failure after https://github.com/ManageIQ/manageiq-providers-google/pull/52 . 
To reproduce:
Make sure you have `ManageIQ::Providers::Google::CloudManager` or `ManageIQ::Providers::Google::NetworkManager` with `provider_region` **not** set to `nil`.
Go to summary page of said provider.
Before:
![image](https://user-images.githubusercontent.com/9210860/38485171-2c199a9e-3bd9-11e8-8925-b168487e062a.png)
After:
![image](https://user-images.githubusercontent.com/9210860/38485210-4bf88d34-3bd9-11e8-8c15-4cbffb8438a6.png)

With both providers not having `description` method but having historically set `provider_region` following lines are problem solved by removing values from `provider_region`.
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/ems_cloud_helper/textual_summary.rb#L42
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/ems_network_helper/textual_summary.rb#L40
 
@miq-bot add_label wip, bug, blocker

https://bugzilla.redhat.com/show_bug.cgi?id=1563600

Fix for Gaprindashvili: https://github.com/ManageIQ/manageiq-ui-classic/pull/3735

[More info](https://github.com/ManageIQ/manageiq-schema/pull/184#pullrequestreview-110086534)