### PR TITLE
Add multiattach field to CloudVolume

### DIFF
--- a/db/migrate/20190110201414_add_multi_attachment_to_cloud_volume.rb
+++ b/db/migrate/20190110201414_add_multi_attachment_to_cloud_volume.rb
@@ -1,0 +1,5 @@
+class AddMultiAttachmentToCloudVolume < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_volumes, :multi_attachment, :boolean
+  end
+end


### PR DESCRIPTION
Adds a "multiattach" boolean column to the CloudVolume model
https://bugzilla.redhat.com/show_bug.cgi?id=1660896