### PR TITLE
Add physical_switch_id and physical_chassis_id column to event stream table

### DIFF
--- a/db/migrate/20180705190447_add_chassis_and_switch_to_event_stream.rb
+++ b/db/migrate/20180705190447_add_chassis_and_switch_to_event_stream.rb
@@ -1,0 +1,6 @@
+class AddChassisAndSwitchToEventStream < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :physical_chassis_id, :bigint
+    add_column :event_streams, :physical_switch_id, :bigint
+  end
+end


### PR DESCRIPTION
This PR's goal is to add physical switch id to `event_streams` table, so we can manage events for those components.