### PR TITLE
Add properties for provisioning and reconfiguration without broker cache

### DIFF
--- a/db/migrate/20180522190253_add_type_and_key_to_guest_devices.rb
+++ b/db/migrate/20180522190253_add_type_and_key_to_guest_devices.rb
@@ -1,0 +1,6 @@
+class AddTypeAndKeyToGuestDevices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :guest_devices, :type, :string
+    add_column :guest_devices, :key,  :integer
+  end
+end

--- a/db/migrate/20180522235633_add_controller_and_unit_number_to_disk.rb
+++ b/db/migrate/20180522235633_add_controller_and_unit_number_to_disk.rb
@@ -1,0 +1,7 @@
+class AddControllerAndUnitNumberToDisk < ActiveRecord::Migration[5.0]
+  def change
+    add_column :disks, :key,           :integer
+    add_column :disks, :unit_number,   :integer
+    add_column :disks, :controller_id, :bigint
+  end
+end


### PR DESCRIPTION
Add a few properties to guest devices and disks so that they don't have to be accessed from live inventory cache.