### PR TITLE
Add limits colums to conversion_hosts table

### DIFF
--- a/db/migrate/20180917151300_add_limits_to_conversion_host.rb
+++ b/db/migrate/20180917151300_add_limits_to_conversion_host.rb
@@ -1,0 +1,9 @@
+class AddLimitsToConversionHost < ActiveRecord::Migration[5.0]
+  def change
+    add_column :conversion_hosts, :concurrent_transformation_limit, :string
+    add_column :conversion_hosts, :cpu_limit, :string
+    add_column :conversion_hosts, :memory_limit, :string
+    add_column :conversion_hosts, :network_limit, :string
+    add_column :conversion_hosts, :blockio_limit, :string
+  end
+end


### PR DESCRIPTION
This adds colums to model V2V throttling limits at conversion host level.