### PR TITLE
[WIP] Add switches.host_id to fix modeling/deletions

### DIFF
--- a/db/migrate/20180514131958_add_host_id_to_switches.rb
+++ b/db/migrate/20180514131958_add_host_id_to_switches.rb
@@ -1,0 +1,5 @@
+class AddHostIdToSwitches < ActiveRecord::Migration[5.0]
+  def change
+    add_column :switches, :host_id, :bigint
+  end
+end


### PR DESCRIPTION
Currently there is no association between either an EMS or a Host to
their switches that don't go through host_switches.  This means that
switch deletions are "interesting".  This also means that the
manager_ref is not consistent because for shared switches uid_ems is
unique but for host local switches the host is needed.

See https://github.com/ManageIQ/manageiq/issues/17383 for the problem description and [`EmsRefresh.save_switches_inventory`](https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_refresh/save_inventory_infra.rb#L307-L332) for what the old save_switches_inventory code looked like (:scream:)

TODO:
Data migration to set ems_id for shared switches.