### PR TITLE
Split up Storages to be unique per EMS and ems_ref

### DIFF
--- a/db/migrate/20190729165913_add_ems_id_to_storages.rb
+++ b/db/migrate/20190729165913_add_ems_id_to_storages.rb
@@ -1,0 +1,5 @@
+class AddEmsIdToStorages < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :storages, :ems, :type => :bigint, :index => true, :references => :ext_management_system
+  end
+end

--- a/db/migrate/20190729170013_split_storages_per_ems.rb
+++ b/db/migrate/20190729170013_split_storages_per_ems.rb
@@ -1,0 +1,62 @@
+class SplitStoragesPerEms < ActiveRecord::Migration[5.0]
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class HostStorage < ActiveRecord::Base
+    belongs_to :host,    :class_name => "::SplitStoragesPerEms::Host"
+    belongs_to :storage, :class_name => "::SplitStoragesPerEms::Storage"
+  end
+
+  class Storage < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    Storage.in_my_region.find_each do |storage|
+      # First we need to group HostStorage records by their ems_id and ems_ref since these will
+      # form the new Storage records. Once the Storage records are created we can link them
+      # to the hosts through these HostStorage records.
+      host_storages_by_ems_id_and_ems_ref = HostStorage.includes(:host).where(:storage_id => storage.id).group_by do |hs|
+        ems_id            = hs.host&.ems_id
+        datastore_ems_ref = hs.ems_ref || storage.ems_ref
+
+        next if ems_id.nil?
+
+        [ems_id, datastore_ems_ref]
+      end
+
+      storages_by_ems_id_and_ems_ref = {}
+      all_ems_id_and_ems_refs        = host_storages_by_ems_id_and_ems_ref.keys
+
+      # Re-use the existing storage record
+      storage.ems_id, storage.ems_ref = all_ems_id_and_ems_refs.shift
+      storage.save!
+      storages_by_ems_id_and_ems_ref[[storage.ems_id, storage.ems_ref]] = storage
+
+      # Create new storages for the rest of the ems_ids and ems_refs
+      all_ems_id_and_ems_refs.each do |ems_id, ems_ref|
+        next if ems_id.nil?
+
+        new_storage = storage.attributes.except("id").merge("ems_id" => ems_id, "ems_ref" => ems_ref)
+        storages_by_ems_id_and_ems_ref[[ems_id, ems_ref]] = Storage.create!(new_storage)
+      end
+
+      # Link up the host_storage records to the new storages
+      host_storages_by_ems_id_and_ems_ref.each_key do |ems_id, ems_ref|
+        # Connect all of the HostStorage records to the new Storage record
+        host_storages_ids = host_storages_by_ems_id_and_ems_ref[[ems_id, ems_ref]].map(&:id)
+        storage = storages_by_ems_id_and_ems_ref[[ems_id, ems_ref]]
+
+        HostStorage.where(:id => host_storages_ids).update_all(:storage_id => storage.id)
+      end
+    end
+  end
+
+  def down
+    Storage.in_my_region.find_each do |storage|
+      # Set the ems_ref back on the HostStorage records
+      HostStorage.where(:storage_id => storage.id).update_all(:ems_ref => storage.ems_ref)
+    end
+  end
+end

--- a/db/migrate/20191209162705_drop_ems_ref_from_host_storage.rb
+++ b/db/migrate/20191209162705_drop_ems_ref_from_host_storage.rb
@@ -1,0 +1,5 @@
+class DropEmsRefFromHostStorage < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :host_storages, :ems_ref, :string
+  end
+end

