### PR TITLE
[WIP] Add type column to service_order table

### DIFF
--- a/db/migrate/20190123145942_add_type_column_to_service_order.rb
+++ b/db/migrate/20190123145942_add_type_column_to_service_order.rb
@@ -1,15 +1,16 @@
 class AddTypeColumnToServiceOrder < ActiveRecord::Migration[5.0]
   def up
-    add_column :service_order, :type, :string
+    add_column :service_order, :request_type, :string
 
-    say_with_time("Set service_order type") do
+    say_with_time("Set service_order request_type") do
       ServiceOrder.all.each do |service_order|
-        service_order.update_attribute(:type, service_order.miq_requests.pluck(:type))
+        request_type = service_order.miq_requests.pluck(:type).uniq.sort.join(',')
+        service_order.update_attribute(:request_type, request_type)
       end
     end
   end
 
   def down
-    remove_column :service_order, :type
+    remove_column :service_order, :request_type
   end
 end

--- a/db/migrate/20190123145942_add_type_column_to_service_order.rb
+++ b/db/migrate/20190123145942_add_type_column_to_service_order.rb
@@ -1,0 +1,15 @@
+class AddTypeColumnToServiceOrder < ActiveRecord::Migration[5.0]
+  def up
+    add_column :service_order, :type, :string
+
+    say_with_time("Set service_order type") do
+      ServiceOrder.all.each do |service_order|
+        service_order.update_attribute(:type, service_order.miq_requests.pluck(:type))
+      end
+    end
+  end
+
+  def down
+    remove_column :service_order, :type
+  end
+end

--- a/db/migrate/20190123145942_add_type_column_to_service_order.rb
+++ b/db/migrate/20190123145942_add_type_column_to_service_order.rb
@@ -1,16 +1,16 @@
 class AddTypeColumnToServiceOrder < ActiveRecord::Migration[5.0]
   def up
-    add_column :service_order, :request_type, :string
+    add_column :service_order, :type, :string
 
-    say_with_time("Set service_order request_type") do
+    say_with_time("Set service_order type") do
       ServiceOrder.all.each do |service_order|
-        request_type = service_order.miq_requests.pluck(:type).uniq.sort.join(',')
-        service_order.update_attribute(:request_type, request_type)
+        type = service_order.miq_requests.pluck(:type).any? { |t| t === 'ServiceTemplateTransformationPlanRequest' } ? ServiceOrderV2V : ServiceOrderCart
+        service_order.update_attribute(:type, type)
       end
     end
   end
 
   def down
-    remove_column :service_order, :request_type
+    remove_column :service_order, :type
   end
 end


### PR DESCRIPTION
This adds a `type` column to the `service_order` table. The associated type would be plucked from its associated requests e.g. `ServiceTemplateProvisionRequest` or `ServiceTemplateTransformationPlanRequest`.

Attempts to solve https://github.com/ManageIQ/manageiq-ui-service/issues/1463

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1565049

WIP until I can confirm how the migration should work.