### PR TITLE
Add status to Physical Network Ports table

### DIFF
--- a/db/migrate/20180830121026_add_port_status_to_physical_network_ports.rb
+++ b/db/migrate/20180830121026_add_port_status_to_physical_network_ports.rb
@@ -1,0 +1,5 @@
+class AddPortStatusToPhysicalNetworkPorts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_network_ports, :port_status, :string
+  end
+end


### PR DESCRIPTION
This PR is able to:
- Add status reference to Physical Network Ports table through migration