### PR TITLE
Add parent physical chassis id to physical chassis

### DIFF
--- a/db/migrate/20180828092111_add_parent_physical_chassis_id_to_physical_chassis.rb
+++ b/db/migrate/20180828092111_add_parent_physical_chassis_id_to_physical_chassis.rb
@@ -1,0 +1,5 @@
+class AddParentPhysicalChassisIdToPhysicalChassis < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_chassis, :parent_physical_chassis_id, :bigint
+  end
+end


### PR DESCRIPTION
This additional field is used to model chassis nesting. Example would be installation that uses Intel's Rack Scale Design (pod containing multiple racks containing multiple blocks that in turn contain multiple sleds ...).