### PR TITLE
Nil MiqDatabase#update_repo_name

### DIFF
--- a/db/migrate/20160913195129_move_repo_data_from_database_to_settings.rb
+++ b/db/migrate/20160913195129_move_repo_data_from_database_to_settings.rb
@@ -9,7 +9,7 @@ class MoveRepoDataFromDatabaseToSettings < ActiveRecord::Migration[5.0]
 
   def up
     db = MiqDatabase.first
-    return unless db && my_region
+    return unless db.try(:update_repo_name) && my_region
 
     say_with_time("Moving repo information from miq_databases to Settings") do
       repos = db.update_repo_name.split

--- a/spec/migrations/20160913195129_move_repo_data_from_database_to_settings_spec.rb
+++ b/spec/migrations/20160913195129_move_repo_data_from_database_to_settings_spec.rb
@@ -33,6 +33,23 @@ describe MoveRepoDataFromDatabaseToSettings do
       ).first
       expect(setting_change.value).to eq(repo_list)
     end
+
+    it "handles nil update_repo_name" do
+      database_attrs = {
+        :session_secret_token => SecureRandom.hex(64),
+        :csrf_secret_token    => SecureRandom.hex(64),
+      }
+      database_stub.create!(database_attrs)
+
+      migrate
+
+      setting_change = settings_stub.where(
+        :key           => described_class::SETTING_KEY,
+        :resource_id   => region.id,
+        :resource_type => "MiqRegion"
+      )
+      expect(setting_change.count).to eq(0)
+    end
   end
 
   migration_context :down do


### PR DESCRIPTION
When migrating from 0, resulted in:
```
MoveRepoDataFromDatabaseToSettings#up handles nil update_repo_name
Failure/Error: described_class.migrate(migration_direction)

NoMethodError:
  undefined method `split' for nil:NilClass
# ./db/migrate/20160913195129_move_repo_data_from_database_to_settings.rb:15:in `block in up'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:815:in `block in say_with_time'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:815:in `say_with_time'
# ./db/migrate/20160913195129_move_repo_data_from_database_to_settings.rb:14:in `up'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:792:in `exec_migration'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:773:in `block (2 levels) in migrate'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:772:in `block in migrate'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/connection_adapters/abstract/connection_pool.rb:398:in `with_connection'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:771:in `migrate'
# /home/bdunne/.gem/ruby/2.4.3/gems/activerecord-5.0.6/lib/active_record/migration.rb:601:in `migrate'
# ./spec/support/migration_helper.rb:71:in `migrate_under_test'
# ./spec/support/migration_helper.rb:35:in `block (2 levels) in migrate'
# ./spec/support/migration_helper.rb:83:in `suppress_migration_messages'
# ./spec/support/migration_helper.rb:35:in `block in migrate'
# ./spec/support/migration_helper.rb:57:in `clearing_caches'
# ./spec/support/migration_helper.rb:31:in `migrate'
# ./spec/migrations/20160913195129_move_repo_data_from_database_to_settings_spec.rb:44:in `block (3 levels) in <top (required)>'
# ./spec/support/migration_helper.rb:57:in `clearing_caches'
# ./spec/support/migration_helper.rb:13:in `block (2 levels) in migration_context'
```
Introduced in: https://github.com/ManageIQ/manageiq/pull/11304