### PR TITLE
Removes OpenStack Cinder event Worker Rows

### DIFF
--- a/db/migrate/20190108163812_remove_cinder_manager_event_worker_rows.rb
+++ b/db/migrate/20190108163812_remove_cinder_manager_event_worker_rows.rb
@@ -1,0 +1,11 @@
+class RemoveCinderManagerEventWorkerRows < ActiveRecord::Migration[5.0]
+  class MiqWorker < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    # ManageIQ::Providers::StorageManager::CinderManager::EventCatcher was removed in 772bdc283360e99f9cf2209184297d1827f3a9e6
+    # https://github.com/ManageIQ/manageiq/pull/14962
+    MiqWorker.where(:type => "ManageIQ::Providers::StorageManager::CinderManager::EventCatcher").delete_all
+  end
+end

--- a/spec/migrations/20190108163812_remove_cinder_manager_event_worker_rows_spec.rb
+++ b/spec/migrations/20190108163812_remove_cinder_manager_event_worker_rows_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe RemoveCinderManagerEventWorkerRows do
+  migration_context :up do
+    let(:miq_worker) { migration_stub(:MiqWorker) }
+
+    it "deletes Openstack Cinder event workers" do
+      miq_worker.create!(:type => "MiqWorker")
+      miq_worker.create!(:type => "ManageIQ::Providers::StorageManager::CinderManager::EventCatcher")
+
+      migrate
+
+      expect(miq_worker.count).to      eq(1)
+      expect(miq_worker.first.type).to eq("MiqWorker")
+    end
+  end
+end


### PR DESCRIPTION
Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1661957

Cinder Event Catcher was removed in
https://github.com/ManageIQ/manageiq/pull/14962