### PR TITLE
Clean Azure image names

### DIFF
--- a/db/migrate/20180507134810_azure_normalize_image_name.rb
+++ b/db/migrate/20180507134810_azure_normalize_image_name.rb
@@ -1,0 +1,20 @@
+class AzureNormalizeImageName < ActiveRecord::Migration[5.0]
+  class VmOrTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    self.table_name = 'vms'
+  end
+
+  def up
+    say_with_time("Updating Azure template name") do
+      VmOrTemplate.where("type = ? and uid_ems like ?", "ManageIQ::Providers::Azure::CloudManager::Template", "http%")
+        .update_all("name = regexp_replace(name, '^./', '')")
+    end
+  end
+
+  def down
+    say_with_time("Reverting Azure template name") do
+      VmOrTemplate.where("type = ? and uid_ems like ?", "ManageIQ::Providers::Azure::CloudManager::Template", "http%")
+        .update_all("name = './' || name")
+    end
+  end
+end

--- a/spec/migrations/20180507134810_azure_normalize_image_name_spec.rb
+++ b/spec/migrations/20180507134810_azure_normalize_image_name_spec.rb
@@ -1,0 +1,87 @@
+require_migration
+
+describe AzureNormalizeImageName do
+  let(:vm_stub) { migration_stub :VmOrTemplate }
+
+  migration_context :up do
+    it "removes ./ from image names" do
+      template = vm_stub.create!(
+        :name    => './foo',
+        :type    => 'ManageIQ::Providers::Azure::CloudManager::Template',
+        :uid_ems => 'http://foo.bar.com'
+      )
+
+      migrate
+      template.reload
+
+      expect(template.name).to eql('foo')
+    end
+
+    it "does not affect images that do not have a ./ in them" do
+      template = vm_stub.create!(
+        :name    => 'foo/bar',
+        :type    => 'ManageIQ::Providers::Azure::CloudManager::Template',
+        :uid_ems => 'http://foo.bar.com'
+      )
+
+      migrate
+      template.reload
+
+      expect(template.name).to eql('foo/bar')
+    end
+
+    it "does not affect other providers" do
+      template = vm_stub.create!(
+        :name    => './foo',
+        :type    => 'ManageIQ::Providers::Amazon::CloudManager::Template',
+        :uid_ems => 'http://foo.bar.com'
+      )
+
+      migrate
+      template.reload
+
+      expect(template.name).to eql('./foo')
+    end
+  end
+
+  migration_context :down do
+    it "restores ./ to unmanaged images" do
+      template = vm_stub.create!(
+        :name    => 'foo',
+        :type    => 'ManageIQ::Providers::Azure::CloudManager::Template',
+        :uid_ems => 'http://foo.bar.com'
+      )
+
+      migrate
+      template.reload
+
+      expect(template.name).to eql('./foo')
+    end
+
+    it "does not affect unmanaged images" do
+      template = vm_stub.create!(
+        :name    => 'bar',
+        :type    => 'ManageIQ::Providers::Azure::CloudManager::Template',
+        :uid_ems => '/subscriptions/whatever'
+      )
+
+      migrate
+      template.reload
+
+      expect(template.name).to eql('bar')
+    end
+
+    it "does not affect other providers" do
+      template = vm_stub.create!(
+        :name    => 'bar',
+        :type    => 'ManageIQ::Providers::Amazon::CloudManager::Template',
+        :uid_ems => 'http://foo.bar.com'
+      )
+
+      migrate
+      template.reload
+
+      expect(template.name).to eql('bar')
+    end
+  end
+end


### PR DESCRIPTION
Due to a quirk of File.dirname, the Azure provider can end up with leading "./" in the image name. This looks dumb and should be fixed.

Should be merged in conjunction with https://github.com/ManageIQ/manageiq-providers-azure/pull/240