### PR TITLE
Convert user quadicon settings from the old format to the new one

### DIFF
--- a/db/migrate/20180606083431_convert_quadicon_settings_keys.rb
+++ b/db/migrate/20180606083431_convert_quadicon_settings_keys.rb
@@ -1,0 +1,25 @@
+class ConvertQuadiconSettingsKeys < ActiveRecord::Migration[5.0]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time("Converting :ems quadicon settings keys for users to :ems_infra") do
+      User.all.each do |user|
+        settings = user.settings
+        settings[:quadicons][:ems_infra] = settings[:quadicons].delete(:ems)
+        user.update_attributes(:settings => settings)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Converting :ems_infra quadicon settings keys for users to :ems") do
+      User.all.each do |user|
+        settings = user.settings
+        settings[:quadicons][:ems] = settings[:quadicons].delete(:ems_infra)
+        user.update_attributes(:settings => settings)
+      end
+    end
+  end
+end

--- a/spec/migrations/20180606083431_convert_quadicon_settings_keys_spec.rb
+++ b/spec/migrations/20180606083431_convert_quadicon_settings_keys_spec.rb
@@ -1,0 +1,31 @@
+require_migration
+
+describe ConvertQuadiconSettingsKeys do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    it 'moves the value of :ems to :ems_infra' do
+      user = user_stub.create!(:settings => {:quadicons => {:ems => false }})
+
+      migrate
+
+      user.reload
+
+      expect(user.settings[:quadicons][:ems]).to be_nil
+      expect(user.settings[:quadicons][:ems_infra]).to be_falsey
+    end
+  end
+
+  migration_context :down do
+    it 'moves the value of :ems to :ems_infra' do
+      user = user_stub.create!(:settings => {:quadicons => {:ems_infra => false }})
+
+      migrate
+
+      user.reload
+
+      expect(user.settings[:quadicons][:ems_infra]).to be_nil
+      expect(user.settings[:quadicons][:ems]).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
The [new quadicon settings logic](https://github.com/ManageIQ/manageiq-ui-classic/pull/4034) requires to move the value from `settings[:quadicons][:ems]` into settings[:quadicons][:ems_infra] for each user.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4027