### PR TITLE
Add conversion_host_id to miq_request_task

### DIFF
--- a/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
+++ b/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
@@ -34,7 +34,7 @@ class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
 
   def down
     conversion_host_ids = MiqRequestTask.where(:type => 'ServiceTemplateTransformationPlanTask').map do |task|
-      return if task.conversion_host.nil?
+      next if task.conversion_host.nil?
       task.options[:transformation_host_id] = task.conversion_host.resource.id
       task.save!
       task.conversion_host.id

--- a/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
+++ b/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
@@ -21,13 +21,14 @@ class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
       host_id = task.options[:transformation_host_id]
       next unless host_id
       host = Host.find_by(:id => host_id)
-      next if host.nil?
-      task.conversion_host = ConversionHost.find_or_create_by!(:resource => host) do |ch|
-        ch.name                     = host.name
-        ch.vddk_transport_supported = true
-        ch.ssh_transport_supported  = false
-      end
       task.options.delete(:transformation_host_id)
+      if host.present?
+        task.conversion_host = ConversionHost.find_or_create_by!(:resource => host) do |ch|
+          ch.name                     = host.name
+          ch.vddk_transport_supported = true
+          ch.ssh_transport_supported  = false
+        end
+      end
       task.save!
     end
   end
@@ -38,7 +39,7 @@ class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
       task.save!
       task.conversion_host.id
     end
-    ConversionHost.destroy(conversion_host_ids)
+    ConversionHost.destroy(conversion_host_ids.compact)
 
     remove_column :miq_request_tasks, :conversion_host_id
   end

--- a/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
+++ b/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
@@ -1,0 +1,48 @@
+class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
+  class MiqRequestTask < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    serialize :options, Hash
+    belongs_to :conversion_host, :class_name => "AddConversionHostIdToMiqRequestTasks::ConversionHost"
+  end
+
+  class ServiceTemplateTransformationPlanTask < MiqRequestTask
+  end
+
+  class ConversionHost < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    has_many :service_template_transformation_plan_tasks, :class_name => "AddConversionHostIdToMiqRequestTasks::MiqRequestTask"
+  end
+
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    has_many :tags, :class_name => "AddConversionHostIdToMiqRequestTasks::Tag"
+  end
+
+  def up
+    add_column :miq_request_tasks, :conversion_host_id, :bigint
+
+    ServiceTemplateTransformationPlanTask.all.reject { |task| task.options[:transformation_host_id].nil? }.each do |task|
+      host = Host.find_by(:id => task.options[:transformation_host_id])
+      task.conversion_host = ConversionHost.where(:id => task.options[:transformation_host_id]).first_or_create do |ch|
+        ch.name                     = host.name
+        ch.resource_type            = host.type
+        ch.resource_id              = host.id
+        ch.address                  = host.ipaddress
+        ch.vddk_transport_supported = true
+        ch.ssh_transport_supported  = false
+      end
+      task.options.delete(:transformation_host_id)
+      task.save!
+    end
+  end
+
+  def down
+    ServiceTemplateTransformationPlanTask.all.select { |task| task.conversion_host.present? }.each do |task|
+      task.options[:transformation_host_id] = task.conversion_host.id
+      ConversionHost.find(task.conversion_host.id).destroy!
+      task.save!
+    end
+
+    remove_column :miq_request_tasks, :conversion_host_id
+  end
+end

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -6,7 +6,7 @@ describe AddConversionHostIdToMiqRequestTasks do
   let(:conversion_host_stub) { migration_stub(:ConversionHost) }
 
   migration_context :up do
-    it "when host doesn't exist" do
+    it "doesn't set the conversion host when the host doesn't exists" do
       host = host_stub.create!
       conversion_host_id = host.id
       task = task_stub.create!(
@@ -19,11 +19,11 @@ describe AddConversionHostIdToMiqRequestTasks do
       task.reload
 
       expect(task.options).to eq(:dummy_key => 'dummy_value')
-      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => conversion_host_id)).to be_nil
+      expect(conversion_host_stub.find_by(:resource_id => conversion_host_id)).to be_nil
       expect(task.conversion_host).to be_nil
     end
 
