### PR TITLE
Create Canister migration

### DIFF
--- a/db/migrate/20180713194201_create_canister.rb
+++ b/db/migrate/20180713194201_create_canister.rb
@@ -1,0 +1,23 @@
+class CreateCanister < ActiveRecord::Migration[5.0]
+  def change
+    create_table :canisters do |t|
+      t.string :ems_ref
+      t.string :serial_number
+      t.string :name
+      t.string :position
+      t.string :status
+      t.string :health_state
+      t.string :disk_bus_type
+      t.string :phy_isolation
+      t.string :controller_redundancy_status
+      t.integer :disks
+      t.integer :disk_channel
+      t.integer :system_cache_memory
+      t.string :power_state
+      t.string :host_ports
+      t.string :hardware_version
+      t.bigint :physical_storage_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180713194229_add_canister_id_to_hardwares.rb
+++ b/db/migrate/20180713194229_add_canister_id_to_hardwares.rb
@@ -1,0 +1,5 @@
+class AddCanisterIdToHardwares < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hardwares, :canister_id, :bigint
+  end
+end


### PR DESCRIPTION
This PR is able to:
- Create a canister migration
- Add its reference to hardwares table

A Canister is a controller inside the Physical Storage (which may have more than one Canister). It contains its own firmware, ports, network, power state, etc.

Depends on:
- [~ManageIQ/manageiq-schema#233 - Merged~](https://github.com/ManageIQ/manageiq-schema/pull/233)
- [ManageIQ/manageiq-schema#269](https://github.com/ManageIQ/manageiq-schema/pull/269)
- [~ManageIQ/manageiq#17700 - Merged~](https://github.com/ManageIQ/manageiq/pull/17700)