### PR TITLE
Remove Settings.product.transformation - add missing specs

### DIFF
--- a/spec/migrations/20180718132840_remove_transformation_product_setting_spec.rb
+++ b/spec/migrations/20180718132840_remove_transformation_product_setting_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe RemoveTransformationProductSetting do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "removes the /product/transformation key" do
+      setting_changed = settings_change_stub.create!(:key => "/product/transformation", :value => true)
+      setting_ignored = settings_change_stub.create!(:key => "/product/magic", :value => true)
+
+      migrate
+
+      expect { setting_changed.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(setting_ignored.reload.value).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
this is a spec for 0f14276 - missed in https://github.com/ManageIQ/manageiq-schema/pull/236.

@miq-bot add_label test, data, transformation, gaprindashvili/no