### PR TITLE
[WIP] Add provision state to service

### DIFF
--- a/db/migrate/20190129212026_add_provision_state_to_services.rb
+++ b/db/migrate/20190129212026_add_provision_state_to_services.rb
@@ -1,0 +1,5 @@
+class AddProvisionStateToServices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :services, :provision_state, :string
+  end
+end


### PR DESCRIPTION
Tina, Loic, and Dennis say we need another state field in the service object to indicate the provision state.

It's WIP for reasons? Because we haven't seemed to have had enough discussions around this to know what's happening with it? Something? 