### PR TITLE
Fix invalid conversion host resource type

### DIFF
--- a/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
+++ b/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
@@ -1,6 +1,8 @@
 class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
   class MiqRequestTask < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
+    include ActiveRecord::IdRegions
+
     serialize :options, Hash
     belongs_to :conversion_host, :class_name => "AddConversionHostIdToMiqRequestTasks::ConversionHost"
   end
@@ -17,7 +19,7 @@ class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
   def up
     add_column :miq_request_tasks, :conversion_host_id, :bigint
 
-    MiqRequestTask.where(:type => 'ServiceTemplateTransformationPlanTask').each do |task|
+    MiqRequestTask.in_my_region.where(:type => 'ServiceTemplateTransformationPlanTask').find_each do |task|
       host_id = task.options.delete(:transformation_host_id)
       next unless host_id
       host = Host.find_by(:id => host_id)
@@ -33,12 +35,13 @@ class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
   end
 
   def down
-    conversion_host_ids = MiqRequestTask.where(:type => 'ServiceTemplateTransformationPlanTask').map do |task|
+    conversion_host_ids = MiqRequestTask.in_my_region.where(:type => 'ServiceTemplateTransformationPlanTask').map do |task|
       next if task.conversion_host.nil?
       task.options[:transformation_host_id] = task.conversion_host.resource.id
       task.save!
       task.conversion_host.id
     end.uniq.compact
+
     ConversionHost.destroy(conversion_host_ids)
 
     remove_column :miq_request_tasks, :conversion_host_id

--- a/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
+++ b/db/migrate/20181001131632_add_conversion_host_id_to_miq_request_tasks.rb
@@ -35,14 +35,16 @@ class AddConversionHostIdToMiqRequestTasks < ActiveRecord::Migration[5.0]
   end
 
   def down
-    conversion_host_ids = MiqRequestTask.in_my_region.where(:type => 'ServiceTemplateTransformationPlanTask').map do |task|
+    conversion_host_ids = []
+    MiqRequestTask.in_my_region.where(:type => 'ServiceTemplateTransformationPlanTask').find_each do |task|
       next if task.conversion_host.nil?
       task.options[:transformation_host_id] = task.conversion_host.resource.id
       task.save!
-      task.conversion_host.id
-    end.uniq.compact
 
-    ConversionHost.destroy(conversion_host_ids)
+      conversion_host_ids << task.conversion_host.id
+    end
+
+    ConversionHost.destroy(conversion_host_ids.uniq.compact)
 
     remove_column :miq_request_tasks, :conversion_host_id
   end

--- a/db/migrate/20181002192054_fix_conversion_host_resource_type.rb
+++ b/db/migrate/20181002192054_fix_conversion_host_resource_type.rb
@@ -1,0 +1,14 @@
+class FixConversionHostResourceType < ActiveRecord::Migration[5.0]
+  class ConversionHost < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    say_with_time("Converting invalid resource_type to Host") do
+      ConversionHost.in_my_region
+                    .where(:resource_type => "AddConversionHostIdToMiqRequestTasks::Host")
+                    .update_all(:resource_type => "Host")
+    end
+  end
+end

--- a/spec/migrations/20181002192054_fix_conversion_host_resource_type_spec.rb
+++ b/spec/migrations/20181002192054_fix_conversion_host_resource_type_spec.rb
@@ -1,0 +1,44 @@
+require_migration
+
+class FixConversionHostResourceType < ActiveRecord::Migration[5.0]
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Vm < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+end
+
+describe FixConversionHostResourceType do
+  let(:conversion_host_stub) { migration_stub(:ConversionHost) }
+  let(:host_stub)            { migration_stub(:Host) }
+  let(:vm_stub)              { migration_stub(:Vm) }
+  let(:conversion_host)      { conversion_host_stub.create! }
+  let(:host)                 { host_stub.create! }
+  let(:vm)                   { vm_stub.create! }
+
+  migration_context :up do
+    it "Updates invalid resource_types" do
+      conversion_host.update_attributes!(
+        :resource_id   => host.id,
+        :resource_type => "AddConversionHostIdToMiqRequestTasks::Host"
+      )
+
+      migrate
+
+      expect(conversion_host.reload.resource_type).to eq("Host")
+    end
+
+    it "Doesn't update valid resource_types" do
+      conversion_host.update_attributes!(
+        :resource_id   => vm.id,
+        :resource_type => "Vm"
+      )
+
+      migrate
+
+      expect(conversion_host.reload.resource_type).to eq("Vm")
+    end
+  end
+end


### PR DESCRIPTION
Fix an invalid polymorphic resource_type from
https://github.com/ManageIQ/manageiq-schema/pull/281 which resulted in
the type being "AddConversionHostIdToMiqRequestTasks::Host" instead of
"Host".