### PR TITLE
[WIP] Add cache columns to operating_systems table

### DIFF
--- a/db/migrate/20190108031411_add_image_name_to_operating_systems.rb
+++ b/db/migrate/20190108031411_add_image_name_to_operating_systems.rb
@@ -1,0 +1,159 @@
+class AddImageNameToOperatingSystems < ActiveRecord::Migration[5.0]
+  include MigrationHelper
+
+  StubOperatingSystemObj = Struct.new(:operating_system) do
+    attr_reader :hardware # always nil
+    def name
+      ""
+    end
+  end
+
+  class OperatingSystem < ActiveRecord::Base
+    belongs_to :host
+    belongs_to :vm_or_template
+    belongs_to :computer_system
+
+    # Using a `before_save` here since this is the mechanism that will be used
+    # in the app.  Causes a bit of issues in the specs, but proves that this
+    # would work moving forward.
+    before_save :update_platform_and_image_name
+
+    def update_platform_and_image_name
+      obj = case # rubocop:disable Style/EmptyCaseCondition
+            when host_id            then host
+            when vm_or_template_id  then vm_or_template
+            when computer_system_id then computer_system
+            else
+              StubOperatingSystemObj.new(self)
+            end
+
+      if obj
+        self.image_name = self.class.image_name(obj)
+        self.platform   = self.image_name.split("_").first # rubocop:disable Style/RedundantSelf
+      end
+    end
+
+    # rubocop:disable Style/PercentLiteralDelimiters
+    @@os_map = [ # rubocop:disable Style/ClassVars
+      ["windows_generic", %w(winnetenterprise w2k3 win2k3 server2003 winnetstandard servernt)],
+      ["windows_generic", %w(winxppro winxp)],
+      ["windows_generic", %w(vista longhorn)],
+      ["windows_generic", %w(win2k win2000)],
+      ["windows_generic", %w(microsoft windows winnt)],
+      ["linux_ubuntu",    %w(ubuntu)],
+      ["linux_chrome",    %w(chromeos)],
+      ["linux_chromium",  %w(chromiumos)],
+      ["linux_suse",      %w(suse sles)],
+      ["linux_redhat",    %w(redhat rhel)],
+      ["linux_fedora",    %w(fedora)],
+      ["linux_gentoo",    %w(gentoo)],
+      ["linux_centos",    %w(centos)],
+      ["linux_debian",    %w(debian)],
+      ["linux_coreos",    %w(coreos)],
+      ["linux_esx",       %w(vmnixx86 vmwareesxserver esxserver vmwareesxi)],
+      ["linux_solaris",   %w(solaris)],
+      ["linux_generic",   %w(linux)]
+    ]
+    # rubocop:enable Style/PercentLiteralDelimiters
+
+    # rubocop:disable Naming/VariableName
+    def self.normalize_os_name(osName) # rubocop:disable Naming/UncommunicativeMethodParamName
+      findStr = osName.downcase.gsub(/[^a-z0-9]/, "")
+      @@os_map.each do |a|
+        a[1].each do |n|
+          return a[0] unless findStr.index(n).nil?
+        end
+      end
+      "unknown"
+    end
+    # rubocop:enable Naming/VariableName
+
+    # rubocop:disable Naming/VariableName
+    def self.image_name(obj)
+      osName = nil
+
+      # Select most accurate name field
+      os = obj.operating_system
+      if os
+        # check the given field names for possible matching value
+        osName = [:distribution, :product_type, :product_name].each do |field|
+          os_field = os.send(field)
+          break(os_field) if os_field && OperatingSystem.normalize_os_name(os_field) != "unknown"
+        end
+
+        # If the normalized name comes back as unknown, nil out the value so we can get it from another field
+        if osName.kind_of?(String)
+          osName = nil if OperatingSystem.normalize_os_name(osName) == "unknown"
+        else
+          osName = nil
+        end
+      end
+
+      # If the OS Name is still blank check the 'user_assigned_os'
+      if osName.nil? && obj.respond_to?(:user_assigned_os) && obj.user_assigned_os
+        osName = obj.user_assigned_os
+      end
+
+      # If the OS Name is still blank check the hardware table
+      if osName.nil? && obj.hardware && !obj.hardware.guest_os.nil?
+        osName = obj.hardware.guest_os
+        # if we get generic linux or unknown back see if the vm name is better
+        norm_os = OperatingSystem.normalize_os_name(osName)
+        if norm_os == "linux_generic" || norm_os == "unknown" # rubocop:disable Style/MultipleComparison
+          vm_name = OperatingSystem.normalize_os_name(obj.name)
+          return vm_name unless vm_name == "unknown"
+        end
+      end
+
+      # If the OS Name is still blank use the name field from the object given
+      osName = obj.name if osName.nil? && obj.respond_to?(:name)
+
+      # Normalize name to match existing icons
+      OperatingSystem.normalize_os_name(osName || "")
+    end
+    # rubocop:enable Naming/VariableName
+  end
+
+  class VmOrTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    self.table_name = 'vms'
+
+    has_one :operating_system
+    has_one :hardware
+  end
+
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    has_one :operating_system
+    has_one :hardware
+  end
+
+  class ComputerSystem < ActiveRecord::Base
+    has_one :operating_system
+    has_one :hardware
+  end
+
+  class Hardware < ActiveRecord::Base
+  end
+
+  def up
+    add_column :operating_systems, :platform,   :string
+    add_column :operating_systems, :image_name, :string
+
+    say_with_time("Updating platform and image_name in OperatingSystems") do
+      base_relation = OperatingSystem.all
+      say_batch_started(base_relation.size)
+
+      base_relation.find_in_batches do |group|
+        group.each(&:save)
+        say_batch_processed(group.count)
+      end
+    end
+  end
+
+  def down
+    remove_column :operating_systems, :platform,   :string
+    remove_column :operating_systems, :image_name, :string
+  end
+end