-    it "when host exist" do
+    it "creates a conversion host and updates the task when the host exists" do
       host = host_stub.create!
       task = task_stub.create!(
         :type    => 'ServiceTemplateTransformationPlanTask',
@@ -34,8 +34,8 @@ describe AddConversionHostIdToMiqRequestTasks do
       task.reload
 
       expect(task.options).to eq(:dummy_key => 'dummy_value')
-      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host)).not_to be_nil
-      expect(task.conversion_host).to eq(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host))
+      expect(conversion_host_stub.find_by(:resource => host)).not_to be_nil
+      expect(task.conversion_host).to eq(conversion_host_stub.find_by(:resource => host))
     end
   end
 

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -4,29 +4,31 @@ describe AddConversionHostIdToMiqRequestTasks do
   let(:task_stub) { migration_stub(:MiqRequestTask) }
   let(:host_stub) { migration_stub(:Host) }
   let(:conversion_host_stub) { migration_stub(:ConversionHost) }
-  let(:host_id) { 42 }
 
   migration_context :up do
     it "when host doesn't exist" do
+      host = host_stub.create!
+      conversion_host_id = host.id
       task = task_stub.create!(
         :type    => 'ServiceTemplateTransformationPlanTask',
-        :options => { :dummy_key => 'dummy_value', :transformation_host_id => host_id }
+        :options => { :dummy_key => 'dummy_value', :transformation_host_id => conversion_host_id }
       )
+      host.destroy!
 
       migrate
       task.reload
 
-      expect(task.options).to eq({ :dummy_key => 'dummy_value', :transformation_host_id => host_id })
-      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => host_id)).to be_nil
+      expect(task.options).to eq({ :dummy_key => 'dummy_value' })
+      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => conversion_host_id)).to be_nil
       expect(task.conversion_host).to be_nil
     end
 
     it "when host exist" do
+      host = host_stub.create!
       task = task_stub.create!(
         :type    => 'ServiceTemplateTransformationPlanTask',
-        :options => { :dummy_key => 'dummy_value', :transformation_host_id => host_id }
+        :options => { :dummy_key => 'dummy_value', :transformation_host_id => host.id }
       )
-      host = host_stub.create!(:id => host_id)
 
       migrate
       task.reload

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -18,7 +18,7 @@ describe AddConversionHostIdToMiqRequestTasks do
       migrate
       task.reload
 
-      expect(task.options).to eq({ :dummy_key => 'dummy_value' })
+      expect(task.options).to eq(:dummy_key => 'dummy_value')
       expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => conversion_host_id)).to be_nil
       expect(task.conversion_host).to be_nil
     end
@@ -33,7 +33,7 @@ describe AddConversionHostIdToMiqRequestTasks do
       migrate
       task.reload
 
-      expect(task.options).to eq({ :dummy_key => 'dummy_value' })
+      expect(task.options).to eq(:dummy_key => 'dummy_value')
       expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host)).not_to be_nil
       expect(task.conversion_host).to eq(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host))
     end

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -4,19 +4,34 @@ describe AddConversionHostIdToMiqRequestTasks do
   let(:task_stub) { migration_stub(:MiqRequestTask) }
   let(:host_stub) { migration_stub(:Host) }
   let(:conversion_host_stub) { migration_stub(:ConversionHost) }
+  let(:host_id) { 42 }
 
   migration_context :up do
-    it "creates conversion host" do
-      host = host_stub.create!
+    it "when host doesn't exist" do
       task = task_stub.create!(
         :type    => 'ServiceTemplateTransformationPlanTask',
-        :options => { :transformation_host_id => host.id }
+        :options => { :dummy_key => 'dummy_value', :transformation_host_id => host_id }
       )
 
       migrate
