### PR TITLE
Enable S3 DB Backups

### DIFF
--- a/db/migrate/20180620170052_add_aws_region_to_file_depot.rb
+++ b/db/migrate/20180620170052_add_aws_region_to_file_depot.rb
@@ -1,0 +1,5 @@
+class AddAwsRegionToFileDepot < ActiveRecord::Migration[5.0]
+  def change
+    add_column :file_depots, :aws_region, :string
+  end
+end

--- a/db/migrate/20180620170052_add_region_to_file_depot.rb
+++ b/db/migrate/20180620170052_add_region_to_file_depot.rb
@@ -1,5 +1,0 @@
-class AddRegionToFileDepot < ActiveRecord::Migration[5.0]
-  def change
-    add_column :file_depots, :region, :string
-  end
-end

--- a/db/migrate/20180620170052_add_region_to_file_depot.rb
+++ b/db/migrate/20180620170052_add_region_to_file_depot.rb
@@ -1,0 +1,5 @@
+class AddRegionToFileDepot < ActiveRecord::Migration[5.0]
+  def change
+    add_column :file_depots, :region, :string
+  end
+end


### PR DESCRIPTION
Add the AWS region to the file depot so S3 depots contain a region value.

For RFE referenced in https://bugzilla.redhat.com/show_bug.cgi?id=1513520

@roliveri please review.  Also requires https://github.com/ManageIQ/manageiq-gems-pending/pull/355
as well as a forthcoming ManageIQ core PR and a TBD manageiq-ui-classic PR.  

@Fryguy please review and merge.  Thanks.