### PR TITLE
[WIP] Add a data migration for orch stacks to have direct ownership concept

### DIFF
--- a/db/migrate/20181016135519_migrate_orch_stacks_to_have_ownership_concept.rb
+++ b/db/migrate/20181016135519_migrate_orch_stacks_to_have_ownership_concept.rb
@@ -1,0 +1,23 @@
+class MigrateOrchStacksToHaveOwnershipConcept < ActiveRecord::Migration[5.0]
+  def up
+    say_with_time("Migrating existing orchestration stacks to have direct owners, groups, tenant") do
+      OrchestrationStack.all.select { |os| os.ems_id.present? }.each do |os|
+        os.evm_owner_id = o.ext_management_system.tenant_identity
+        os.tenant_id = o.ext_management_system.tenant_identity.current_tenant.id
+        os.group_id = o.ext_management_system.tenant_identity.current_group.id
+      end
+
+      OrchestrationStack.all.select { |os| os.ems_id.nil? }.each do |os|
+        # if orch stack has no ems, can we even set any of this stuff?
+      end
+    end
+  end
+
+  def down
+    OrchestrationStack.all.each do |os|
+      os.evm_owner_id = nil
+      os.tenant_id = nil
+      os.group_id = nil
+    end
+  end
+end


### PR DESCRIPTION
@tinaafitz this is silly. 

Orch stacks should have owners and tenants and groups just like services n vms so when we retire them the stack has some concept of who owns the request.

WIP cause questions in PR and needs tests n stuff

Related to https://github.com/ManageIQ/manageiq-schema/pull/288 and https://github.com/ManageIQ/manageiq/pull/17951
