### PR TITLE
Create OpenShift Service Catalog tables

### DIFF
--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -13,7 +13,10 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.jsonb :extra
 
       t.datetime :ems_created_on
+      t.datetime :deleted_on
       t.timestamps
+
+      t.index :deleted_on
     end
 
     create_table :container_service_plans, :id => :bigserial, :force => :cascade do |t|
@@ -29,7 +32,10 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.jsonb :extra
 
       t.datetime :ems_created_on
+      t.datetime :deleted_on
       t.timestamps
+
+      t.index :deleted_on
     end
 
     create_table :container_service_instances, :id => :bigserial, :force => :cascade do |t|
@@ -47,7 +53,10 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.jsonb :extra
 
       t.datetime :ems_created_on
+      t.datetime :deleted_on
       t.timestamps
+
+      t.index :deleted_on
     end
   end
 end

--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -3,7 +3,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
     create_table :container_service_classes, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
-      t.integer :resource_version
+      t.string :resource_version
       t.text :description
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
@@ -19,7 +19,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
     create_table :container_service_plans, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
-      t.integer :resource_version
+      t.string :resource_version
       t.text :description
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
@@ -36,7 +36,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.string :name
       t.string :ems_ref
       t.string :secret_name
-      t.integer :resource_version
+      t.string :resource_version
       t.string :generate_name
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system

--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -6,7 +6,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.text :url
 
-      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
 
       t.jsonb :extra
@@ -21,7 +21,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.text :description
 
-      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
       t.references :container_service_brokers, :type => :bigint, :index => true
 
@@ -37,7 +37,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.text :description
 
-      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
       t.references :container_service_classes, :type => :bigint, :index => true
 
@@ -54,7 +54,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.string :generate_name
 
-      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
       t.references :container_service_classes, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
       t.references :container_service_plans, :type => :bigint, :index => true
@@ -70,7 +70,7 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.string :ems_ref
       t.integer :resource_version
 
-      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
       t.references :container_service_instances, :type => :bigint, :index => {:name => 'csb_on_container_service_instances'}
 

--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -6,8 +6,8 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.text :url
 
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
-      t.references :container_projects, :type => :bigint, :index => true
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :container_project, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -21,9 +21,9 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.text :description
 
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
-      t.references :container_projects, :type => :bigint, :index => true
-      t.references :container_service_brokers, :type => :bigint, :index => true
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :container_project, :type => :bigint, :index => true
+      t.references :container_service_broker, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -37,9 +37,9 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.text :description
 
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
-      t.references :container_projects, :type => :bigint, :index => true
-      t.references :container_service_classes, :type => :bigint, :index => true
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :container_project, :type => :bigint, :index => true
+      t.references :container_service_class, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -54,10 +54,10 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.integer :resource_version
       t.string :generate_name
 
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
-      t.references :container_projects, :type => :bigint, :index => true
-      t.references :container_service_classes, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
-      t.references :container_service_plans, :type => :bigint, :index => true
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :container_project, :type => :bigint, :index => true
+      t.references :container_service_class, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
+      t.references :container_service_plan, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -70,9 +70,9 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.string :ems_ref
       t.integer :resource_version
 
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_systems
-      t.references :container_projects, :type => :bigint, :index => true
-      t.references :container_service_instances, :type => :bigint, :index => {:name => 'csb_on_container_service_instances'}
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :container_project, :type => :bigint, :index => true
+      t.references :container_service_instance, :type => :bigint, :index => {:name => 'csb_on_container_service_instances'}
 
       t.jsonb :extra
 

--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -1,20 +1,5 @@
 class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
   def change
-    create_table :container_service_brokers, :id => :bigserial, :force => :cascade do |t|
-      t.string :name
-      t.string :ems_ref
-      t.integer :resource_version
-      t.text :url
-
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :container_project, :type => :bigint, :index => true
-
-      t.jsonb :extra
-
-      t.datetime :ems_created_on
-      t.timestamps
-    end
-
     create_table :container_service_classes, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
@@ -58,21 +43,6 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.references :container_project, :type => :bigint, :index => true
       t.references :container_service_class, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
       t.references :container_service_plan, :type => :bigint, :index => true
-
-      t.jsonb :extra
-
-      t.datetime :ems_created_on
-      t.timestamps
-    end
-
-    create_table :container_service_bindings, :id => :bigserial, :force => :cascade do |t|
-      t.string :name
-      t.string :ems_ref
-      t.integer :resource_version
-
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :container_project, :type => :bigint, :index => true
-      t.references :container_service_instance, :type => :bigint, :index => {:name => 'csb_on_container_service_instances'}
 
       t.jsonb :extra
 

