### PR TITLE
Creating physical_network_ports table

### DIFF
--- a/db/migrate/20180409120422_create_physical_network_ports.rb
+++ b/db/migrate/20180409120422_create_physical_network_ports.rb
@@ -1,0 +1,20 @@
+class CreatePhysicalNetworkPorts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :physical_network_ports do |t|
+      t.string  :ems_ref
+      t.string  :uid_ems
+      t.string  :type
+      t.string  :port_name
+      t.string  :port_type
+      t.string  :peer_mac_address
+      t.string  :vlan_key
+      t.string  :mac_address
+      t.integer :port_index
+      t.boolean :vlan_enabled
+      t.bigint  :guest_device_id
+      t.bigint  :switch_id
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
__This PR is able to:__
- Create `physical_network_ports` table;

__Goal:__
Actually the ports are saved as a `GuestDevice` instance that should only represent elements that are plugged into a mother board. With this new table we avoid the pollution of `guest_devices` table.