--- a/spec/migrations/20190729170013_split_storages_per_ems_spec.rb
+++ b/spec/migrations/20190729170013_split_storages_per_ems_spec.rb
@@ -1,0 +1,163 @@
+require_migration
+
+class SplitStoragesPerEms
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    has_many :host_storages, :class_name => "::SplitStoragesPerEms::HostStorage"
+    has_many :storages, :through => :host_storages
+  end
+end
+
+describe SplitStoragesPerEms do
+  let(:ems_stub)          { migration_stub(:ExtManagementSystem) }
+  let(:host_stub)         { migration_stub(:Host) }
+  let(:host_storage_stub) { migration_stub(:HostStorage) }
+  let(:storage_stub)      { migration_stub(:Storage) }
+
+  migration_context :up do
+    context "with a single storage" do
+      let(:storage) { storage_stub.create!(:ems_ref => "datastore-1") }
+
+      context "and a single active host" do
+        let(:ems) { ems_stub.create! }
+        let!(:host) do
+          host_stub.create!(:ems_id => ems.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id)
+          end
+        end
+
+        it "doesn't touch the storage record" do
+          migrate
+          expect(storage_stub.count).to eq(1)
+        end
+
+        it "host is still linked to the storage" do
+          migrate
+          expect(host.reload.storages.first).to eq(storage_stub.first)
+        end
+      end
+
+      context "and two active hosts" do
+        let(:ems) { ems_stub.create! }
+        let!(:host_1) do
+          host_stub.create!(:ems_id => ems.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id)
+          end
+        end
+        let!(:host_2) do
+          host_stub.create!(:ems_id => ems.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id)
+          end
+        end
+
+        it "doesn't touch the storage record" do
+          migrate
+          expect(storage_stub.count).to eq(1)
+        end
+
+        it "both hosts are still linked to the storage" do
+          migrate
+
+          storage = storage_stub.first
+          expect(host_1.reload.storages.first).to eq(storage)
+          expect(host_2.reload.storages.first).to eq(storage)
+        end
+      end
+
+      context "with different datastores in the same EMS" do
+        let(:ems) { ems_stub.create! }
+        let!(:host_1) do
+          host_stub.create!(:ems_id => ems.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, :ems_ref => "datastore-1")
+          end
+        end
+        let!(:host_2) do
+          host_stub.create!(:ems_id => ems.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, :ems_ref => "datastore-2")
+          end
+        end
+
+        it "creates two storages" do
+          migrate
+          expect(storage_stub.count).to eq(2)
+        end
+
+        it "links the right host to the right datastore" do
+          migrate
+          expect(host_1.reload.storages.first.ems_ref).to eq("datastore-1")
+          expect(host_2.reload.storages.first.ems_ref).to eq("datastore-2")
+        end
+      end
+
+      context "with different datastores in different EMSs" do
+        let(:ems_1) { ems_stub.create! }
+        let(:ems_2) { ems_stub.create! }
+        let!(:host_1) do
+          host_stub.create!(:ems_id => ems_1.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, :ems_ref => "datastore-1")
+          end
+        end
+        let!(:host_2) do
+          host_stub.create!(:ems_id => ems_2.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, :ems_ref => "datastore-2")
+          end
+        end
+
+        it "creates two storages" do
+          migrate
+          expect(storage_stub.count).to eq(2)
+          expect(storage_stub.pluck(:ems_id)).to match_array([ems_1.id, ems_2.id])
+        end
+
+        it "links the right host to the right datastore" do
+          migrate
+
+          expect(host_1.reload.storages.first.ems_id).to eq(host_1.ems_id)
+          expect(host_2.reload.storages.first.ems_id).to eq(host_2.ems_id)
+        end
+
+        context "with an archived host" do
+          let(:archived_host) do
+            host_stub.create!.tap do |h|
+              host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, ems_ref => "datastore-3")
+            end
+          end
+
+          it "doesn't create a storage record for the archived host" do
+            migrate
+
+            expect(storage_stub.count).to eq(2)
+          end
+        end
+      end
+    end
+  end
+
+  migration_context :down do
+    context "with a single storage" do
+      let(:storage) { storage_stub.create!(:ems_ref => "datastore-1") }
+
+      context "and a single active host" do
+        let(:ems) { ems_stub.create! }
+        let!(:host) do
+          host_stub.create!(:ems_id => ems.id).tap do |h|
+            host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id)
+          end
+        end
+
+        it "links hosts to the old storage" do
+          migrate
+          expect(host.reload.host_storages.first.storage).to eq(storage)
+        end
+
+        it "sets the ems_ref" do
+          migrate
+          expect(host.reload.host_storages.first.ems_ref).to eq(storage.ems_ref)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently storages are not owned by any single EMS and can actually be shared by multiple providers (of different types even).

This is nice for identifying the underlying physical storage that might be shared by a few providers but it presents a few challenges.
A lot of properties on a storage record are actually hypervisor-level properties and can be overwritten by each refresh.  For example ems_ref, name, master, etc... can be different on two different providers that the storage is added to.

The solution is to create a new storage record for each [ems_id, ems_ref] pair so that storages become just like any other virtual record.

The multiple-ems_ref-per-storage issue was worked-around by dumping the ems_ref into the host_storages table (https://bugzilla.redhat.com/show_bug.cgi?id=1280402).  This worked for the most critical property but it isn't feasible to copy every datastore-type property into host_storages.

We can use the ems_ref from host_storages to get a list of all of the new storage records that we would need.  Once these storage records are created we can update host_storages to point to the new storage.

There are two BZs that this is related to,
https://bugzilla.redhat.com/show_bug.cgi?id=1394909 - This one needs to store if a datastore is in maintenance mode or not, since a datastore can be added to multiple providers it is possible for it to be in maintenance mode on one VC and not another causing race conditions with provisioning depending on which EMS was refreshed last.
https://bugzilla.redhat.com/show_bug.cgi?id=1668020 - This one needs to store the status of the datastore (e.g. is it disconnected), again this can be okay on one VC and not okay on another leading to race conditions.

Core PR: https://github.com/ManageIQ/manageiq/pull/19617
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/33