### PR TITLE
UserRole's features spec without "not changed" test

### DIFF
--- a/spec/migrations/20150914202922_correct_user_created_role_feature_sets_spec.rb
+++ b/spec/migrations/20150914202922_correct_user_created_role_feature_sets_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CorrectUserCreatedRoleFeatureSets do
       )
       user_role = user_role_stub.create!(:miq_product_features => [], :read_only => false)
 
-      expect { migrate }.not_to change { user_role.reload.miq_product_features }
+      expect { migrate }.not_to(change { user_role.reload.miq_product_features })
     end
 
     it "leaves read only user roles alone" do
@@ -112,7 +112,7 @@ RSpec.describe CorrectUserCreatedRoleFeatureSets do
       )
       user_role = user_role_stub.create!(:miq_product_features => [vm_infra_explorer], :read_only => true)
 
-      expect { migrate }.not_to change { user_role.reload.miq_product_features }
+      expect { migrate }.not_to(change { user_role.reload.miq_product_features })
     end
   end
 end

--- a/spec/migrations/20150914202922_correct_user_created_role_feature_sets_spec.rb
+++ b/spec/migrations/20150914202922_correct_user_created_role_feature_sets_spec.rb
@@ -88,7 +88,9 @@ RSpec.describe CorrectUserCreatedRoleFeatureSets do
       )
       user_role = user_role_stub.create!(:miq_product_features => [], :read_only => false)
 
-      expect { migrate }.not_to(change { user_role.reload.miq_product_features })
+      migrate
+
+      expect(user_role.reload.miq_product_features).to be_empty
     end
 
     it "leaves read only user roles alone" do
@@ -112,7 +114,11 @@ RSpec.describe CorrectUserCreatedRoleFeatureSets do
       )
       user_role = user_role_stub.create!(:miq_product_features => [vm_infra_explorer], :read_only => true)
 
-      expect { migrate }.not_to(change { user_role.reload.miq_product_features })
+      migrate
+      user_role.reload
+
+      expect(user_role.miq_product_features.size).to eq(1)
+      expect(user_role.miq_product_features[0].id).to eq(vm_infra_explorer.id)
     end
   end
 end


### PR DESCRIPTION
Potential solution of https://travis-ci.org/ManageIQ/manageiq-schema/jobs/413016733

`expect...not_to change` tests two `ActiveRecord::Associations::CollectionProxy` objects which causes problem in CI. 
Contents of these proxies are correct thus now are tested associated product features directly