### PR TITLE
Add configuration_script_sources.last_update_error

### DIFF
--- a/db/migrate/20180329141018_add_last_update_error_to_configuration_script_source.rb
+++ b/db/migrate/20180329141018_add_last_update_error_to_configuration_script_source.rb
@@ -1,0 +1,5 @@
+class AddLastUpdateErrorToConfigurationScriptSource < ActiveRecord::Migration[5.0]
+  def change
+    add_column :configuration_script_sources, :last_update_error, :text
+  end
+end


### PR DESCRIPTION
Add new `last_update_stdout` column to `configuration_script_sources` table. This allows to store last update stdout to display more information about why its refresh failed.

Fetching and presenting this information is a workaround for cloning repositories from HTTPS servers with untrusted SSL certificates. Tower API does not offer an option to disable SSL check, so with the stdout user can at least see, why the cloning actually failed.

https://bugzilla.redhat.com/show_bug.cgi?id=1513616

Followed by adding the column to model: [#17290 in `manageiq`](https://github.com/ManageIQ/manageiq/pull/17290).

/cc @jameswnl for review