### PR TITLE
Fix the quadicon settings migration for users without quadicon settings

### DIFF
--- a/db/migrate/20180606083431_convert_quadicon_settings_keys.rb
+++ b/db/migrate/20180606083431_convert_quadicon_settings_keys.rb
@@ -7,6 +7,7 @@ class ConvertQuadiconSettingsKeys < ActiveRecord::Migration[5.0]
     say_with_time("Converting :ems quadicon settings keys for users to :ems_infra") do
       User.all.each do |user|
         settings = user.settings
+        next unless settings[:quadicons]
         settings[:quadicons][:ems_infra] = settings[:quadicons].delete(:ems)
         user.update_attributes(:settings => settings)
       end
@@ -17,6 +18,7 @@ class ConvertQuadiconSettingsKeys < ActiveRecord::Migration[5.0]
     say_with_time("Converting :ems_infra quadicon settings keys for users to :ems") do
       User.all.each do |user|
         settings = user.settings
+        next unless settings[:quadicons]
         settings[:quadicons][:ems] = settings[:quadicons].delete(:ems_infra)
         user.update_attributes(:settings => settings)
       end

--- a/spec/migrations/20180606083431_convert_quadicon_settings_keys_spec.rb
+++ b/spec/migrations/20180606083431_convert_quadicon_settings_keys_spec.rb
@@ -14,6 +14,16 @@ describe ConvertQuadiconSettingsKeys do
       expect(user.settings[:quadicons][:ems]).to be_nil
       expect(user.settings[:quadicons][:ems_infra]).to be_falsey
     end
+
+    it 'skips the user when the quadicons are not set' do
+      user = user_stub.create!
+
+      migrate
+
+      user.reload
+
+      expect(user.settings).to eq({})
+    end
   end
 
   migration_context :down do
@@ -26,6 +36,16 @@ describe ConvertQuadiconSettingsKeys do
 
       expect(user.settings[:quadicons][:ems_infra]).to be_nil
       expect(user.settings[:quadicons][:ems]).to be_falsey
+    end
+
+    it 'skips the user when the quadicons are not set' do
+      user = user_stub.create!
+
+      migrate
+
+      user.reload
+
+      expect(user.settings).to eq({})
     end
   end
 end


### PR DESCRIPTION
As we discussed with @Fryguy and reported by @branic the migration can fail if the `:quadicons` key isn't available in the `User#settings` hash. This simple one-liner fixes the problem by skipping to migrate the affected users.

@miq-bot add_label bug, gaprindashvili/no
@miq-bot assign @Fryguy 