### PR TITLE
Migrate Nuage CloudSubnet default type to new subclass

### DIFF
--- a/db/migrate/20180607084710_nuage_subclass_l3_cloud_subnet.rb
+++ b/db/migrate/20180607084710_nuage_subclass_l3_cloud_subnet.rb
@@ -1,0 +1,24 @@
+class NuageSubclassL3CloudSubnet < ActiveRecord::Migration[5.0]
+  class CloudSubnet < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Migrating Nuage default subnet type to L3 subnet subclass') do
+      CloudSubnet.where(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet')
+                 .update_all(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3')
+    end
+  end
+
+  def down
+    say_with_time('Reverting Nuage L3 subnet subclass to default subnet type') do
+      CloudSubnet.where(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3')
+                 .update_all(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet')
+    end
+
+    say_with_time('Reverting Nuage L2 subnet subclass to default subnet type') do
+      CloudSubnet.where(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2')
+                 .update_all(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet')
+    end
+  end
+end

--- a/spec/migrations/20180607084710_nuage_subclass_l3_cloud_subnet_spec.rb
+++ b/spec/migrations/20180607084710_nuage_subclass_l3_cloud_subnet_spec.rb
@@ -1,0 +1,48 @@
+require_migration
+
+describe NuageSubclassL3CloudSubnet do
+  let(:subnet_stub) { migration_stub :CloudSubnet }
+
+  migration_context :up do
+    it 'migrates base Nuage type' do
+      subnet = subnet_stub.create!(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet')
+
+      migrate
+      subnet.reload
+
+      expect(subnet.type).to eql('ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3')
+    end
+
+    it 'doesnt modify other subnets' do
+      subnet = subnet_stub.create!(:type => 'CloudSubnet')
+
+      migrate
+      subnet.reload
+
+      expect(subnet.type).to eql('CloudSubnet')
+    end
+  end
+
+  migration_context :down do
+    it 'restores base Nuage type' do
+      subnet_l3 = subnet_stub.create!(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3')
+      subnet_l2 = subnet_stub.create!(:type => 'ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2')
+
+      migrate
+      subnet_l3.reload
+      subnet_l2.reload
+
+      expect(subnet_l3.type).to eql('ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet')
+      expect(subnet_l2.type).to eql('ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet')
+    end
+
+    it 'doesnt modify other subnets' do
+      subnet = subnet_stub.create!(:type => 'CloudSubnet')
+
+      migrate
+      subnet.reload
+
+      expect(subnet.type).to eql('CloudSubnet')
+    end
+  end
+end


### PR DESCRIPTION
Nuage inventory was recently updated to fetch two types of CloudSubnets:

```
- ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3
- ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2
```

Before only CloudSubnet::L3 were inventoried using default type CloudSubnet. With this migration we make sure that this default type is converted to CloudSubnet::L3 type because persister won't modify STI type per se.

Related PR where we updated parser: https://github.com/ManageIQ/manageiq-providers-nuage/pull/94
@Ladas thanks for pointing out that STI type won't be updated by refresher!

@miq-bot add_label data
@miq-bot assign @Ladas 