### PR TITLE
Move ansible secrets from OpenShift to the database

### DIFF
--- a/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
+++ b/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
@@ -1,10 +1,7 @@
 class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
-  require 'kubeclient'
-
   TOKEN_FILE   = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
   CA_CERT_FILE = "/run/secrets/kubernetes.io/serviceaccount/ca.crt".freeze
   SECRET_NAME  = "ansible-secrets".freeze
-  SERVICE_NAME = "ansible".freeze
 
   class MiqDatabase < ActiveRecord::Base; end
 
@@ -15,9 +12,6 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
   def up
     return unless containerized?
     update_authentications
-    delete_deployment_config(SERVICE_NAME)
-    delete_service(SERVICE_NAME)
-    delete_secret(SECRET_NAME)
   end
 
   private
@@ -27,13 +21,12 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
   end
 
   def update_authentications
-    secret_key, rabbit_password, database_password = get_secret_data
+    secret_key, rabbit_password, admin_password, database_password = get_secret_data
 
-    return unless secret_key.present? && rabbit_password.present?
+    return unless secret_key.present? && rabbit_password.present? && admin_password.present?
 
-    db_id = MiqDatabase.first.id
     db_args = {
-      :resource_id   => db_id,
+      :resource_id   => MiqDatabase.first.id,
       :resource_type => "MiqDatabase"
     }
 
@@ -48,6 +41,12 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
       :userid   => "ansible",
       :type     => "AuthUseridPassword"
     )
