### PR TITLE
Add ID references to PhysicalDisks and Canisters

### DIFF
--- a/db/migrate/20181003122633_add_canister_id_and_ems_ref_to_physical_disks.rb
+++ b/db/migrate/20181003122633_add_canister_id_and_ems_ref_to_physical_disks.rb
@@ -1,0 +1,6 @@
+class AddCanisterIdAndEmsRefToPhysicalDisks < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :physical_disks, :canister, :type => :bigint
+    add_column :physical_disks, :ems_ref, :string
+  end
+end


### PR DESCRIPTION
This PR is able to:
- Add Canister reference into PhysicalDisks
- Add `ems_ref` to PhysicalDisks