### PR TITLE
Add a test requiring data migrations to have an associated spec file

### DIFF
--- a/spec/automated_review/data_migrations_need_tests_spec.rb
+++ b/spec/automated_review/data_migrations_need_tests_spec.rb
@@ -1,0 +1,29 @@
+describe "Data migrations" do
+  KNOWN_MISSING_DATA_MIGRATION_SPEC_FILES = [
+    "20151021174044_add_tenant_default_group_spec.rb",
+    "20160317041206_add_maintenance_to_host_spec.rb",
+    "20160428215808_add_filters_to_entitlements_spec.rb",
+    "20160713130940_remove_type_template_and_vms_filters_from_miq_search_spec.rb",
+    "20170419154137_remove_deleted_migration_timestamps_spec.rb",
+    "20171011180000_move_openstack_refresher_settings_spec.rb"
+  ].freeze
+
+  def data_migration_files
+    Spec::Support::ConstantWatcher.classes_by_file.keys.select { |file| file.include?("db/migrate") }
+  end
+
+  it "need tests" do
+    Dir.glob(ManageIQ::Schema::Engine.root.join("db", "migrate", "*.rb")).each { |i| require i }
+
+    data_migration_files.each do |data_migration_file|
+      spec_file_basename = File.basename(data_migration_file).sub(".rb", "_spec.rb")
+      spec_file = ManageIQ::Schema::Engine.root.join("spec", "migrations", spec_file_basename)
+
+      if spec_file_basename.in?(KNOWN_MISSING_DATA_MIGRATION_SPEC_FILES)
+        expect(spec_file.file?).to eq(false), "Thanks for adding a test!! Please remove #{spec_file_basename} from KNOWN_MISSING_DATA_MIGRATION_SPEC_FILES in #{__FILE__}"
+      else
+        expect(spec_file.file?).to eq(true), "Missing data migration spec at #{spec_file}"
+      end
+    end
+  end
+end

--- a/spec/support/constant_watcher.rb
+++ b/spec/support/constant_watcher.rb
@@ -1,0 +1,21 @@
+module Spec
+  module Support
+    module ConstantWatcher
+      mattr_accessor :classes_by_file
+
+      def inherited(other)
+        Spec::Support::ConstantWatcher.add(other)
+        super
+      end
+
+      def self.add(const)
+        path = caller_locations(2..2).first.path
+        self.classes_by_file ||= {}
+        self.classes_by_file[path] ||= []
+        self.classes_by_file[path] << const.name
+      end
+    end
+  end
+end
+
+ActiveRecord::Base.singleton_class.prepend(Spec::Support::ConstantWatcher)


### PR DESCRIPTION
We can determine which files are data migrations since they will define a class that inherits from ActiveRecord::Base.  If we hook inherited in AR::Base, we can get the constant and the file in which it is defined (the data migration).

Adding this as an automated code review to address https://github.com/ManageIQ/manageiq-schema/issues/4#issue-237082801