### PR TITLE
Add Accessible to HostStorages

### DIFF
--- a/db/migrate/20190123210452_add_accessible_to_host_storages.rb
+++ b/db/migrate/20190123210452_add_accessible_to_host_storages.rb
@@ -1,0 +1,5 @@
+class AddAccessibleToHostStorages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :host_storages, :accessible, :boolean
+  end
+end


### PR DESCRIPTION
Add a property to the host storage mount information about if a
particular datastore is accessible to the given host or not.

If a datastore is inaccessible for some reason (e.g. the NFS server is
down) then even though read_only may be false the datastore still cannot
be accessed.

VMware tracks this property in the HostMountInfo (where read_only is
already pulled from) in a boolean field called "accessible" [0].

This can be used to ignore offline datastore for the purposes of
provisioning as well as alerting the user of issues on their datastores

[0] https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.host.MountInfo.html

https://bugzilla.redhat.com/show_bug.cgi?id=1668020