### PR TITLE
classification#parent_id = nil when no parents

### DIFF
--- a/db/migrate/20181130203334_classification_parent_null.rb
+++ b/db/migrate/20181130203334_classification_parent_null.rb
@@ -1,0 +1,14 @@
+class ClassificationParentNull < ActiveRecord::Migration[5.0]
+  class Classification < ActiveRecord::Base
+  end
+
+  def up
+    change_column_default(:classifications, :parent_id, nil)
+    Classification.where(:parent_id => 0).update_all(:parent_id => nil)
+  end
+
+  def down
+    change_column_default(:classifications, :parent_id, 0)
+    Classification.where(:parent_id => nil).update_all(:parent_id => 0)
+  end
+end

--- a/spec/migrations/20181130203334_classification_parent_null_spec.rb
+++ b/spec/migrations/20181130203334_classification_parent_null_spec.rb
@@ -1,0 +1,30 @@
+require_migration
+
+describe ClassificationParentNull do
+  let(:classification_stub) { migration_stub(:Classification) }
+
+  migration_context :up do
+    it 'changes parent to nil when parent is 0' do
+      c = classification_stub.create(:parent_id => 0)
+      migrate
+      c.reload
+      expect(c.parent_id).to be_nil
+    end
+
+    it 'leaves other parents alone' do
+      c = classification_stub.create(:parent_id => 1)
+      migrate
+      c.reload
+      expect(c.parent_id).to eq(1)
+    end
+  end
+
+  migration_context :down do
+    it 'changes parent to 0 when parent is null' do
+      c = classification_stub.create(:parent_id => nil)
+      migrate
+      c.reload
+      expect(c.parent_id).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
We used to have parent_id=0 when there was no parent.
Rails prefers to use a nil

This is in response to @Fryguy comment in ManageIQ/manageiq#17210