### PR TITLE
Add deleted_on to ServiceTemplate for archival

### DIFF
--- a/db/migrate/20180525171150_add_deleted_on_to_service_template.rb
+++ b/db/migrate/20180525171150_add_deleted_on_to_service_template.rb
@@ -1,0 +1,29 @@
+class AddDeletedOnToServiceTemplate < ActiveRecord::Migration[5.0]
+  class ServiceTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    include ReservedMigrationMixin
+    include MigrationStubHelper
+  end
+
+  def up
+    add_column :service_templates, :deleted_on, :datetime
+
+    say_with_time("Migrate data from reserved table to service_templates") do
+      ServiceTemplate.includes(:reserved_rec).each do |st|
+        st.reserved_hash_migrate(:deleted_on)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrate data from service_templates to reserved table") do
+      ServiceTemplate.includes(:reserved_rec).each do |st|
+        st.reserved_hash_set(:deleted_on, st.deleted_on)
+        st.save!
+      end
+    end
+
+    remove_column :service_templates, :deleted_on
+  end
+end

--- a/spec/migrations/20180525171150_add_deleted_on_to_service_template_spec.rb
+++ b/spec/migrations/20180525171150_add_deleted_on_to_service_template_spec.rb
@@ -1,0 +1,48 @@
+require_migration
+
+describe AddDeletedOnToServiceTemplate do
+  let(:reserve_stub)          { Spec::Support::MigrationStubs.reserved_stub }
+  let(:service_template_stub) { migration_stub(:ServiceTemplate) }
+
+  migration_context :up do
+    it "Migrates Reserve data to ServiceTemplate" do
+      deleted_on_time = Time.current
+
+      st = service_template_stub.create!
+      reserve_stub.create!(
+        :resource_type => st.class.name,
+        :resource_id   => st.id,
+        :reserved      => {
+          :deleted_on => deleted_on_time,
+        }
+      )
+
+      migrate
+
+      st.reload
+
+      expect(reserve_stub.count).to eq(0)
+      expect(st.deleted_on.to_s).to eq(deleted_on_time.to_s)
+    end
+  end
+
+  migration_context :down do
+    it "Migrates deleted_on in ServiceTemplate to Reserve table" do
+      deleted_on_time = Time.current
+
+      st = service_template_stub.create!(
+        :deleted_on => deleted_on_time,
+      )
+
+      migrate
+
+      expect(reserve_stub.count).to eq(1)
+
+      reserved_rec = reserve_stub.first
+      expect(reserved_rec.resource_id).to   eq(st.id)
+      expect(reserved_rec.resource_type).to eq(st.class.name)
+
+      expect(reserved_rec.reserved[:deleted_on].to_s).to eq(deleted_on_time.to_s)
+    end
+  end
+end


### PR DESCRIPTION
This adds a deleted_on datetime column to service_templates to allow for the use of the ArchivedMixin.
Also included here is code to migrate this out of the reserved table since this is intended to be backported.

https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/314

Core change: https://github.com/ManageIQ/manageiq/pull/17480
Backport: https://github.com/ManageIQ/manageiq/pull/17481