### PR TITLE
Add the severity column to event_streams table

### DIFF
--- a/db/migrate/20180524133942_add_severity_to_events.rb
+++ b/db/migrate/20180524133942_add_severity_to_events.rb
@@ -1,0 +1,5 @@
+class AddSeverityToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :severity, :string
+  end
+end


### PR DESCRIPTION
This pr is able to:
* Add a new column in the event_streams table and allow the providers access the severity information more quickly.

This is an advantage because a physical infra provider have about 5000 events and is a lot expensive to access each event and recover the severity inside the full_data column.   