### PR TITLE
Add Owner/Group/Tenant to Authentication

### DIFF
--- a/db/migrate/20180719162710_add_owner_and_group_to_auth.rb
+++ b/db/migrate/20180719162710_add_owner_and_group_to_auth.rb
@@ -1,0 +1,13 @@
+class AddOwnerAndGroupToAuth < ActiveRecord::Migration[5.0]
+  def up
+    add_column :authentications, :evm_owner_id, :bigint
+    add_column :authentications, :miq_group_id, :bigint
+    add_column :authentications, :tenant_id, :bigint
+  end
+
+  def down
+    remove_column :authentications, :evm_owner_id
+    remove_column :authentications, :miq_group_id
+    remove_column :authentications, :tenant_id
+  end
+end


### PR DESCRIPTION
Add foreign keys for evm_owner, miq_group, and tenant to the
authentications table to allow ownership of key pairs by users, groups,
and tenants.

https://bugzilla.redhat.com/show_bug.cgi?id=1589766