--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -1,0 +1,114 @@
+class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
+  def change
+    create_table :container_service_brokers, :id => :bigserial, :force => :cascade do |t|
+      t.string :name
+      t.string :kind
+      t.string :ems_ref
+      t.integer :resource_version
+      t.text :url
+
+      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :container_projects, :type => :bigint, :index => true
+
+      t.jsonb :extra
+
+      t.datetime :ems_created_on
+      t.timestamps
+    end
+
+    create_table :container_service_classes, :id => :bigserial, :force => :cascade do |t|
+      t.string :name
+      t.string :kind
+      t.string :status
+      t.string :ems_ref
+      t.integer :resource_version
+      t.text :description
+      t.boolean :bindable
+      t.boolean :plan_updatable
+
+      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :container_projects, :type => :bigint, :index => true
+      t.references :container_service_brokers, :type => :bigint, :index => true
+
+      t.jsonb :extra
+
+      t.datetime :ems_created_on
+      t.timestamps
+    end
+
+    create_table :container_service_plans, :id => :bigserial, :force => :cascade do |t|
+      t.string :name
+      t.string :kind
+      t.string :status
+      t.string :ems_ref
+      t.integer :resource_version
+      t.text :description
+      t.boolean :free
+
+      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :container_projects, :type => :bigint, :index => true
+      t.references :container_service_classes, :type => :bigint, :index => true
+
+      t.jsonb :extra
+
+      t.datetime :ems_created_on
+      t.timestamps
+    end
+
+    create_table :container_service_instances, :id => :bigserial, :force => :cascade do |t|
+      t.string :name
+      t.string :kind
+      t.string :status
+      t.string :ems_ref
+      t.string :secret_name
+      t.integer :resource_version
+
+      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :container_projects, :type => :bigint, :index => true
+      t.references :container_service_classes, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
+      t.references :container_service_plans, :type => :bigint, :index => true
+
+      t.jsonb :parameters
+      t.jsonb :parameters_from
+      t.jsonb :extra
+
+      t.datetime :ems_created_on
+      t.timestamps
+    end
+
+    create_table :container_service_bindings, :id => :bigserial, :force => :cascade do |t|
+      t.string :name
+      t.string :kind
+      t.string :status
+      t.string :ems_ref
+      t.string :secret_name
+      t.integer :resource_version
+
+      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :container_projects, :type => :bigint, :index => true
+      t.references :container_service_instances, :type => :bigint, :index => {:name => 'csb_on_container_service_instances'}
+
+      t.jsonb :parameters
+      t.jsonb :parameters_from
+      t.jsonb :extra
+
+      t.datetime :ems_created_on
+      t.timestamps
+    end
+
+    create_table :container_secrets, :id => :bigserial, :force => :cascade do |t|
+      t.string :name
+      t.string :kind
+      t.string :ems_ref
+      t.integer :resource_version
+
+      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
+      t.references :container_projects, :type => :bigint, :index => true
+
+      t.jsonb :extra
+
+      t.datetime :ems_created_on
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_openshift_service_catalog_tables.rb
@@ -2,7 +2,6 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
   def change
     create_table :container_service_brokers, :id => :bigserial, :force => :cascade do |t|
       t.string :name
-      t.string :kind
       t.string :ems_ref
       t.integer :resource_version
       t.text :url
@@ -18,13 +17,9 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
 
     create_table :container_service_classes, :id => :bigserial, :force => :cascade do |t|
       t.string :name
-      t.string :kind
-      t.string :status
       t.string :ems_ref
       t.integer :resource_version
       t.text :description
-      t.boolean :bindable
-      t.boolean :plan_updatable
 
       t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
@@ -38,12 +33,9 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
 
     create_table :container_service_plans, :id => :bigserial, :force => :cascade do |t|
       t.string :name
-      t.string :kind
-      t.string :status
       t.string :ems_ref
       t.integer :resource_version
       t.text :description
-      t.boolean :free
 
       t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
@@ -57,19 +49,16 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
 
     create_table :container_service_instances, :id => :bigserial, :force => :cascade do |t|
       t.string :name
-      t.string :kind
-      t.string :status
       t.string :ems_ref
       t.string :secret_name
       t.integer :resource_version
+      t.string :generate_name
 
       t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
       t.references :container_service_classes, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
       t.references :container_service_plans, :type => :bigint, :index => true
 
-      t.jsonb :parameters
-      t.jsonb :parameters_from
       t.jsonb :extra
 
       t.datetime :ems_created_on
@@ -78,32 +67,12 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
 
     create_table :container_service_bindings, :id => :bigserial, :force => :cascade do |t|
       t.string :name
-      t.string :kind
-      t.string :status
       t.string :ems_ref
-      t.string :secret_name
       t.integer :resource_version
 
       t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
       t.references :container_projects, :type => :bigint, :index => true
       t.references :container_service_instances, :type => :bigint, :index => {:name => 'csb_on_container_service_instances'}
-
-      t.jsonb :parameters
-      t.jsonb :parameters_from
-      t.jsonb :extra
-
-      t.datetime :ems_created_on
-      t.timestamps
-    end
-
-    create_table :container_secrets, :id => :bigserial, :force => :cascade do |t|
-      t.string :name
-      t.string :kind
-      t.string :ems_ref
-      t.integer :resource_version
-
-      t.references :ems_id, :type => :bigint, :index => true, :references => :ext_management_systems
-      t.references :container_projects, :type => :bigint, :index => true
 
       t.jsonb :extra
 

