### PR TITLE
Enable PhysicalStorage inside PhysicalChassis

### DIFF
--- a/db/migrate/20180713201539_add_physical_chassis_id_to_physical_storage.rb
+++ b/db/migrate/20180713201539_add_physical_chassis_id_to_physical_storage.rb
@@ -1,0 +1,5 @@
+class AddPhysicalChassisIdToPhysicalStorage < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_storages, :physical_chassis_id, :bigint
+  end
+end


### PR DESCRIPTION
This PR is able to:
- Enable PhysicalStorage inside PhysicalChassis by storing chassis ID in storage schema