### PR TITLE
[WIP] Adding refresh_queue table

### DIFF
--- a/db/migrate/20180730092457_create_refresh_queue_table.rb
+++ b/db/migrate/20180730092457_create_refresh_queue_table.rb
@@ -1,0 +1,16 @@
+class CreateRefreshQueueTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :refresh_queue do |t|
+
+      t.string "class_name"
+      t.jsonb "persister_data", default: {}
+
+      t.string "zone"
+      t.string "role"
+      t.string "server_guid"
+
+      t.datetime "created_on"
+      t.datetime "expires_on"
+    end
+  end
+end


### PR DESCRIPTION
Adding refresh_queue table, as a temporary solution for refresh,
before we have a normal queue. We will be using this table as a
normal queue, which will be more efficient, even if the DB is
not really good option for this.