### PR TITLE
Adding Location LED name to asset_details table

### DIFF
--- a/db/migrate/20180706115011_add_loc_led_name_asset_details.rb
+++ b/db/migrate/20180706115011_add_loc_led_name_asset_details.rb
@@ -1,0 +1,5 @@
+class AddLocLedNameAssetDetails < ActiveRecord::Migration[5.0]
+  def change
+    add_column :asset_details, :location_led_ems_ref, :string
+  end
+end


### PR DESCRIPTION
It is required to send LED action to physical components, once that the name of the LED can vary to each component.