### PR TITLE
Remove column report_base_model from ChargebackRate table

### DIFF
--- a/db/migrate/20180905144610_remove_report_base_model_from_chargeback_rate.rb
+++ b/db/migrate/20180905144610_remove_report_base_model_from_chargeback_rate.rb
@@ -1,0 +1,5 @@
+class RemoveReportBaseModelFromChargebackRate < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :chargeback_rates, :report_base_model, :string
+  end
+end


### PR DESCRIPTION
**Related to:** 
https://github.com/ManageIQ/manageiq-schema/pull/209
https://bugzilla.redhat.com/show_bug.cgi?id=1581817

**What:**
We need to store the type of the Rate which is related to type of Report: Chargeback for VMs/Images/Projects, but not in `ChargebackRate` table. This was the first idea presented in https://github.com/ManageIQ/manageiq-schema/pull/209 but we decided that storing report type in `ChargeableField` is the best option (another migration will be needed).

**Details:**
We need to store the type of the Rate for adding new drop down to editing screen for Rate to be able to choose the type of the rate and then to display only appropriate columns of the rate, based on the chosen type of the rate (VMs, Images, Projects).