### PR TITLE
Skip updating rows with vm_ems_ref=nil for EventStream

### DIFF
--- a/db/migrate/20180424141617_azure_backslash_to_forward_slash.rb
+++ b/db/migrate/20180424141617_azure_backslash_to_forward_slash.rb
@@ -67,7 +67,7 @@ class AzureBackslashToForwardSlash < ActiveRecord::Migration[5.0]
     end
 
     say_with_time("Updating Azure event stream ems_ref") do
-      EventStream.where(:source => "AZURE").update_all("vm_ems_ref = replace(vm_ems_ref, '\\', '/')")
+      EventStream.where(:source => "AZURE").where.not(:vm_ems_ref => nil).update_all("vm_ems_ref = replace(vm_ems_ref, '\\', '/')")
     end
   end
 end


### PR DESCRIPTION
During upgrade customer's db to latest it spent some time on this query.

And then I saw that `EventStream#vm_ems_ref` was nil. So we can skip them in updating process.
(Not sure what does it mean)
