### PR TITLE
Default VM connection_state is now 'connected'

### DIFF
--- a/db/migrate/20181119154009_set_vm_connection_state.rb
+++ b/db/migrate/20181119154009_set_vm_connection_state.rb
@@ -1,0 +1,14 @@
+class SetVmConnectionState < ActiveRecord::Migration[4.2]
+  class VmOrTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+    self.table_name = 'vms'
+  end
+
+  def up
+    say_with_time('Filling nil connection_state to "connected"') do
+      VmOrTemplate.in_my_region.where(:connection_state => nil).update_all(:connection_state => 'connected')
+    end
+  end
+end

--- a/spec/migrations/20181119154009_set_vm_connection_state_spec.rb
+++ b/spec/migrations/20181119154009_set_vm_connection_state_spec.rb
@@ -1,0 +1,26 @@
+require_migration
+
+describe SetVmConnectionState do
+  let(:vm_stub)          { migration_stub(:VmOrTemplate) }
+  let!(:vm)              { vm_stub.create!(:connection_state => connection_state) }
+  let(:connection_state) { nil }
+
+  migration_context :up do
+    context 'connection_state is nil' do
+      it 'flips to "connected"' do
+        migrate
+        vm.reload
+        expect(vm.connection_state).to eq('connected')
+      end
+    end
+
+    context 'vm is disconnected' do
+      let(:connection_state) { 'disconnected' }
+      it 'disconnected stays disconnected' do
+        migrate
+        vm.reload
+        expect(vm.connection_state).to eq(connection_state)
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this commit we migrate all occurances of

```
vm.connection_state == nil
```

to now contain 'connected' instead nil.

@miq-bot assign @agrare 

/cc @kbrock 