### PR TITLE
Add Firmware Type to Hardwares

### DIFF
--- a/db/migrate/20180613200937_add_firmware_type_to_hardware.rb
+++ b/db/migrate/20180613200937_add_firmware_type_to_hardware.rb
@@ -1,0 +1,5 @@
+class AddFirmwareTypeToHardware < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hardwares, :firmware_type, :string
+  end
+end


### PR DESCRIPTION
Add a column to store if a VM/Host is using BIOS or EFI as their
firmware type.