-
       task.reload
-      expect(task.options).to eq({})
+
+      expect(task.options).to eq({ :dummy_key => 'dummy_value', :transformation_host_id => host_id })
+      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => host_id)).to be_nil
+      expect(task.conversion_host).to be_nil
+    end
+
+    it "when host exist" do
+      task = task_stub.create!(
+        :type    => 'ServiceTemplateTransformationPlanTask',
+        :options => { :dummy_key => 'dummy_value', :transformation_host_id => host_id }
+      )
+      host = host_stub.create!(:id => host_id)
+
+      migrate
+      task.reload
+
+      expect(task.options).to eq({ :dummy_key => 'dummy_value' })
       expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host)).not_to be_nil
       expect(task.conversion_host).to eq(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host))
     end
@@ -25,9 +40,7 @@ describe AddConversionHostIdToMiqRequestTasks do
   migration_context :down do
     it "updates task.options" do
       host = host_stub.create!
-      conversion_host = conversion_host_stub.create!(
-        :resource => host
-      )
+      conversion_host = conversion_host_stub.create!(:resource => host)
       task = task_stub.create!(
         :type            => 'ServiceTemplateTransformationPlanTask',
         :conversion_host => conversion_host

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -1,0 +1,47 @@
+require_migration
+
+describe AddConversionHostIdToMiqRequestTasks do
+  let(:task_stub) { migration_stub(:MiqRequestTask) }
+  let(:host_stub) { migration_stub(:Host) }
+  let(:conversion_host_stub) { migration_stub(:ConversionHost) }
+
+  migration_context :up do
+    it "creates conversion host" do
+      task = task_stub.create!
+      host = host_stub.create!
+      conversion_host = conversion_host_stub.create!(
+        :resource_id   => host.id,
+        :resource_type => host.type
+      )
+      task.options = { :transformation_host_id => conversion_host.id }
+      task.save
+
+      migrate
+
+      task.reload
+      expect(task.options).to eq({})
+      expect(task.conversion_host).to eq(conversion_host)
+    end
+  end
+
+  migration_context :down do
+    it "updates task.options" do
+      task = task_stub.create!
+      host = host_stub.create!
+      conversion_host = conversion_host_stub.create!(
+        :resource_id   => host.id,
+        :resource_type => host.type
+      )
+      conversion_host.save
+      task.conversion_host = conversion_host
+      task.save
+
+      migrate
+
+      task.reload
+      expect(task.attributes).not_to include('conversion_host_id')
+      expect(task.options[:transformation_host_id]).to eq(conversion_host.id)
+      expect { conversion_host.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -17,8 +17,8 @@ describe AddConversionHostIdToMiqRequestTasks do
 
       task.reload
       expect(task.options).to eq({})
-      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => host.id)).not_to be_nil
-      expect(task.conversion_host).to eq(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource_id => host.id))
+      expect(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host)).not_to be_nil
+      expect(task.conversion_host).to eq(AddConversionHostIdToMiqRequestTasks::ConversionHost.find_by(:resource => host))
     end
   end
 
@@ -26,8 +26,7 @@ describe AddConversionHostIdToMiqRequestTasks do
     it "updates task.options" do
       host = host_stub.create!
       conversion_host = conversion_host_stub.create!(
-        :resource_id   => host.id,
-        :resource_type => host.type
+        :resource => host
       )
       task = task_stub.create!(
         :type            => 'ServiceTemplateTransformationPlanTask',


### PR DESCRIPTION
The `ServiceTemplateTransformationPlanTask` class relies on a conversion host to actually run the migration. The conversion host is modeled in `ConversionHost` class. From a database point of view, the `ServiceTemplateTransformationPlanTask` class is stored in `miq_request_tasks` table, because it's a sub-sub-class of `MiqRequestTask`. This PR adds a `conversion_host_id` column to `miq_request_tasks` to set the relationship.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029