### PR TITLE
Model relation "SecurityGroup belongs to NetworkRouter or CloudSubnet"

### DIFF
--- a/db/migrate/20180817152200_add_network_router_id_to_security_group.rb
+++ b/db/migrate/20180817152200_add_network_router_id_to_security_group.rb
@@ -1,0 +1,5 @@
+class AddNetworkRouterIdToSecurityGroup < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :security_groups, :network_router, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20180817152201_add_cloud_subnet_id_to_security_group.rb
+++ b/db/migrate/20180817152201_add_cloud_subnet_id_to_security_group.rb
@@ -1,0 +1,5 @@
+class AddCloudSubnetIdToSecurityGroup < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :security_groups, :cloud_subnet, :type => :bigint, :index => true
+  end
+end


### PR DESCRIPTION
With this commit we add a foreign key on SecurityGroup to follow what Nuage needs. In Nuage, security group is something that only exists in a scope of either L3 domain (NetworkRouter) or L2 domain (CloudSubnet::L2).

![image](https://user-images.githubusercontent.com/8102426/44323384-fb496e80-a451-11e8-8ef9-533883aa2141.png)


MIQ is currently not able to model such relation yet, hence this PR.

@miq-bot add_label enhancement
@miq-bot assign @Fryguy 

@Ladas @agrare looking forward to your opinion. Need for this was revealed when enhancing targeted refresh where we would need something like `network_router.security_groups`, but there is no such relation yet... Is schema already frozen for Hammer?