--- a/db/migrate/20180821112856_create_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_service_catalog_tables.rb
@@ -1,14 +1,13 @@
-class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
+class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
   def change
-    create_table :container_service_classes, :id => :bigserial, :force => :cascade do |t|
+    create_table :service_classes, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
       t.string :resource_version
+      t.string :type
       t.text :description
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :container_project, :type => :bigint, :index => true
-      t.references :container_service_broker, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -19,15 +18,15 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.index :deleted_on
     end
 
-    create_table :container_service_plans, :id => :bigserial, :force => :cascade do |t|
+    create_table :service_plans, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
       t.string :resource_version
+      t.string :type
       t.text :description
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :container_project, :type => :bigint, :index => true
-      t.references :container_service_class, :type => :bigint, :index => true
+      t.references :service_class, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -38,17 +37,15 @@ class CreateOpenshiftServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.index :deleted_on
     end
 
-    create_table :container_service_instances, :id => :bigserial, :force => :cascade do |t|
+    create_table :service_instances, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
-      t.string :secret_name
       t.string :resource_version
-      t.string :generate_name
+      t.string :type
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :container_project, :type => :bigint, :index => true
-      t.references :container_service_class, :type => :bigint, :index => {:name => 'csi_on_container_service_classes'}
-      t.references :container_service_plan, :type => :bigint, :index => true
+      t.references :service_class, :type => :bigint, :index => true
+      t.references :service_plan, :type => :bigint, :index => true
 
       t.jsonb :extra
 

--- a/db/migrate/20180821112856_create_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_service_catalog_tables.rb
@@ -32,22 +32,5 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
 
       t.index :deleted_on
     end
-
-    create_table :service_instances, :id => :bigserial, :force => :cascade do |t|
-      t.string :name
-      t.string :ems_ref
-      t.string :type
-
-      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :service_offering, :type => :bigint, :index => true
-      t.references :service_plan, :type => :bigint, :index => true
-
-      t.jsonb :extra
-
-      t.datetime :deleted_on
-      t.timestamps
-
-      t.index :deleted_on
-    end
   end
 end

--- a/db/migrate/20180821112856_create_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_service_catalog_tables.rb
@@ -16,7 +16,7 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.index :deleted_on
     end
 
-    create_table :service_parameters_set, :id => :bigserial, :force => :cascade do |t|
+    create_table :service_parameters_sets, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
       t.string :type

--- a/db/migrate/20180821112856_create_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_service_catalog_tables.rb
@@ -3,7 +3,6 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
     create_table :service_offerings, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
-      t.string :resource_version
       t.string :type
       t.text :description
 
@@ -11,7 +10,6 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
 
       t.jsonb :extra
 
-      t.datetime :ems_created_on
       t.datetime :deleted_on
       t.timestamps
 
@@ -21,7 +19,6 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
     create_table :service_plans, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
-      t.string :resource_version
       t.string :type
       t.text :description
 
@@ -30,7 +27,6 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
 
       t.jsonb :extra
 
-      t.datetime :ems_created_on
       t.datetime :deleted_on
       t.timestamps
 
@@ -40,7 +36,6 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
     create_table :service_instances, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
-      t.string :resource_version
       t.string :type
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
@@ -49,7 +44,6 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
 
       t.jsonb :extra
 
-      t.datetime :ems_created_on
       t.datetime :deleted_on
       t.timestamps
 

--- a/db/migrate/20180821112856_create_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_service_catalog_tables.rb
@@ -16,7 +16,7 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.index :deleted_on
     end
 
-    create_table :service_plans, :id => :bigserial, :force => :cascade do |t|
+    create_table :service_parameters_set, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
       t.string :type

--- a/db/migrate/20180821112856_create_service_catalog_tables.rb
+++ b/db/migrate/20180821112856_create_service_catalog_tables.rb
@@ -1,6 +1,6 @@
 class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
   def change
-    create_table :service_classes, :id => :bigserial, :force => :cascade do |t|
+    create_table :service_offerings, :id => :bigserial, :force => :cascade do |t|
       t.string :name
       t.string :ems_ref
       t.string :resource_version
@@ -26,7 +26,7 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.text :description
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :service_class, :type => :bigint, :index => true
+      t.references :service_offering, :type => :bigint, :index => true
 
       t.jsonb :extra
 
@@ -44,7 +44,7 @@ class CreateServiceCatalogTables < ActiveRecord::Migration[5.0]
       t.string :type
 
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
-      t.references :service_class, :type => :bigint, :index => true
+      t.references :service_offering, :type => :bigint, :index => true
       t.references :service_plan, :type => :bigint, :index => true
 
       t.jsonb :extra


### PR DESCRIPTION
Create OpenShift Service Catalog tables

This is a first version of what the tables could look like. It probably has more columns that will be needed, but we can delete the unused later. The docs do not contain API resources description https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/v1/api.md

So basing this on the examples in docs:
https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/walkthrough.md
https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/cli.md
https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/resources.md