### PR TITLE
Fixed version of rubocop in gemspec

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "~> 0.52.1"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Newer version than 0.52.1 causes error:

```ruby
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
```

Probably source of problem is 
https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml

specified in `.rubocop.yml`

Cc @Fryguy 