### PR TITLE
Add tenant_id to miq_product_features

### DIFF
--- a/db/migrate/20181023171353_add_tenant_id_and_tenant_node_to_miq_product_features.rb
+++ b/db/migrate/20181023171353_add_tenant_id_and_tenant_node_to_miq_product_features.rb
@@ -1,0 +1,5 @@
+class AddTenantIdAndTenantNodeToMiqProductFeatures < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :miq_product_features, :tenant, :type => :bigint, :index => true
+  end
+end


### PR DESCRIPTION
issue https://github.com/ManageIQ/manageiq/issues/18100

tenant_id establish relation between dynamic product features and tenants

from MiqUserRole:
![screenshot 2018-10-24 at 16 39 43](https://user-images.githubusercontent.com/14937244/47439135-20d55a00-d7ac-11e8-84e5-9c3e77a49a0d.png)

cc @gtanzillo 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1297415