### PR TITLE
PhysicalDisk#type wasn't being used for STI

### DIFF
--- a/db/migrate/20180924144957_rename_physical_disk_type.rb
+++ b/db/migrate/20180924144957_rename_physical_disk_type.rb
@@ -1,0 +1,5 @@
+class RenamePhysicalDiskType < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :physical_disks, :type, :controller_type
+  end
+end


### PR DESCRIPTION
Rename the type column to controller_type for consistency with disks.

Ref: https://github.com/ManageIQ/manageiq-schema/pull/233#discussion_r219855558