### PR TITLE
Allow FloatingIp to relate directly to NetworkRouter

### DIFF
--- a/db/migrate/20180607134817_add_network_router_id_to_floating_ip.rb
+++ b/db/migrate/20180607134817_add_network_router_id_to_floating_ip.rb
@@ -1,0 +1,5 @@
+class AddNetworkRouterIdToFloatingIp < ActiveRecord::Migration[5.0]
+  def change
+    add_reference(:floating_ips, :network_router, :type => :bigint, :index => true)
+  end
+end


### PR DESCRIPTION
With this commit we add foreign key `network_router_id` on FloatingIp model in order to be able to connect FloatingIp with NetworkRouter. Currently such connection is only possible through CloudNetworks which does not fit well in Nuage inventoring.

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574922

@miq-bot assign @Fryguy 
@miq-bot add_label schema

/cc @Ladas 