### PR TITLE
Remove worker rows referencing a renamed worker

### DIFF
--- a/db/migrate/20181203224640_remove_renamed_ansible_tower_configuration_manager_refresh_worker_rows.rb
+++ b/db/migrate/20181203224640_remove_renamed_ansible_tower_configuration_manager_refresh_worker_rows.rb
@@ -1,0 +1,10 @@
+class RemoveRenamedAnsibleTowerConfigurationManagerRefreshWorkerRows < ActiveRecord::Migration[5.0]
+  class MiqWorker < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    # Was renamed to ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker in 2f0ef1a90758f2
+    MiqWorker.where(:type => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker").delete_all
+  end
+end

--- a/spec/migrations/20181203224640_remove_renamed_ansible_tower_configuration_manager_refresh_worker_rows_spec.rb
+++ b/spec/migrations/20181203224640_remove_renamed_ansible_tower_configuration_manager_refresh_worker_rows_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe RemoveRenamedAnsibleTowerConfigurationManagerRefreshWorkerRows do
+  migration_context :up do
+    let(:miq_worker) { migration_stub(:MiqWorker) }
+
+    it "deletes ansible tower configuration manager refresh workers" do
+      miq_worker.create!(:type => "MiqWorker")
+      miq_worker.create!(:type => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker")
+
+      migrate
+
+      expect(miq_worker.count).to      eq(1)
+      expect(miq_worker.first.type).to eq("MiqWorker")
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1655794

The worker was renamed in
https://github.com/ManageIQ/manageiq/commit/2f0ef1a90758f2b5c37e93a0ed2f586a916dad64