### PR TITLE
Moving location_led_state to asset_details table

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,4 +1,8 @@
 ActiveSupport::Inflector.inflections do |inflect|
+  inflect.singular(/Chassis$/, "Chassis")
+  inflect.plural(/Chassis$/, "Chassis")
+  inflect.singular(/chassis$/, "chassis")
+  inflect.plural(/chassis$/, "chassis")
   inflect.singular(/Queue$/, "Queue")
   inflect.plural(/Queue$/, "Queue")
   inflect.singular(/queue$/, "queue")

--- a/db/migrate/20180823111741_move_location_led_state_to_asset_details_table.rb
+++ b/db/migrate/20180823111741_move_location_led_state_to_asset_details_table.rb
@@ -1,0 +1,44 @@
+class MoveLocationLedStateToAssetDetailsTable < ActiveRecord::Migration[5.0]
+  class AssetDetail < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  class PhysicalChassis < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  class PhysicalServer < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    add_column :asset_details, :location_led_state, :string
+
+    PhysicalChassis.in_my_region.find_each { |chassis| move_location_led_state_to_asset_detail("PhysicalChassis", chassis) }
+    PhysicalServer.in_my_region.find_each { |server| move_location_led_state_to_asset_detail("PhysicalServer", server) }
+
+    remove_column :physical_chassis, :location_led_state
+    remove_column :physical_servers, :location_led_state
+  end
+
+  def down
+    add_column :physical_chassis, :location_led_state, :string
+    add_column :physical_servers, :location_led_state, :string
+
+    AssetDetail.where(:resource_type => %w(PhysicalChassis PhysicalServer)).in_my_region.find_each do |asset_detail|
+      self.class.const_get(asset_detail.resource_type).update(asset_detail.resource_id, :location_led_state => asset_detail.location_led_state)
+    end
+
+    remove_column :asset_details, :location_led_state
+  end
+
+  private
+
+  def move_location_led_state_to_asset_detail(class_name, asset)
+    AssetDetail.in_my_region.find_or_initialize_by(:resource_type => class_name, :resource_id => asset.id).update_attributes!(:location_led_state => asset.location_led_state)
+  end
+end

--- a/spec/migrations/20180823111741_move_location_led_state_to_asset_details_table_spec.rb
+++ b/spec/migrations/20180823111741_move_location_led_state_to_asset_details_table_spec.rb
@@ -1,0 +1,53 @@
+require_migration
+
+describe MoveLocationLedStateToAssetDetailsTable do
+  let(:asset_detail_stub)     { migration_stub(:AssetDetail) }
+  let(:physical_chassis_stub) { migration_stub(:PhysicalChassis) }
+  let(:physical_server_stub)  { migration_stub(:PhysicalServer) }
+
+  context "resources with asset detail" do
+    migration_context :up do
+      let!(:physical_chassis) { physical_chassis_stub.create!(:location_led_state => 'Blinking') }
+      let!(:physical_server)  { physical_server_stub.create!(:location_led_state => 'Off') }
+
+      it "should migrate the data from physical_chassis and physical_servers to asset_details table" do
+        asset_detail_chassis = asset_detail_stub.create!(:resource_type => "PhysicalChassis", :resource_id => physical_chassis.id)
+        asset_detail_server  = asset_detail_stub.create!(:resource_type => "PhysicalServer", :resource_id => physical_server.id)
+
+        migrate
+
+        expect(asset_detail_chassis.reload.location_led_state).to eq('Blinking')
+        expect(asset_detail_server.reload.location_led_state).to  eq('Off')
+      end
+
+      it "should create associated asset_detail and migrate the data if it doesn't exist" do
+        migrate
+
+        expect(asset_detail_stub.find_by(:resource_type => "PhysicalChassis", :resource_id => physical_chassis.id)).to have_attributes(:location_led_state => 'Blinking')
+        expect(asset_detail_stub.find_by(:resource_type => "PhysicalServer", :resource_id => physical_server.id)).to   have_attributes(:location_led_state => 'Off')
+      end
+    end
+
+    migration_context :down do
+      let!(:physical_chassis) { physical_chassis_stub.create! }
+      let!(:physical_server)  { physical_server_stub.create! }
+
+      it "should migrate the data back from asset_details to physical_chassis and physical_servers tables" do
+        asset_detail_stub.create!(:location_led_state => 'Blinking', :resource_type => "PhysicalChassis", :resource_id => physical_chassis.id)
+        asset_detail_stub.create!(:location_led_state => 'Off', :resource_type => "PhysicalServer", :resource_id => physical_server.id)
+
+        migrate
+
+        expect(physical_chassis.reload.location_led_state).to eq('Blinking')
+        expect(physical_server.reload.location_led_state).to  eq('Off')
+      end
+
+      it "should migrate the data back from asset_details to physical_chassis and physical_servers tables" do
+        migrate
+
+        expect(physical_chassis.reload.location_led_state).to be_nil
+        expect(physical_server.reload.location_led_state).to  be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
__This PR is able to:__
- Move the `location_led_state` column from `physical_chassis` and `physical_servers` to `asset_details`

__Goal__
The goal is to put together ems_ref and state information of the location led.

It is a complement of https://github.com/ManageIQ/manageiq-schema/pull/231