### PR TITLE
adding migration for cve data for openscap

### DIFF
--- a/db/migrate/20180607113212_add_cve_to_openscap_rule_results.rb
+++ b/db/migrate/20180607113212_add_cve_to_openscap_rule_results.rb
@@ -1,0 +1,6 @@
+class AddCVEToOpenScapRuleResults < ActiveRecord::Migration[5.0] 
+  def change 
+    add_column :openscap_rule_results, :title, :string 
+    add_column :openscap_rule_results, :cves, :string 
+  end 
+end

--- a/db/migrate/20180607113212_add_cve_to_openscap_rule_results.rb
+++ b/db/migrate/20180607113212_add_cve_to_openscap_rule_results.rb
@@ -1,6 +1,6 @@
-class AddCveToOpenscapRuleResults < ActiveRecord::Migration[5.0] 
-  def change 
-    add_column :openscap_rule_results, :title, :string 
-    add_column :openscap_rule_results, :cves, :string 
-  end 
+class AddCveToOpenscapRuleResults < ActiveRecord::Migration[5.0]
+  def change
+    add_column :openscap_rule_results, :title, :string
+    add_column :openscap_rule_results, :cves, :string
+  end
 end

--- a/db/migrate/20180607113212_add_cve_to_openscap_rule_results.rb
+++ b/db/migrate/20180607113212_add_cve_to_openscap_rule_results.rb
@@ -1,4 +1,4 @@
-class AddCVEToOpenScapRuleResults < ActiveRecord::Migration[5.0] 
+class AddCveToOpenscapRuleResults < ActiveRecord::Migration[5.0] 
   def change 
     add_column :openscap_rule_results, :title, :string 
     add_column :openscap_rule_results, :cves, :string 


### PR DESCRIPTION
As part of https://github.com/ManageIQ/manageiq/pull/17219 we need a migration to the openscap_rule_result table. 