--- a/spec/migrations/20190108031411_add_image_name_to_operating_systems_spec.rb
+++ b/spec/migrations/20190108031411_add_image_name_to_operating_systems_spec.rb
@@ -1,0 +1,159 @@
+require_migration
+
+describe AddImageNameToOperatingSystems do
+  let(:host_stub)             { migration_stub(:Host) }
+  let(:hardware_stub)         { migration_stub(:Hardware) }
+  let(:vm_or_template_stub)   { migration_stub(:VmOrTemplate) }
+  let(:computer_system_stub)  { migration_stub(:ComputerSystem) }
+  let(:operating_system_stub) { migration_stub(:OperatingSystem) }
+
+  # rubocop:disable Layout/SpaceInsideArrayPercentLiteral
+  let(:test_os_values) do
+    [
+      %w[an_amazing_undiscovered_os unknown],
+      %w[centos-7                   linux_centos],
+      %w[debian-8                   linux_debian],
+      %w[opensuse-13                linux_suse],
+      %w[sles-12                    linux_suse],
+      %w[rhel-7                     linux_redhat],
+      %w[ubuntu-15-10               linux_ubuntu],
+      %w[windows-2012-r2            windows_generic],
+      %w[vmnix-x86                  linux_esx],
+      %w[vista                      windows_generic],
+      %w[coreos-cloud               linux_coreos]
+    ]
+  end
+  # rubocop:enable Layout/SpaceInsideArrayPercentLiteral
+
+  def record_with_os(klass, os_attributes = nil, record_attributes = {:name => ""}, hardware_attributes = nil)
+    os_record = operating_system_stub.new(os_attributes) if os_attributes
+
+    if klass == operating_system_stub
+      os_record.save!
+      os_record
+    else
+      record = klass.new
+      record_attributes.each do |attr, val|
+        record.send("#{attr}=", val) if record.respond_to?(attr)
+      end
+
+      record.operating_system = os_record
+      record.hardware         = hardware_stub.new(hardware_attributes) if hardware_attributes
+      record.save!
+      record
+    end
+  end
+
+  # Runs tests for class type to confirm they
+  def test_for_klass(klass)
+    begin
+      # This callback is necessary after the migration, but fails when the
+      # column doesn't eixst (prior to the migration).  Removing it and
+      # re-enabling it after the migration.
+      operating_system_stub.skip_callback(:save, :before, :update_platform_and_image_name)
+
+      distribution_based = []
+      product_type_based = []
+      product_name_based = []
+      fallback_records   = []
+
+      test_os_values.each do |(value, _)|
+        distribution_based << record_with_os(klass, :distribution => value)
+        product_type_based << record_with_os(klass, :product_type => value)
+        product_name_based << record_with_os(klass, :product_name => value)
+      end
+
+      # favor distribution over product_type
+      fallback_records << record_with_os(klass, :distribution => "rhel-7", :product_type => "centos-7")
+      # falls back to os.product_type if invalid os.distribution
+      fallback_records << record_with_os(klass, :distribution => "undiscovered-7", :product_type => "rhel-7")
+      # falls back to os.product_name
+      fallback_records << record_with_os(klass, :distribution => "undiscovered-7", :product_name => "rhel-7")
+      # falls back to hardware.guest_os
+      fallback_records << record_with_os(klass, {:distribution => "undiscovered-7"}, {}, {:guest_os => "rhel-7"})
+      # falls back to Host#user_assigned_os
+      fallback_records << record_with_os(klass, {:distribution => "undiscovered-7"}, {:user_assigned_os => "rhel-7"})
+    ensure
+      # If the any of the above fails, make sure we re-enable callbacks so
+      # subsequent specs don't fail trying to skip this callback when it
+      # doesn't exist.
+      operating_system_stub.set_callback(:save, :before, :update_platform_and_image_name)
+    end
+
+    migrate
+
+    test_os_values.each.with_index do |(_, image_name), index|
+      [distribution_based, product_type_based, product_name_based].each do |record_list|
+        os_record = record_list[index]
+        os_record.reload
+        os_record = os_record.operating_system if os_record.respond_to?(:operating_system)
+
+        expect(os_record.image_name).to eq(image_name)
+        expect(os_record.platform).to   eq(image_name.split("_").first)
+      end
+    end
+
+    fallback_records.each(&:reload)
+
+    platform, image_name = %w[linux linux_redhat]
+    fallback_records.each.with_index do |record, index|
+      os_record = record
+      os_record = os_record.operating_system if os_record.respond_to?(:operating_system)
+
+      # OperatingSystem records don't have a hardware relation, so this will be
+      # a "unknown" OS
+      platform, image_name = %w[unknown unknown] if index == 3 && klass == operating_system_stub
+
+      # Both ComputerSystem and VmOrTemplate don't have :user_assigned_os, so
+      # these will return "unknown" instead of what we (tried to) set.
+      platform, image_name = %w[unknown unknown] if index == 4 && klass != host_stub
+
+      expect(os_record.image_name).to eq(image_name)
+      expect(os_record.platform).to   eq(platform)
+    end
+  end
+
+  migration_context :up do
+    it "adds the columns" do
+      before_columns = operating_system_stub.columns.map(&:name)
+      expect(before_columns).to_not include("platform")
+      expect(before_columns).to_not include("image_name")
+
+      migrate
+
+      after_columns = operating_system_stub.columns.map(&:name)
+      expect(after_columns).to include("platform")
+      expect(after_columns).to include("image_name")
+    end
+
+    it "updates OperatingSystem for Host records" do
+      test_for_klass host_stub
+    end
+
+    it "updates OperatingSystem for VmOrTemplate records" do
+      test_for_klass vm_or_template_stub
+    end
+
+    it "updates OperatingSystem for ComputerSystem records" do
+      test_for_klass computer_system_stub
+    end
+
+    it "updates orphaned OperatingSystem records" do
+      test_for_klass operating_system_stub
+    end
+  end
+
+  migration_context :down do
+    it "adds the columns" do
+      before_columns = operating_system_stub.columns.map(&:name)
+      expect(before_columns).to include("platform")
+      expect(before_columns).to include("image_name")
+
+      migrate
+
+      after_columns = operating_system_stub.columns.map(&:name)
+      expect(after_columns).to_not include("platform")
+      expect(after_columns).to_not include("image_name")
+    end
+  end
+end


