### PR TITLE
Adding column on physical_network_ports table to connect other ports

### DIFF
--- a/db/migrate/20180525111220_add_connected_port_to_physical_network_port.rb
+++ b/db/migrate/20180525111220_add_connected_port_to_physical_network_port.rb
@@ -1,0 +1,5 @@
+class AddConnectedPortToPhysicalNetworkPort < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_network_ports, :connected_port_uid, :string
+  end
+end


### PR DESCRIPTION
__This PR is able to__
- Add the `connected_port_uid` column to set the `uid_ems` of the connected port;

__Goal__
A physical network port should know to who it is connected, so it have a bidirectional one to one relationship:
![image](https://user-images.githubusercontent.com/8550928/40680350-2fe4e66a-635c-11e8-8f3f-b1a5f0f913e8.png)
