### PR TITLE
Add two columns title and cves to OpenscapRuleResults table

### DIFF
--- a/db/migrate/20180605210436_add_title_cves_to_openscap_rule_results.rb
+++ b/db/migrate/20180605210436_add_title_cves_to_openscap_rule_results.rb
@@ -1,0 +1,6 @@
+class AddTitleCvesToOpenscapRuleResults < ActiveRecord::Migration[5.0]
+  def change
+    add_column :openscap_rule_results, :title, :string
+    add_column :openscap_rule_results, :cves, :string
+  end
+end


### PR DESCRIPTION
**Related to** https://bugzilla.redhat.com/show_bug.cgi?id=1561959

We need to store readable title and CVE references in the OpenSCAP rule results.