### PR TITLE
Add a version to the more_core_extensions dependency

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "activerecord-id_regions"
-  s.add_dependency "more_core_extensions"
+  s.add_dependency "more_core_extensions", "~> 3.5"
   s.add_dependency "pg", "~> 0.18.2"
   s.add_dependency "rails", "~> 5.0.2"
   s.add_dependency "pg-pglogical", "~> 2.1.1"


### PR DESCRIPTION
We require at least version 3.5 for the String#hostname? method