### PR TITLE
Add version dependency for activerecord-id_regions

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "activerecord-id_regions"
+  s.add_dependency "activerecord-id_regions", "~> 0.2.2"
   s.add_dependency "more_core_extensions", "~> 3.5"
   s.add_dependency "pg", "~> 0.18.2"
-  s.add_dependency "rails", "~> 5.0.2"
   s.add_dependency "pg-pglogical", "~> 2.1.1"
+  s.add_dependency "rails", "~> 5.0.2"
 
   s.add_dependency "manageiq-gems-pending"  # This is just for MiqPassword for now
 


### PR DESCRIPTION
v0.2.2 fixes random spec failures that are fairly common on Travis due to https://github.com/ManageIQ/activerecord-id_regions/pull/10