### PR TITLE
Rename WebsocketWorker to RemoteConsoleWorker

### DIFF
--- a/db/migrate/20190108135546_rename_websocket_to_remote_console.rb
+++ b/db/migrate/20190108135546_rename_websocket_to_remote_console.rb
@@ -1,0 +1,61 @@
+class RenameWebsocketToRemoteConsole < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base; end
+
+  class ServerRole < ActiveRecord::Base; end
+
+  class MiqWorker < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    rename_column :miq_servers, :has_active_websocket, :has_active_remote_console
+
+    say_with_time("Renaming the websocket server role to remote_console") do
+      ServerRole.where(:name => 'websocket').update(:name => 'remote_console', :description => "Remote Consoles")
+    end
+
+    say_with_time("Renaming the /log/level_websocket key to /log/level_remote_console in SettingsChange") do
+      SettingsChange.where(:key => '/log/level_websocket').update(:key => '/log/level_remote_console')
+    end
+
+    say_with_time("Renaming all websocket_worker related SettingsChange keys to remote_console_worker") do
+      SettingsChange.where("key LIKE '/workers/worker_base/websocket_worker/%'").select('id, key').each do |row|
+        row.update(:key => row.key.sub('websocket_worker', 'remote_console_worker'))
+      end
+    end
+
+    say_with_time("Renaming all websocket server role SettingsChange records to remote_console") do
+      SettingsChange.where("key = '/server/role' AND value LIKE '%websocket%'").select('id', 'value').each do |row|
+        row.update(:value => row.value.sub('websocket', 'remote_console'))
+      end
+    end
+
+    say_with_time("Removing all MiqWorker records related to WebsocketWorker instances") do
+      MiqWorker.where(:type => 'MiqWebsocketWorker').delete_all
+    end
+  end
+
+  def down
+    rename_column :miq_servers, :has_active_remote_console, :has_active_websocket
+
+    say_with_time("Renaming the remote_console server role to websocket") do
+      ServerRole.where(:name => 'remote_console').update(:name => 'websocket', :description => "Websocket")
+    end
+
+    say_with_time("Renaming the /log/level_remote_console key to /log/level_websocket in SettingsChange") do
+      SettingsChange.where(:key => '/log/level_remote_console').update(:key => '/log/level_websocket')
+    end
+
+    say_with_time("Renaming all remote_console_worker related SettingsChange keys to websocket_worker") do
+      SettingsChange.where("key LIKE '/workers/worker_base/remote_console_worker/%'").select('id, key').each do |row|
+        row.update(:key => row.key.sub('remote_console_worker', 'websocket_worker'))
+      end
+    end
+
+    say_with_time("Renaming all remote_console server role SettingsChange records to websocket") do
+      SettingsChange.where("key = '/server/role' AND value LIKE '%remote_console%'").select('id', 'value').each do |row|
+        row.update(:value => row.value.sub('remote_console', 'websocket'))
+      end
+    end
+  end
+end

--- a/spec/migrations/20190108135546_rename_websocket_to_remote_console_spec.rb
+++ b/spec/migrations/20190108135546_rename_websocket_to_remote_console_spec.rb
@@ -1,0 +1,77 @@
+require_migration
+
+describe RenameWebsocketToRemoteConsole do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "converts the server roles" do
+      setting_changed = settings_change_stub.create!(:key => "/server/role", :value => "database,websocket,reporting")
+      setting_ignored = settings_change_stub.create!(:key => "/server/role", :value => "database,reporting")
+
+      migrate
+
+      expect(setting_changed.reload.value).to eq("database,remote_console,reporting")
+      expect(setting_ignored.reload.value).to eq("database,reporting")
+    end
+
+    it "converts the log levels" do
+      setting_changed = settings_change_stub.create!(:key => "/log/level_websocket", :value => "foo")
+      setting_ignored = settings_change_stub.create!(:key => "/log/level_api", :value => "bar")
+
+      migrate
+
+      expect(setting_changed.reload.key).to eq("/log/level_remote_console")
+      expect(setting_changed.value).to eq("foo")
+      expect(setting_ignored.reload.key).to eq("/log/level_api")
+      expect(setting_ignored.value).to eq("bar")
+    end
+
+    it "converts the worker settings" do
+      setting_changed = settings_change_stub.create!(:key => "/workers/worker_base/websocket_worker/anything", :value => "foo")
+      setting_ignored = settings_change_stub.create!(:key => "/workers/worker_base/sleepy_worker", :value => "bar")
+
+      migrate
+
+      expect(setting_changed.reload.key).to eq("/workers/worker_base/remote_console_worker/anything")
+      expect(setting_changed.value).to eq("foo")
+      expect(setting_ignored.reload.key).to eq("/workers/worker_base/sleepy_worker")
+      expect(setting_ignored.value).to eq("bar")
+    end
+  end
+
+  migration_context :down do
+    it "converts the server roles" do
+      setting_changed = settings_change_stub.create!(:key => "/server/role", :value => "database,remote_console,reporting")
+      setting_ignored = settings_change_stub.create!(:key => "/server/role", :value => "database,reporting")
+
+      migrate
+
+      expect(setting_changed.reload.value).to eq("database,websocket,reporting")
+      expect(setting_ignored.reload.value).to eq("database,reporting")
+    end
+
+    it "converts the log levels" do
+      setting_changed = settings_change_stub.create!(:key => "/log/level_remote_console", :value => "foo")
+      setting_ignored = settings_change_stub.create!(:key => "/log/level_api", :value => "bar")
+
+      migrate
+
+      expect(setting_changed.reload.key).to eq("/log/level_websocket")
+      expect(setting_changed.value).to eq("foo")
+      expect(setting_ignored.reload.key).to eq("/log/level_api")
+      expect(setting_ignored.value).to eq("bar")
+    end
+
+    it "converts the worker settings" do
+      setting_changed = settings_change_stub.create!(:key => "/workers/worker_base/remote_console_worker/anything", :value => "foo")
+      setting_ignored = settings_change_stub.create!(:key => "/workers/worker_base/sleepy_worker", :value => "bar")
+
+      migrate
+
+      expect(setting_changed.reload.key).to eq("/workers/worker_base/websocket_worker/anything")
+      expect(setting_changed.value).to eq("foo")
+      expect(setting_ignored.reload.key).to eq("/workers/worker_base/sleepy_worker")
+      expect(setting_ignored.value).to eq("bar")
+    end
+  end
+end


### PR DESCRIPTION
Renaming both the role and the worker, dropping old workers from the DB.

Parent issue: https://github.com/ManageIQ/manageiq/issues/18300
Core PR: https://github.com/ManageIQ/manageiq/pull/18337

@miq-bot add_label hammer/no