### PR TITLE
Optimize migration which creates task for each job

### DIFF
--- a/db/migrate/20170120164058_create_task_for_each_job_and_transfer_attributes.rb
+++ b/db/migrate/20170120164058_create_task_for_each_job_and_transfer_attributes.rb
@@ -9,6 +9,9 @@ class CreateTaskForEachJobAndTransferAttributes < ActiveRecord::Migration[5.0]
   end
 
   def up
+    say_with_time("Deleting finished jobs older than 7 days") do
+      Job.where("updated_on < ?", Time.now.utc - 7.days).where("state = 'finished'").delete_all
+    end
     say_with_time("Creating tasks associated with jobs") do
       Job.find_each do |job|
         job.create_miq_task(:status        => job.status.try(:capitalize),

--- a/db/migrate/20170120164058_create_task_for_each_job_and_transfer_attributes.rb
+++ b/db/migrate/20170120164058_create_task_for_each_job_and_transfer_attributes.rb
@@ -12,6 +12,9 @@ class CreateTaskForEachJobAndTransferAttributes < ActiveRecord::Migration[5.0]
     say_with_time("Deleting finished jobs older than 7 days") do
       Job.where("updated_on < ?", Time.now.utc - 7.days).where("state = 'finished'").delete_all
     end
+    say_with_time("Deleting finished tasks older than 7 days") do
+      MiqTask.where("updated_on < ?", Time.now.utc - 7.days).where("state = 'Finished'").delete_all
+    end
     say_with_time("Creating tasks associated with jobs") do
       Job.find_each do |job|
         job.create_miq_task(:status        => job.status.try(:capitalize),

--- a/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
+++ b/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
@@ -5,6 +5,16 @@ describe CreateTaskForEachJobAndTransferAttributes do
   let(:jobs_stub) { migration_stub(:Job) }
 
   migration_context :up do
+    it "deletes finished job older than 7 days" do
+      jobs_stub.create!(:name => "Test Job1", :state => "finished", :updated_on => Time.now.utc - 6.days)
+      jobs_stub.create!(:name => "Test Job2", :state => "finished", :updated_on => Time.now.utc - 8.days)
+      jobs_stub.create!(:name => "Test Job3", :state => "finished", :updated_on => Time.now.utc - 1.month)
+
+      migrate
+
+      expect(jobs_stub.count).to eq 1
+    end
+
     it "creates associated task for each job and assigns to task the same name" do
       jobs_stub.create!(:name => "Hello Test Job", :status => "Some test status", :miq_task_id => nil)
       jobs_stub.create!(:name => "Hello Test Job2", :state => "Some state", :miq_task_id => nil)

--- a/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
+++ b/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
@@ -15,6 +15,16 @@ describe CreateTaskForEachJobAndTransferAttributes do
       expect(jobs_stub.count).to eq 1
     end
 
+    it "deletes finished tasks older than 7 days" do
+      miq_tasks_stub.create!(:name => "Test Task1", :state => "Finished", :updated_on => Time.now.utc - 6.days)
+      miq_tasks_stub.create!(:name => "Test Task2", :state => "Finished", :updated_on => Time.now.utc - 8.days)
+      miq_tasks_stub.create!(:name => "Test Task2", :state => "Finished", :updated_on => Time.now.utc - 1.month)
+
+      migrate
+
+      expect(miq_tasks_stub.count).to eq 1
+    end
+
     it "creates associated task for each job and assigns to task the same name" do
       jobs_stub.create!(:name => "Hello Test Job", :status => "Some test status", :miq_task_id => nil)
       jobs_stub.create!(:name => "Hello Test Job2", :state => "Some state", :miq_task_id => nil)

--- a/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
+++ b/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
@@ -3,26 +3,38 @@ require_migration
 describe CreateTaskForEachJobAndTransferAttributes do
   let(:miq_tasks_stub) { migration_stub(:MiqTask) }
   let(:jobs_stub) { migration_stub(:Job) }
+  let(:log_stub) { migration_stub(:LogFile) }
+  let(:binary_blob_stub) { migration_stub(:BinaryBlob) }
 
   migration_context :up do
     it "deletes finished job older than 7 days" do
-      jobs_stub.create!(:name => "Test Job1", :state => "finished", :updated_on => Time.now.utc - 6.days)
-      jobs_stub.create!(:name => "Test Job2", :state => "finished", :updated_on => Time.now.utc - 8.days)
-      jobs_stub.create!(:name => "Test Job3", :state => "finished", :updated_on => Time.now.utc - 1.month)
+      jobs_stub.create!(:name => "Test Job1", :state => "finished", :updated_on => 6.days.ago.utc)
+      jobs_stub.create!(:name => "Test Job2", :state => "finished", :updated_on => 8.days.ago.utc)
+      jobs_stub.create!(:name => "Test Job3", :state => "finished", :updated_on => 1.month.ago.utc)
 
       migrate
 
       expect(jobs_stub.count).to eq 1
     end
 
-    it "deletes finished tasks older than 7 days" do
-      miq_tasks_stub.create!(:name => "Test Task1", :state => "Finished", :updated_on => Time.now.utc - 6.days)
-      miq_tasks_stub.create!(:name => "Test Task2", :state => "Finished", :updated_on => Time.now.utc - 8.days)
-      miq_tasks_stub.create!(:name => "Test Task2", :state => "Finished", :updated_on => Time.now.utc - 1.month)
+    it "deletes finished tasks older than 7 days and linked LogFiles and BynaryBlobs" do
+      task1 = miq_tasks_stub.create!(:name => "Test Task1", :state => "Finished", :updated_on => 6.days.ago.utc)
+      log_stub.create!(:miq_task_id => task1.id)
+      binary_blob_stub.create!(:resource_type => "MiqTask", :resource_id => task1.id)
+
+      task2 = miq_tasks_stub.create!(:name => "Test Task2", :state => "Finished", :updated_on => 8.days.ago.utc)
+      log_stub.create!(:miq_task_id => task2.id)
+      binary_blob_stub.create!(:resource_type => "MiqTask", :resource_id => task2.id)
+
+      task3 = miq_tasks_stub.create!(:name => "Test Task2", :state => "Finished", :updated_on => 1.month.ago.utc)
+      log_stub.create!(:miq_task_id => task3.id)
+      binary_blob_stub.create!(:resource_type => "MiqTask", :resource_id => task3.id)
 
       migrate
 
       expect(miq_tasks_stub.count).to eq 1
+      expect(log_stub.count).to eq 1
+      expect(binary_blob_stub.count).to eq 1
     end
 
     it "creates associated task for each job and assigns to task the same name" do


### PR DESCRIPTION
There are several long running migrations observed on client's DB (`Job.count` around 1.3 millions)  : 
`CreateTaskForEachJobAndTransferAttributes`        - 4863 seconds
`CopyAgentIdToMiqServerIdInJobsTable`                  -  168 seconds
`CopyServerIdFromJobsToMiqTask`                           - 1645

In UI (Task management screen) we show only tasks for the last 6 days, so there is no need to do anything with jobs/task older than 7 days.

This PR:  changed exiting `CreateTaskForEachJobAndTransferAttributes` by:
- deleting finished `Job` older than 7 days first and creating task for each job after that.
- deleting finished `MiqTask` older than 7 days. This change will no speed-up migration, it is just clen-up and done t be consistent with `Job` deletion. 

on the same client's DB deleting old records from `Job` table took 16 seconds:
```
>> Job.where("updated_on < ?", t).where("state = 'finished'").delete_all
  SQL (16330.1ms)  DELETE FROM "jobs" WHERE (updated_on < '2018-04-14 16:05:23.679929') AND (state = 'finished')
=> 1232220
```

Depends on https://github.com/ManageIQ/manageiq/pull/17727 for backports