### PR TITLE
[WIP] Combine switches column migrations

### DIFF
--- a/db/migrate/20180126144529_add_extra_information_to_switches.rb
+++ b/db/migrate/20180126144529_add_extra_information_to_switches.rb
@@ -4,10 +4,5 @@ class AddExtraInformationToSwitches < ActiveRecord::Migration[5.0]
     add_column :switches, :type, :string
     add_column :switches, :health_state, :string
     add_column :switches, :power_state, :string
-    add_column :switches, :product_name, :string
-    add_column :switches, :part_number, :string
-    add_column :switches, :serial_number, :string
-    add_column :switches, :description, :string
-    add_column :switches, :manufacturer, :string
   end
 end

--- a/db/migrate/20180323204821_remove_switch_details_from_switches.rb
+++ b/db/migrate/20180323204821_remove_switch_details_from_switches.rb
@@ -1,9 +1,0 @@
-class RemoveSwitchDetailsFromSwitches < ActiveRecord::Migration[5.0]
-  def change
-    remove_column :switches, :product_name,  :string
-    remove_column :switches, :part_number,   :string
-    remove_column :switches, :serial_number, :string
-    remove_column :switches, :description,   :string
-    remove_column :switches, :manufacturer,  :string
-  end
-end


### PR DESCRIPTION
This causes an issue with upgrading replicated environments

When the first migration is run, data is generated which references
the new columns in the switches table, but those columns are then removed.

When replication sees data which references a column not in the global
schema it exits and tries again later (typically within a few minutes).
If we then migrate the global database to add then quickly remove the
column in question the data from the remote stream will never be
able to be successfully consumed.

This fixes the issue by not adding the column to the wrong table
to start with.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601015

This is one option to fix the issue, but it does edit existing migrations which I acknowledge is something we don't want to do lightly. Additionally this makes no attempt to detect or fix this kind of issue for future releases.