### PR TITLE
Creating physical_components table

### DIFF
--- a/db/migrate/20180524135736_create_physical_components.rb
+++ b/db/migrate/20180524135736_create_physical_components.rb
@@ -1,0 +1,10 @@
+class CreatePhysicalComponents < ActiveRecord::Migration[5.0]
+  def change
+    create_table :physical_components do |t|
+      t.belongs_to :component, :type => :bigint, :polymorphic => true
+      t.string     :ems_ref
+      t.timestamps :null => true
+      t.index      %i(component_id component_type)
+    end
+  end
+end


### PR DESCRIPTION
__This PR is able to__
- Create the `physical_components` table.

__Goal__
The goal is to generalize some physical components relationships as well as have a common way to describe these components.

In a first perspective, this way we solve a problem with the `event_streams` where we want to relate to the physical components (Servers, Switches, Chassis, etc), so instead to add a new column for each component in `event_streams` we just add a relation `event_streams -> physical_components` and all components could be bind to an event. Also, the MangeIQ API could return events with its related components in a common way, making more easier for the consumer to figure out the source component of an event.

__Future benefits__
Looking more forward we also can migrate other relationships to use this table, looking more like the following diagram:

![image](https://user-images.githubusercontent.com/8550928/40505185-d6948c32-5f69-11e8-8ed8-461cf79f4472.png)

- __`has_many` relationship between `PhysicalInfraManager` -> `PhysicalComponent`:__ This way we can grant that a `PhysicalInfraManager` can manage any physical component and a new component can be managed just creating a relation to `PhysicalComponent` (for example the upcoming component `PhysicalStorage`)

- __Add physical components common relationships:__
  - `asset_details`;
  - `computer_systems`.