### PR TITLE
Index vms also by `vm.uid_ems` field to speedup query

### DIFF
--- a/db/migrate/20181002145147_add_index_for_uid_ems_on_vm.rb
+++ b/db/migrate/20181002145147_add_index_for_uid_ems_on_vm.rb
@@ -1,0 +1,5 @@
+class AddIndexForUidEmsOnVm < ActiveRecord::Migration[5.0]
+  def change
+    add_index :vms, :uid_ems
+  end
+end


### PR DESCRIPTION
With this commit we do nothing but add another index to the vms because Nuage cross-connecting needs to cherry-pick vms by this specific filed, which is not indexed so far:

```
vm.uid_ems
```
Related: https://github.com/ManageIQ/manageiq-providers-nuage/pull/150
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1635232

@miq-bot add_label enhancement,hammer/yes
@miq-bot assign @agrare

/cc @Ladas 