### PR TITLE
Add ems_ref to lans to help with unique listing

### DIFF
--- a/db/migrate/20180625120055_add_ems_ref_to_lans.rb
+++ b/db/migrate/20180625120055_add_ems_ref_to_lans.rb
@@ -1,0 +1,5 @@
+class AddEmsRefToLans < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lans, :ems_ref, :string
+  end
+end


### PR DESCRIPTION
Add an ems_ref column to the lans table so that it can be used to assist
in getting a unique list of lans across hosts in cases where the uid_ems
is not unique i.e. VMware where the uid_ems is the name of the lan.

By adding the ems_ref which is unique across the ems we are able to get
a truly unique list of networks when showing a list across hosts.