### PR TITLE
Add Total Space column to Physical Storages

### DIFF
--- a/db/migrate/20181002123523_add_total_space_to_physical_storages.rb
+++ b/db/migrate/20181002123523_add_total_space_to_physical_storages.rb
@@ -1,0 +1,5 @@
+class AddTotalSpaceToPhysicalStorages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_storages, :total_space, :bigint
+  end
+end


### PR DESCRIPTION
This PR is able to add a new column called `total_space` that will be useful to store this information extracted from all `PhysicalDisks` inside the physical storage.