### PR DESCRIPTION
Both `platform` and `image_name` are relatively stable values that get re-calculated every time they are accessed, and in the worst case, causes it to traverse through many different sources to try and find a proper `platform`/`image_name`.  This is compounded when you are trying to fetch thousands of records at once.

This patch adds the columns to be cache store for those values, and should be triggered on every update of those records, and related records (not addressed in this patch).

Links to associated `manageiq` implementation and BZ related PRs to come, but those are what will provide more context to the advantages to this change.


Considerations
--------------

- Is this the best way to handle this problem?
- Are these columns going to add much size to the DB?
- Is there a better size for some of these columns?
- Should these be enum cols?
- Is there a way these could become out of sync?  Does that matter?
- Is there a faster way to run this migration?  (example run below)


Example Output
--------------

This was done with a DB that had a single Amazon EMS with public images that have been included in a refresh:

```
$ bin/rake db:migrate
** Using session_store: ActionDispatch::Session::MemCacheStore
** ManageIQ master, codename: Ivanchuk
== 20190108031411 AddImageNameToOperatingSystems: migrating ===================
-- add_column(:operating_systems, :platform, :string)
   -> 0.0073s
-- add_column(:operating_systems, :image_name, :string)
   -> 0.0004s
-- Updating platform and image_name in OperatingSystems
   -> Processing 121475 rows
   -> 1000 rows (0.82% - 1000 total - 2.45s - ETA: 5 minutes)
   -> 1000 rows (1.65% - 2000 total - 2.39s - ETA: 5 minutes)
   -> 1000 rows (2.47% - 3000 total - 2.29s - ETA: 5 minutes)
   -> 1000 rows (3.29% - 4000 total - 2.39s - ETA: 5 minutes)
   -> 1000 rows (4.12% - 5000 total - 2.27s - ETA: 5 minutes)
   -> 1000 rows (4.94% - 6000 total - 2.44s - ETA: 5 minutes)
   -> 1000 rows (5.76% - 7000 total - 2.25s - ETA: 4 minutes)
   -> 1000 rows (6.59% - 8000 total - 2.30s - ETA: 4 minutes)
   -> 1000 rows (7.41% - 9000 total - 2.40s - ETA: 4 minutes)
   -> 1000 rows (8.23% - 10000 total - 2.32s - ETA: 4 minutes)
   -> 1000 rows (9.06% - 11000 total - 2.29s - ETA: 4 minutes)
   -> 1000 rows (9.88% - 12000 total - 2.42s - ETA: 4 minutes)
   -> 1000 rows (10.70% - 13000 total - 2.24s - ETA: 4 minutes)
   -> 1000 rows (11.53% - 14000 total - 2.29s - ETA: 4 minutes)
   -> 1000 rows (12.35% - 15000 total - 2.44s - ETA: 4 minutes)
   -> 1000 rows (13.17% - 16000 total - 2.30s - ETA: 4 minutes)
   -> 1000 rows (13.99% - 17000 total - 2.38s - ETA: 4 minutes)
   -> 1000 rows (14.82% - 18000 total - 2.75s - ETA: 4 minutes)
   -> 1000 rows (15.64% - 19000 total - 2.29s - ETA: 4 minutes)
   -> 1000 rows (16.46% - 20000 total - 2.29s - ETA: 4 minutes)
   -> 1000 rows (17.29% - 21000 total - 2.41s - ETA: 4 minutes)
   -> 1000 rows (18.11% - 22000 total - 2.31s - ETA: 4 minutes)
   -> 1000 rows (18.93% - 23000 total - 2.27s - ETA: 4 minutes)
   -> 1000 rows (19.76% - 24000 total - 2.52s - ETA: 4 minutes)
   -> 1000 rows (20.58% - 25000 total - 2.29s - ETA: 4 minutes)
   -> 1000 rows (21.40% - 26000 total - 2.29s - ETA: 4 minutes)
   -> 1000 rows (22.23% - 27000 total - 2.39s - ETA: 4 minutes)
   -> 1000 rows (23.05% - 28000 total - 2.26s - ETA: 4 minutes)
   -> 1000 rows (23.87% - 29000 total - 2.27s - ETA: 4 minutes)
   -> 1000 rows (24.70% - 30000 total - 2.50s - ETA: 4 minutes)
   -> 1000 rows (25.52% - 31000 total - 2.28s - ETA: 4 minutes)
   -> 1000 rows (26.34% - 32000 total - 2.28s - ETA: 4 minutes)
   -> 1000 rows (27.17% - 33000 total - 2.43s - ETA: 3 minutes)
   -> 1000 rows (27.99% - 34000 total - 2.29s - ETA: 3 minutes)
   -> 1000 rows (28.81% - 35000 total - 2.33s - ETA: 3 minutes)
   -> 1000 rows (29.64% - 36000 total - 2.48s - ETA: 3 minutes)
   -> 1000 rows (30.46% - 37000 total - 2.26s - ETA: 3 minutes)
   -> 1000 rows (31.28% - 38000 total - 2.54s - ETA: 3 minutes)
   -> 1000 rows (32.11% - 39000 total - 2.71s - ETA: 3 minutes)
   -> 1000 rows (32.93% - 40000 total - 2.26s - ETA: 3 minutes)
   -> 1000 rows (33.75% - 41000 total - 2.31s - ETA: 3 minutes)
   -> 1000 rows (34.58% - 42000 total - 2.53s - ETA: 3 minutes)
   -> 1000 rows (35.40% - 43000 total - 2.29s - ETA: 3 minutes)
   -> 1000 rows (36.22% - 44000 total - 2.34s - ETA: 3 minutes)
   -> 1000 rows (37.04% - 45000 total - 2.42s - ETA: 3 minutes)
   -> 1000 rows (37.87% - 46000 total - 2.30s - ETA: 3 minutes)
   -> 1000 rows (38.69% - 47000 total - 2.31s - ETA: 3 minutes)
   -> 1000 rows (39.51% - 48000 total - 2.44s - ETA: 3 minutes)
   -> 1000 rows (40.34% - 49000 total - 2.43s - ETA: 3 minutes)
   -> 1000 rows (41.16% - 50000 total - 2.98s - ETA: 3 minutes)
   -> 1000 rows (41.98% - 51000 total - 2.95s - ETA: 3 minutes)
   -> 1000 rows (42.81% - 52000 total - 2.66s - ETA: 3 minutes)
   -> 1000 rows (43.63% - 53000 total - 2.83s - ETA: 3 minutes)
   -> 1000 rows (44.45% - 54000 total - 2.68s - ETA: 3 minutes)
   -> 1000 rows (45.28% - 55000 total - 2.47s - ETA: 3 minutes)
   -> 1000 rows (46.10% - 56000 total - 2.43s - ETA: 3 minutes)
   -> 1000 rows (46.92% - 57000 total - 2.68s - ETA: 3 minutes)
   -> 1000 rows (47.75% - 58000 total - 2.57s - ETA: 3 minutes)
   -> 1000 rows (48.57% - 59000 total - 2.45s - ETA: 3 minutes)
   -> 1000 rows (49.39% - 60000 total - 2.59s - ETA: 2 minutes)
   -> 1000 rows (50.22% - 61000 total - 2.51s - ETA: 2 minutes)
   -> 1000 rows (51.04% - 62000 total - 2.50s - ETA: 2 minutes)
   -> 1000 rows (51.86% - 63000 total - 2.66s - ETA: 2 minutes)
   -> 1000 rows (52.69% - 64000 total - 2.51s - ETA: 2 minutes)
   -> 1000 rows (53.51% - 65000 total - 2.50s - ETA: 2 minutes)
   -> 1000 rows (54.33% - 66000 total - 2.69s - ETA: 2 minutes)
   -> 1000 rows (55.16% - 67000 total - 2.53s - ETA: 2 minutes)
   -> 1000 rows (55.98% - 68000 total - 2.45s - ETA: 2 minutes)
   -> 1000 rows (56.80% - 69000 total - 2.59s - ETA: 2 minutes)
   -> 1000 rows (57.63% - 70000 total - 2.42s - ETA: 2 minutes)
   -> 1000 rows (58.45% - 71000 total - 2.47s - ETA: 2 minutes)
   -> 1000 rows (59.27% - 72000 total - 2.57s - ETA: 2 minutes)
   -> 1000 rows (60.09% - 73000 total - 2.34s - ETA: 2 minutes)
   -> 1000 rows (60.92% - 74000 total - 2.47s - ETA: 2 minutes)
   -> 1000 rows (61.74% - 75000 total - 2.71s - ETA: 2 minutes)
   -> 1000 rows (62.56% - 76000 total - 2.48s - ETA: 2 minutes)
   -> 1000 rows (63.39% - 77000 total - 2.58s - ETA: 2 minutes)
   -> 1000 rows (64.21% - 78000 total - 2.96s - ETA: 2 minutes)
   -> 1000 rows (65.03% - 79000 total - 3.22s - ETA: 2 minutes)
   -> 1000 rows (65.86% - 80000 total - 2.72s - ETA: 2 minutes)
   -> 1000 rows (66.68% - 81000 total - 2.59s - ETA: 2 minutes)
   -> 1000 rows (67.50% - 82000 total - 2.48s - ETA: 2 minutes)
   -> 1000 rows (68.33% - 83000 total - 2.46s - ETA: 2 minutes)
   -> 1000 rows (69.15% - 84000 total - 2.56s - ETA: 2 minutes)
   -> 1000 rows (69.97% - 85000 total - 2.40s - ETA: 1 minute)
   -> 1000 rows (70.80% - 86000 total - 2.44s - ETA: 1 minute)
   -> 1000 rows (71.62% - 87000 total - 2.59s - ETA: 1 minute)
   -> 1000 rows (72.44% - 88000 total - 2.46s - ETA: 1 minute)
   -> 1000 rows (73.27% - 89000 total - 2.52s - ETA: 1 minute)
   -> 1000 rows (74.09% - 90000 total - 2.55s - ETA: 1 minute)
   -> 1000 rows (74.91% - 91000 total - 2.43s - ETA: 1 minute)
   -> 1000 rows (75.74% - 92000 total - 2.46s - ETA: 1 minute)
   -> 1000 rows (76.56% - 93000 total - 2.60s - ETA: 1 minute)
   -> 1000 rows (77.38% - 94000 total - 2.41s - ETA: 1 minute)
   -> 1000 rows (78.21% - 95000 total - 2.45s - ETA: 1 minute)
   -> 1000 rows (79.03% - 96000 total - 2.60s - ETA: 1 minute)
   -> 1000 rows (79.85% - 97000 total - 2.60s - ETA: 1 minute)
   -> 1000 rows (80.68% - 98000 total - 2.58s - ETA: less than a minute)
   -> 1000 rows (81.50% - 99000 total - 2.63s - ETA: less than a minute)
   -> 1000 rows (82.32% - 100000 total - 2.53s - ETA: less than a minute)
   -> 1000 rows (83.14% - 101000 total - 2.62s - ETA: less than a minute)
   -> 1000 rows (83.97% - 102000 total - 2.68s - ETA: less than a minute)
   -> 1000 rows (84.79% - 103000 total - 2.59s - ETA: less than a minute)
   -> 1000 rows (85.61% - 104000 total - 2.52s - ETA: less than a minute)
   -> 1000 rows (86.44% - 105000 total - 2.44s - ETA: less than a minute)
   -> 1000 rows (87.26% - 106000 total - 2.48s - ETA: half a minute)
   -> 1000 rows (88.08% - 107000 total - 2.49s - ETA: half a minute)
   -> 1000 rows (88.91% - 108000 total - 2.43s - ETA: half a minute)
   -> 1000 rows (89.73% - 109000 total - 2.28s - ETA: half a minute)
   -> 1000 rows (90.55% - 110000 total - 2.31s - ETA: half a minute)
   -> 1000 rows (91.38% - 111000 total - 2.46s - ETA: half a minute)
   -> 1000 rows (92.20% - 112000 total - 2.28s - ETA: half a minute)
   -> 1000 rows (93.02% - 113000 total - 2.37s - ETA: half a minute)
   -> 1000 rows (93.85% - 114000 total - 2.46s - ETA: less than 20 seconds)
   -> 1000 rows (94.67% - 115000 total - 2.39s - ETA: less than 20 seconds)
   -> 1000 rows (95.49% - 116000 total - 2.38s - ETA: less than 20 seconds)
   -> 1000 rows (96.32% - 117000 total - 2.59s - ETA: less than 20 seconds)
   -> 1000 rows (97.14% - 118000 total - 2.45s - ETA: less than 10 seconds)
   -> 1000 rows (97.96% - 119000 total - 2.47s - ETA: less than 10 seconds)
   -> 1000 rows (98.79% - 120000 total - 2.63s - ETA: less than 5 seconds)
   -> 1000 rows (99.61% - 121000 total - 2.45s - ETA: less than 5 seconds)
   -> 475 rows (100.00% - 121475 total - 1.22s - ETA: less than 5 seconds)
   -> 300.5599s
== 20190108031411 AddImageNameToOperatingSystems: migrated (300.5679s) ========
```