### PR TITLE
Remove Settings.product.transformation

### DIFF
--- a/db/migrate/20180718132840_remove_transformation_product_setting.rb
+++ b/db/migrate/20180718132840_remove_transformation_product_setting.rb
@@ -1,0 +1,11 @@
+class RemoveTransformationProductSetting < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  def up
+    say_with_time("Removing transformation product setting (v2v)") do
+      SettingsChange.where(:key => "/product/transformation").delete_all
+    end
+  end
+end


### PR DESCRIPTION
v2v product feature, this should be always on from 5.9.3 on - replaced by RBAC.

Goes together with https://github.com/ManageIQ/manageiq/pull/17711 (and ManageIQ/miq_v2v_ui_plugin#490).

Cc @Fryguy 