+    admin_auth_find_args = db_args.merge(
+      :name     => "Ansible Admin Authentication",
+      :authtype => "ansible_admin_password",
+      :userid   => "admin",
+      :type     => "AuthUseridPassword"
+    )
     database_auth_find_args = db_args.merge(
       :name     => "Ansible Database Authentication",
       :authtype => "ansible_database_password",
@@ -57,16 +56,27 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
 
     update_or_create_authentication!(secret_key_find_args, :auth_key => secret_key)
     update_or_create_authentication!(rabbitmq_auth_find_args, :password => rabbit_password)
+    update_or_create_authentication!(admin_auth_find_args, :password => admin_password)
     update_or_create_authentication!(database_auth_find_args, :password => database_password)
   end
 
   def get_secret_data
-    kube_data = kube_connection.get_secret(SECRET_NAME, my_namespace).data
-    decrypted_data = kube_data.to_h.stringify_keys.transform_values { |v| Base64.decode64(v) }
+    require 'open-uri'
+    require 'json'
 
-    [decrypted_data["secret-key"], decrypted_data["rabbit-password"], ApplicationRecord.configurations[Rails.env]["password"]].map { |v| MiqPassword.encrypt(v) }
-  rescue KubeException => e
-    raise unless e.error_code == 404
+    kube_data = secret_uri.open(request_params) do |f|
+      JSON.parse(f.read)["data"]
+    end
+
+    decoded_data = kube_data.transform_values { |v| Base64.decode64(v) }
+
+    [
+      decoded_data["secret-key"],
+      decoded_data["rabbit-password"],
+      decoded_data["admin-password"],
+      ApplicationRecord.configurations[Rails.env]["password"]
+    ].map { |v| MiqPassword.encrypt(v) }
+  rescue OpenURI::HTTPError
     nil
   end
 
@@ -75,67 +85,20 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
     auth.update_attributes!(update_args)
   end
 
-  def delete_deployment_config(name)
-    rc = kube_connection.get_replication_controllers(
-      :label_selector => "openshift.io/deployment-config.name=#{name}",
-      :namespace      => my_namespace
-    ).first
-
-    oc_connection.patch_deployment_config(name, { :spec => { :replicas => 0 } }, my_namespace)
-    oc_connection.delete_deployment_config(name, my_namespace)
-    delete_replication_controller(rc.metadata.name) if rc
-  rescue KubeException => e
-    raise unless e.error_code == 404
-  end
-
-  def delete_replication_controller(name)
-    kube_connection.delete_replication_controller(name, my_namespace)
-  rescue KubeException => e
-    raise unless e.error_code == 404
-  end
-
-  def delete_service(name)
-    kube_connection.delete_service(name, my_namespace)
-  rescue KubeException => e
-    raise unless e.error_code == 404
-  end
-
-  def delete_secret(name)
-    kube_connection.delete_secret(name, my_namespace)
-  rescue KubeException => e
-    raise unless e.error_code == 404
-  end
-
-  def oc_connection
-    @oc_connection ||= raw_connect(manager_uri("/oapi"))
-  end
-
-  def kube_connection
-    @kube_connection ||= raw_connect(manager_uri("/api"))
-  end
-
-  def raw_connect(uri)
-    ssl_options = {
-      :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
-      :ca_file    => CA_CERT_FILE
+  def request_params
+    {
+      'Accept'         => "application/json",
+      'Authorization'  => "Bearer #{File.read(TOKEN_FILE)}",
+      :ssl_ca_cert     => CA_CERT_FILE,
+      :ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER
     }
-
-    Kubeclient::Client.new(
-      uri,
-      :auth_options => { :bearer_token_file => TOKEN_FILE },
-      :ssl_options  => ssl_options
-    )
   end
 
-  def manager_uri(path)
+  def secret_uri
     URI::HTTPS.build(
       :host => ENV["KUBERNETES_SERVICE_HOST"],
       :port => ENV["KUBERNETES_SERVICE_PORT"],
-      :path => path
+      :path => "/api/v1/namespaces/#{ENV["MY_POD_NAMESPACE"]}/secrets/#{SECRET_NAME}"
     )
-  end
-
-  def my_namespace
-    ENV["MY_POD_NAMESPACE"]
   end
 end

--- a/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
+++ b/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
@@ -1,0 +1,141 @@
+class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
+  require 'kubeclient'
+
+  TOKEN_FILE   = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
+  CA_CERT_FILE = "/run/secrets/kubernetes.io/serviceaccount/ca.crt".freeze
+  SECRET_NAME  = "ansible-secrets".freeze
+  SERVICE_NAME = "ansible".freeze
+
+  class MiqDatabase < ActiveRecord::Base; end
+
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    return unless containerized?
+    update_authentications
+    delete_deployment_config(SERVICE_NAME)
+    delete_service(SERVICE_NAME)
+    delete_secret(SECRET_NAME)
+  end
+
+  private
+
+  def containerized?
+    File.exist?(TOKEN_FILE) && File.exist?(CA_CERT_FILE)
+  end
+
+  def update_authentications
+    secret_key, rabbit_password, database_password = get_secret_data
+
+    return unless secret_key.present? && rabbit_password.present?
+
+    db_id = MiqDatabase.first.id
+    db_args = {
+      :resource_id   => db_id,
+      :resource_type => "MiqDatabase"
+    }
+
+    secret_key_find_args = db_args.merge(
+      :name     => "Ansible Secret Key",
+      :authtype => "ansible_secret_key",
+      :type     => "AuthToken"
+    )
+    rabbitmq_auth_find_args = db_args.merge(
+      :name     => "Ansible Rabbitmq Authentication",
+      :authtype => "ansible_rabbitmq_auth",
+      :userid   => "ansible",
+      :type     => "AuthUseridPassword"
+    )
+    database_auth_find_args = db_args.merge(
+      :name     => "Ansible Database Authentication",
+      :authtype => "ansible_database_password",
+      :userid   => ApplicationRecord.configurations[Rails.env]["username"],
+      :type     => "AuthUseridPassword"
+    )
+
+    update_or_create_authentication!(secret_key_find_args, :auth_key => secret_key)
+    update_or_create_authentication!(rabbitmq_auth_find_args, :password => rabbit_password)
+    update_or_create_authentication!(database_auth_find_args, :password => database_password)
+  end
+
+  def get_secret_data
+    kube_data = kube_connection.get_secret(SECRET_NAME, my_namespace).data
+    decrypted_data = kube_data.to_h.stringify_keys.transform_values { |v| Base64.decode64(v) }
+
+    [decrypted_data["secret-key"], decrypted_data["rabbit-password"], ApplicationRecord.configurations[Rails.env]["password"]].map { |v| MiqPassword.encrypt(v) }
+  rescue KubeException => e
+    raise unless e.error_code == 404
+    nil
+  end
+
+  def update_or_create_authentication!(find_args, update_args)
+    auth = Authentication.find_or_initialize_by(find_args)
+    auth.update_attributes!(update_args)
+  end
+
+  def delete_deployment_config(name)
+    rc = kube_connection.get_replication_controllers(
+      :label_selector => "openshift.io/deployment-config.name=#{name}",
+      :namespace      => my_namespace
+    ).first
+
+    oc_connection.patch_deployment_config(name, { :spec => { :replicas => 0 } }, my_namespace)
+    oc_connection.delete_deployment_config(name, my_namespace)
+    delete_replication_controller(rc.metadata.name) if rc
+  rescue KubeException => e
+    raise unless e.error_code == 404
+  end
+
+  def delete_replication_controller(name)
+    kube_connection.delete_replication_controller(name, my_namespace)
+  rescue KubeException => e
+    raise unless e.error_code == 404
+  end
+
+  def delete_service(name)
+    kube_connection.delete_service(name, my_namespace)
+  rescue KubeException => e
+    raise unless e.error_code == 404
+  end
+
+  def delete_secret(name)
+    kube_connection.delete_secret(name, my_namespace)
+  rescue KubeException => e
+    raise unless e.error_code == 404
+  end
+
+  def oc_connection
+    @oc_connection ||= raw_connect(manager_uri("/oapi"))
+  end
+
+  def kube_connection
+    @kube_connection ||= raw_connect(manager_uri("/api"))
+  end
+
+  def raw_connect(uri)
+    ssl_options = {
+      :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
+      :ca_file    => CA_CERT_FILE
+    }
+
+    Kubeclient::Client.new(
+      uri,
+      :auth_options => { :bearer_token_file => TOKEN_FILE },
+      :ssl_options  => ssl_options
+    )
+  end
+
+  def manager_uri(path)
+    URI::HTTPS.build(
+      :host => ENV["KUBERNETES_SERVICE_HOST"],
+      :port => ENV["KUBERNETES_SERVICE_PORT"],
+      :path => path
+    )
+  end
+
+  def my_namespace
+    ENV["MY_POD_NAMESPACE"]
+  end
+end

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "activerecord-id_regions"
+  s.add_dependency "kubeclient", "~> 2.4"
   s.add_dependency "more_core_extensions"
   s.add_dependency "pg", "~> 0.18.2"
   s.add_dependency "rails", "~> 5.0.2"

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "activerecord-id_regions"
-  s.add_dependency "kubeclient", "~> 2.4"
   s.add_dependency "more_core_extensions"
   s.add_dependency "pg", "~> 0.18.2"
   s.add_dependency "rails", "~> 5.0.2"

--- a/spec/migrations/20180606155924_move_ansible_container_secrets_into_database_spec.rb
+++ b/spec/migrations/20180606155924_move_ansible_container_secrets_into_database_spec.rb
@@ -1,0 +1,167 @@
+require_migration
+
+describe MoveAnsibleContainerSecretsIntoDatabase do
+  let(:database_stub)       { migration_stub(:MiqDatabase) }
+  let(:authentication_stub) { migration_stub(:Authentication) }
+  let(:db_id)               { database_stub.first.id }
+
+  let(:cert)       { Tempfile.new("cert") }
+  let(:token)      { Tempfile.new("token") }
+  let(:cert_path)  { cert.path }
+  let(:token_path) { token.path }
+  let(:kube_host)  { "kube.example.com" }
+  let(:kube_port)  { "8443" }
+  let(:namespace)  { "manageiq" }
+
+  before do
+    database_stub.create!
+
+    ENV["KUBERNETES_SERVICE_HOST"] = kube_host
+    ENV["KUBERNETES_SERVICE_PORT"] = kube_port
+    ENV["MY_POD_NAMESPACE"] = namespace
+  end
+
+  after do
+    FileUtils.rm_f(cert_path)
+    FileUtils.rm_f(token_path)
+    ENV.delete("KUBERNETES_SERVICE_HOST")
+    ENV.delete("KUBERNETES_SERVICE_PORT")
+    ENV.delete("MY_POD_NAMESPACE")
+  end
+
+  migration_context :up do
+    it "doesn't add any authentications if not running in a container" do
+      migrate
+      expect(database_authentications.count).to eq(0)
+    end
+
+    context "with an API connection in a container" do
+      before do
+        stub_const("MoveAnsibleContainerSecretsIntoDatabase::TOKEN_FILE", token_path)
+        stub_const("MoveAnsibleContainerSecretsIntoDatabase::CA_CERT_FILE", cert_path)
+      end
+
+      let(:kube_connection) { subject.send(:kube_connection) }
+      let(:oc_connection) { subject.send(:oc_connection) }
+
+      it "creates the correct kube connection" do
+        expect(kube_connection.api_endpoint.to_s).to eq("https://kube.example.com:8443/api")
+        expect(kube_connection.auth_options[:bearer_token_file]).to eq(token_path)
+        expect(kube_connection.ssl_options[:verify_ssl]).to eq(1)
+      end
+
+      it "creates the correct oc connection" do
+        expect(oc_connection.api_endpoint.to_s).to eq("https://kube.example.com:8443/oapi")
+        expect(oc_connection.auth_options[:bearer_token_file]).to eq(token_path)
+        expect(oc_connection.ssl_options[:verify_ssl]).to eq(1)
+      end
+
+      context "with stub connection" do
+        let(:connection_stub) { double("KubeConnection") }
+        let(:secret) do
+          OpenStruct.new(:data => {
+            :"admin-password" => "YWRtaW5wYXNzd29yZA==",
+            :"rabbit-password" => "cmFiYml0cGFzc3dvcmQ=",
+            :"secret-key" => "c2VjcmV0a2V5"
+          })
+        end
+
+        before do
+          allow(Kubeclient::Client).to receive(:new).and_return(connection_stub)
+          expect_objects_deleted
+        end
+
+        it "doesn't add any authentications if the secret is not found" do
+          error = KubeException.new(404, "secret not found", "")
+          expect(connection_stub).to receive(:get_secret).and_raise(error)
+
+          migrate
+
+          expect(database_authentications.count).to eq(0)
+        end
+
+        it "creates new authentications for the secret values" do
+          expect(connection_stub).to receive(:get_secret).with("ansible-secrets", namespace).and_return(secret)
+          migrate
+
+          expect(database_authentications.count).to eq(3)
+          expect(ansible_secret_key).to eq("secretkey")
+          expect(ansible_rabbitmq_password).to eq("rabbitpassword")
+          expect(ansible_database_password).to eq(ApplicationRecord.configurations[Rails.env]["password"])
+        end
+
+        it "updates authentications with the secret values" do
+          expect(connection_stub).to receive(:get_secret).with("ansible-secrets", namespace).and_return(secret)
+          authentication_stub.create!(
+            :name          => "Ansible Secret Key",
+            :authtype      => "ansible_secret_key",
+            :type          => "AuthToken",
+            :auth_key      => MiqPassword.encrypt("notthekey"),
+            :resource_id   => db_id,
+            :resource_type => "MiqDatabase"
+          )
+          expect(ansible_secret_key).to eq("notthekey")
+
+          migrate
+
+          expect(ansible_secret_key).to eq("secretkey")
+          expect(ansible_rabbitmq_password).to eq("rabbitpassword")
+          expect(ansible_database_password).to eq(ApplicationRecord.configurations[Rails.env]["password"])
+        end
+      end
+    end
+  end
+
+  def database_authentications
+    authentication_stub.where(:resource_id => db_id, :resource_type => "MiqDatabase")
+  end
+
+  def ansible_secret_key
+    auths = database_authentications.where(
+      :name     => "Ansible Secret Key",
+      :authtype => "ansible_secret_key",
+      :type     => "AuthToken"
+    )
+    expect(auths.count).to eq(1)
+    MiqPassword.decrypt(auths.first.auth_key)
+  end
+
+  def ansible_rabbitmq_password
+    auths = database_authentications.where(
+      :name     => "Ansible Rabbitmq Authentication",
+      :authtype => "ansible_rabbitmq_auth",
+      :userid   => "ansible",
+      :type     => "AuthUseridPassword"
+    )
+    expect(auths.count).to eq(1)
+    MiqPassword.decrypt(auths.first.password)
+  end
+
+  def ansible_database_password
+    auths = database_authentications.where(
+      :name     => "Ansible Database Authentication",
+      :authtype => "ansible_database_password",
+      :userid   => ApplicationRecord.configurations[Rails.env]["username"],
+      :type     => "AuthUseridPassword"
+    )
+    expect(auths.count).to eq(1)
+    MiqPassword.decrypt(auths.first.password)
+  end
+
+  def expect_objects_deleted
+    # deletes deployment and repliction controller
+    expect(connection_stub).to receive(:get_replication_controllers).with(
+      :label_selector => "openshift.io/deployment-config.name=ansible",
+      :namespace      => namespace
+    ).and_return([double(:metadata => double(:name => "testrepcontroller"))])
+    expect(connection_stub).to receive(:patch_deployment_config).with("ansible", {:spec => {:replicas => 0}}, namespace)
+    expect(connection_stub).to receive(:delete_deployment_config).with("ansible", namespace)
+    expect(connection_stub).to receive(:delete_replication_controller).with("testrepcontroller", namespace)
+
+    # deletes service
+    expect(connection_stub).to receive(:delete_service).with("ansible", namespace)
+
+    # deletes secret
+    expect(connection_stub).to receive(:delete_secret).with("ansible-secrets", namespace)
+  end
+end


### PR DESCRIPTION
In previous versions, the secret values for the embedded ansible pod
lived in an OpenShift secret object named "ansible-secrets".In newer
versions these values are managed using the Authentication model
against MiqDatabase.

This migration retrieves the values from the secret and saves them
as "Authentication" objects if we see that we are running in OpenShift
and the secret object is present.

https://www.pivotaltracker.com/story/show/157287338

@miq-bot assign @Fryguy 

/cc @bdunne 