### PR TITLE
Creating Switches group migration

### DIFF
--- a/db/migrate/20180517151926_switches_group.rb
+++ b/db/migrate/20180517151926_switches_group.rb
@@ -1,0 +1,5 @@
+class SwitchesGroup < ActiveRecord::Migration[5.0]
+  class PhysicalSwitches < ActiveRecord::Base
+    self.table_name = 'switches'
+  end
+end


### PR DESCRIPTION
This PR is able to:
- Create a Switch group migration
- Add PhysicalSwitches to Switches group

This change enable Switches to share its table with other implementations like PhysicalSwitches. This was necessary because making Switch as base model for PhysicalSwitch produced strange behaviors.