### PR TITLE
Add column report_base_model to ChargebackRate table

### DIFF
--- a/db/migrate/20180530160321_add_report_base_model_to_chargeback_rate.rb
+++ b/db/migrate/20180530160321_add_report_base_model_to_chargeback_rate.rb
@@ -1,0 +1,5 @@
+class AddReportBaseModelToChargebackRate < ActiveRecord::Migration[5.0]
+  def change
+    add_column :chargeback_rates, :report_base_model, :string
+  end
+end


### PR DESCRIPTION
**Related to:** https://bugzilla.redhat.com/show_bug.cgi?id=1581817

**What:**
We need to store the type of the Rate which is related to type of Report: _Chargeback for VMs/Images/Projects_.

**Why:**
We need it for adding new drop down to editing screen for Rate to be able to choose the type of the rate and then to display only appropriate columns of the rate, based on the chosen type of the rate (VMs, Images, Projects). I will add appropriate screenshots later.