### PR TITLE
Create table for Cloud Volume Types

### DIFF
--- a/db/migrate/20180618212608_create_cloud_volume_types.rb
+++ b/db/migrate/20180618212608_create_cloud_volume_types.rb
@@ -7,7 +7,7 @@ class CreateCloudVolumeTypes < ActiveRecord::Migration[5.0]
       t.string :backend_name
       t.string :ems_ref
       t.bigint :ems_id
-      t.boolean :is_public
+      t.boolean :public
 
       t.timestamps
     end

--- a/db/migrate/20180618212608_create_cloud_volume_types.rb
+++ b/db/migrate/20180618212608_create_cloud_volume_types.rb
@@ -1,0 +1,15 @@
+class CreateCloudVolumeTypes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cloud_volume_types do |t|
+      t.text :description
+      t.string :name
+      t.string :type
+      t.string :backend_name
+      t.string :ems_ref
+      t.bigint :ems_id
+      t.boolean :is_public
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
http://bugzilla.redhat.com/show_bug.cgi?id=1592900
Cloud Volume Types are needed for mapping new Cinder volumes to specific backends.