### PR TITLE
[WIP] Switch ems_ref column to citext type

### DIFF
--- a/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
+++ b/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
@@ -1,0 +1,6 @@
+class ChangeEmsRefToCaseInsensitive < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension :citext
+    change_column :vms, :emsref, :citext
+  end
+end

--- a/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
+++ b/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
@@ -1,6 +1,10 @@
 class ChangeEmsRefToCaseInsensitive < ActiveRecord::Migration[5.0]
-  def change
+  def up
     enable_extension :citext
     change_column :vms, :ems_ref, :citext
+  end
+
+  def down
+    disable_extension :citext
   end
 end

--- a/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
+++ b/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
@@ -1,10 +1,38 @@
 class ChangeEmsRefToCaseInsensitive < ActiveRecord::Migration[5.0]
   def up
     enable_extension :citext
+    change_column :availability_zones, :ems_ref, :citext
+    change_column :cloud_networks, :ems_ref, :citext
+    change_column :cloud_subnets, :ems_ref, :citext
+    change_column :cloud_volumes, :ems_ref, :citext
+    change_column :flavors, :ems_ref, :citext
+    change_column :floating_ips, :ems_ref, :citext
+    change_column :load_balancers, :ems_ref, :citext
+    change_column :load_balancer_health_checks, :ems_ref, :citext
+    change_column :load_balancer_listeners, :ems_ref, :citext
+    change_column :load_balancer_pools, :ems_ref, :citext
+    change_column :load_balancer_pool_members, :ems_ref, :citext
+    change_column :network_groups, :ems_ref, :citext
+    change_column :network_ports, :ems_ref, :citext
+    change_column :network_routers, :ems_ref, :citext
     change_column :vms, :ems_ref, :citext
   end
 
   def down
-    disable_extension :citext
+    change_column :availability_zones, :ems_ref, :text
+    change_column :cloud_networks, :ems_ref, :text
+    change_column :cloud_subnets, :ems_ref, :text
+    change_column :cloud_volumes, :ems_ref, :text
+    change_column :flavors, :ems_ref, :text
+    change_column :floating_ips, :ems_ref, :text
+    change_column :load_balancers, :ems_ref, :text
+    change_column :load_balancer_health_checks, :ems_ref, :text
+    change_column :load_balancer_listeners, :ems_ref, :text
+    change_column :load_balancer_pools, :ems_ref, :text
+    change_column :load_balancer_pool_members, :ems_ref, :text
+    change_column :network_groups, :ems_ref, :text
+    change_column :network_ports, :ems_ref, :text
+    change_column :network_routers, :ems_ref, :text
+    change_column :vms, :ems_ref, :text
   end
 end

--- a/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
+++ b/db/migrate/20181024204639_change_ems_ref_to_case_insensitive.rb
@@ -1,6 +1,6 @@
 class ChangeEmsRefToCaseInsensitive < ActiveRecord::Migration[5.0]
   def change
     enable_extension :citext
-    change_column :vms, :emsref, :citext
+    change_column :vms, :ems_ref, :citext
   end
 end


### PR DESCRIPTION
We've occasionally run into issues for the Azure provider with upper vs lowercase for the `ems_ref` column. It struck me that we should not really care about case for what is essentially a unique identifier that will never have "duplicates" that differ only via case (will we?).

For now I've only selected the tables that most directly the Azure provider.

Why not redefine `ems_ref=` on the provider side so that it automatically downcases everything? Short answer, batch saving. @Ladas please correct me if I'm wrong here.

Questions: should we index the column in the up method? Do they need to be reindexed in the down method? Which other tables would we want to modify? What about tables that don't have an ems_ref column, e.g. disks? Is the performance hit significant vs a bunch of `.downcase` calls on the Ruby side that we would avoid?