### PR TITLE
add local_path to configuration_script_source

### DIFF
--- a/db/migrate/20170726201054_add_local_path_to_configuration_script_source.rb
+++ b/db/migrate/20170726201054_add_local_path_to_configuration_script_source.rb
@@ -1,0 +1,5 @@
+class AddLocalPathToConfigurationScriptSource < ActiveRecord::Migration[5.0]
+  def change
+    add_column :configuration_script_sources, :local_path, :string
+  end
+end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1465966

The repo type of `manual` keeps the path to a Tower local folder that stores playbooks. Adding this attribute to support this `manual` type.