### PR TITLE
Remove Host Provisioning references

### DIFF
--- a/db/migrate/20180712122000_remove_host_provisioning.rb
+++ b/db/migrate/20180712122000_remove_host_provisioning.rb
@@ -1,0 +1,24 @@
+class RemoveHostProvisioning < ActiveRecord::Migration[5.0]
+  class MiqApproval < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :miq_request, :class_name => `RemoveHostProvisioning::MiqRequest`
+  end
+
+  class MiqRequest < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    has_many :miq_approvals, :dependent => :destroy, :class_name => `RemoveHostProvisioning::MiqApproval`
+  end
+
+  class MiqRequestTask < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Delete Host Provision Requests and Tasks") do
+      MiqRequest.where(:type => :MiqHostProvisionRequest).destroy_all
+      MiqRequestTask.where(:type => :MiqHostProvision).destroy_all
+    end
+  end
+end

--- a/spec/migrations/20180712122000_remove_host_provisioning_spec.rb
+++ b/spec/migrations/20180712122000_remove_host_provisioning_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe RemoveHostProvisioning do
+  migration_context :up do
+    let(:miq_request_stub) { migration_stub :MiqRequest }
+    let(:miq_request_task_stub) { migration_stub :MiqRequestTask }
+    let(:miq_approval_stub) { migration_stub :MiqApproval }
+
+    it 'only removes Host Provision request instances' do
+      miq_request_stub.create!(:type => 'MiqProvisionRequest', :miq_approvals => [miq_approval_stub.create!])
+      miq_request_stub.create!(:type => 'MiqHostProvisionRequest', :miq_approvals => [miq_approval_stub.create!])
+      miq_request_stub.create!(:type => 'ServiceTemplateProvisionRequest', :miq_approvals => [miq_approval_stub.create!])
+
+      miq_request_task_stub.create!(:type => 'MiqProvision')
+      miq_request_task_stub.create!(:type => 'MiqHostProvision')
+      miq_request_task_stub.create!(:type => 'ServiceTemplateProvisionTask')
+
+      migrate
+
+      expect(miq_request_stub.count).to eq 2
+      expect(miq_request_task_stub.count).to eq 2
+      expect(miq_approval_stub.count).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
Remove any `MiqHostProvisionRequest` and `HostProvision` records.

Followup from https://github.com/ManageIQ/manageiq/pull/17604