### PR TITLE
Maintenance zone support for suspending provider

### DIFF
--- a/db/migrate/20180618083035_add_visible_to_zone.rb
+++ b/db/migrate/20180618083035_add_visible_to_zone.rb
@@ -1,0 +1,5 @@
+class AddVisibleToZone < ActiveRecord::Migration[5.0]
+  def change
+    add_column :zones, :visible, :boolean
+  end
+end

--- a/db/migrate/20180618084054_init_zones_visibility.rb
+++ b/db/migrate/20180618084054_init_zones_visibility.rb
@@ -1,0 +1,16 @@
+class InitZonesVisibility < ActiveRecord::Migration[5.0]
+  class Zone < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Updating all zones to visible") do
+      Zone.update_all(:visible => true)
+    end
+  end
+
+  def down
+    say_with_time("Resetting zone visibility") do
+      Zone.update_all(:visible => nil)
+    end
+  end
+end

--- a/db/migrate/20180618084757_add_zone_before_pause_id_to_ext_management_system.rb
+++ b/db/migrate/20180618084757_add_zone_before_pause_id_to_ext_management_system.rb
@@ -1,0 +1,5 @@
+class AddZoneBeforePauseIdToExtManagementSystem < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :ext_management_systems, :zone_before_pause, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20180920085721_add_maintenance_zone_id_to_region.rb
+++ b/db/migrate/20180920085721_add_maintenance_zone_id_to_region.rb
@@ -1,0 +1,5 @@
+class AddMaintenanceZoneIdToRegion < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_regions, :maintenance_zone_id, :bigint, :index => true
+  end
+end

--- a/spec/migrations/20180618084054_init_zones_visibility_spec.rb
+++ b/spec/migrations/20180618084054_init_zones_visibility_spec.rb
@@ -1,0 +1,26 @@
+require_migration
+describe InitZonesVisibility do
+  let(:zone_stub) { migration_stub(:Zone) }
+
+  migration_context :up do
+    it "makes zones visible" do
+      zone = zone_stub.create!(:name => 'zone1')
+
+      migrate
+      zone.reload
+
+      expect(zone.visible).to be_truthy
+    end
+  end
+
+  migration_context :down do
+    it 'resets zone visibility' do
+      zone = zone_stub.create!(:name => 'zone_visible', :visible => true)
+
+      migrate
+      zone.reload
+
+      expect(zone.visible).to be_nil
+    end
+  end
+end

--- a/spec/migrations/20180618084757_add_backup_zone_id_to_ext_management_system.rb
+++ b/spec/migrations/20180618084757_add_backup_zone_id_to_ext_management_system.rb
@@ -1,0 +1,5 @@
+class AddBackupZoneIdToExtManagementSystem < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :ext_management_systems, :backup_zone, :type => :bigint, :index => true
+  end
+end

--- a/spec/migrations/20180618084757_add_backup_zone_id_to_ext_management_system.rb
+++ b/spec/migrations/20180618084757_add_backup_zone_id_to_ext_management_system.rb
@@ -1,5 +1,0 @@
-class AddBackupZoneIdToExtManagementSystem < ActiveRecord::Migration[5.0]
-  def change
-    add_reference :ext_management_systems, :backup_zone, :type => :bigint, :index => true
-  end
-end


### PR DESCRIPTION
**BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1455145
**Issue**: https://github.com/ManageIQ/manageiq/issues/17489

Suspending provider consists of moving provider (`ExtManagementSystem`) to maintenance zone.

Maintenance zone will be created in `Zone.seed` and identified by association to region.
Name of zone will be generated as `maintenance_#{uuid}`. This zone will have `visible` flag set to false, which will be handled by PRs in UI and API.

---

This is an alternative to https://github.com/ManageIQ/manageiq-schema/pull/222, where zone is supposed to be identified by unique name.

- [ ] (**dependent**) https://github.com/ManageIQ/manageiq/pull/17452