### PR TITLE
Create report types

### DIFF
--- a/db/migrate/20181107164348_create_report_type.rb
+++ b/db/migrate/20181107164348_create_report_type.rb
@@ -1,0 +1,11 @@
+class CreateReportType < ActiveRecord::Migration[5.0]
+  def change
+    create_table :report_types do |t|
+      t.string :name
+      t.belongs_to :resource, :polymorphic => true, :type => :bigint
+      t.timestamps
+    end
+
+    add_index :report_types, [:resource_id, :resource_type]
+  end
+end


### PR DESCRIPTION
alternative of https://github.com/ManageIQ/manageiq-schema/pull/209:

Taken  from @hstastna's description:
**What:**
We need to store the type of the Rate which is related to type of Report: Chargeback for VMs/Images/Projects.

**Why:**
We need it for adding new drop down to editing screen for Rate to be able to choose the type of the rate and then to display only appropriate columns of the rate, based on the chosen type of the rate (VMs, Images, Projects).

I added selected option 2 https://github.com/ManageIQ/manageiq-schema/pull/209#issuecomment-411702444 option after our discussion.

The only difference is that I created more general table `ReportType` - even If I don't have other use case at this moment.

ReportType is new one.
<img width="1005" alt="screenshot 2018-11-14 at 19 54 55" src="https://user-images.githubusercontent.com/14937244/48505646-d6457b80-e847-11e8-92bf-d2409b90ea8d.png">

cc @gtanzillo @carbonin @hstastna 

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1581817
