### PR TITLE
Swift DB Backups Requirements

### DIFF
--- a/db/migrate/20180817212259_add_api_version_and_domain_id_and_security_protocol_and_openstack_region_to_file_depot.rb
+++ b/db/migrate/20180817212259_add_api_version_and_domain_id_and_security_protocol_and_openstack_region_to_file_depot.rb
@@ -1,0 +1,8 @@
+class AddApiVersionAndDomainIdAndSecurityProtocolAndOpenstackRegionToFileDepot < ActiveRecord::Migration[5.0]
+  def change
+    add_column :file_depots, :keystone_api_version, :string
+    add_column :file_depots, :v3_domain_id,         :string
+    add_column :file_depots, :security_protocol,    :string
+    add_column :file_depots, :openstack_region,     :string
+  end
+end

--- a/db/migrate/20180817212259_add_api_version_and_domain_id_and_security_protocol_and_openstack_region_to_file_depot.rb
+++ b/db/migrate/20180817212259_add_api_version_and_domain_id_and_security_protocol_and_openstack_region_to_file_depot.rb
@@ -1,7 +1,7 @@
 class AddApiVersionAndDomainIdAndSecurityProtocolAndOpenstackRegionToFileDepot < ActiveRecord::Migration[5.0]
   def change
     add_column :file_depots, :keystone_api_version, :string
-    add_column :file_depots, :v3_domain_id,         :string
+    add_column :file_depots, :v3_domain_ident,      :string
     add_column :file_depots, :security_protocol,    :string
     add_column :file_depots, :openstack_region,     :string
   end


### PR DESCRIPTION
In order to add a file depot supporting Openstack Swift object store
as a destination for DB backups, several fields describing the Swift connection
and storage location are required.

The biggest question is whether some of these can be encoded in the URI that is contained in the
File Depot instead of adding new columns for the data.  The URI would be passed along to perform the backup with the encoded data (which would then need to be pulled out in order to connect to Swift, and to correctly address the storage location for the backup file).

The plan is for the UI to collect this information, store it in the DB, and pass it along to the backup process by way of the "Mount Session".

Required information includes:

Keystone API version - a string that is currently "v2" or "v3".  For Openstack providers this is stored in the ext_management_systems table.

V3 Dynamic ID - for Openstack providers, this string value is stored in the uid_ems column of the ext_management_systems table.

Region - I'm actually not sure where this is stored for providers, but that is sort of irrelevant.  At issue is that we just added a "region" column to the FileDepot specifically for S3 File Depots - and went so far as to name it "aws_region" because we were convinced it would only be needed for S3 (unfortunately).

Security Protocol - Stored in the endpoint table for providers - this is either 'ssl', 'ssl-with-validation', or 'non-ssl'.

Port - Also stored in the endpoint table for providers.  This is the most obvious field to be added to the URI except that for accessing the Storage location via Swift it appears that the port is not expected in the URI, so some handling will be necessary after connecting to the Openstack endpoint.

This change adds the first four of these fields as new columns to the FileDepot table.  We can discuss overloading the URI with all or none of them.

Note in addition that the knowledge about using this information will need to be brought over from the Provider to the new SwiftFileDepot class in order to do credential validation.  In addition, the new SwiftMountSession class in manageiq-gems-pending will need to use the info to connect to Swift.

@carbonin @Fryguy @NickLaMuro @roliveri Please review and comment.   Opinions are not only welcome but probably required.  Thanks much. 

This change is in support of the RFE contained in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1615488.

@carbonin @roliveri @bdunne @agrare Please review and merge - prerequisite for other work coming down the pipe for this release.  I will update with other PR numbers when added.