### PR TITLE
Add cancelation_status column in MiqRequest and MiqRequestTask

### DIFF
--- a/db/migrate/20180813141056_add_cancelation_status_to_miq_request.rb
+++ b/db/migrate/20180813141056_add_cancelation_status_to_miq_request.rb
@@ -1,0 +1,6 @@
+class AddCancelationStatusToMiqRequest < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_requests,      :cancelation_status, :string
+    add_column :miq_request_tasks, :cancelation_status, :string
+  end
+end


### PR DESCRIPTION
Add `cancelation_status` to enable cancel operation for V2V migration.

This PR is related with:
https://github.com/ManageIQ/manageiq/pull/17825
https://github.com/ManageIQ/manageiq-automation_engine/pull/212