### PR TITLE
Create a new migration to fix special characters in the rabbitmq password

### DIFF
--- a/db/migrate/20181012160010_remove_special_characters_from_ansible_rabbitmq_password.rb
+++ b/db/migrate/20181012160010_remove_special_characters_from_ansible_rabbitmq_password.rb
@@ -1,25 +1,3 @@
-require 'securerandom'
-
 class RemoveSpecialCharactersFromAnsibleRabbitmqPassword < ActiveRecord::Migration[5.0]
-  # used only in specs
-  class MiqDatabase < ActiveRecord::Base; end
-
-  class Authentication < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled
-    include ActiveRecord::IdRegions
-  end
-
-  def up
-    auth = Authentication.in_my_region.find_by(
-      :name     => "Ansible Rabbitmq Authentication",
-      :authtype => "ansible_rabbitmq_auth",
-      :userid   => "ansible",
-      :type     => "AuthUseridPassword"
-    )
-
-    return unless auth
-
-    current = MiqPassword.decrypt(auth.password)
-    auth.update_attributes!(:password => MiqPassword.encrypt(SecureRandom.hex(18))) unless current =~ /^[a-zA-Z0-9]+$/
-  end
+  # noop - see RemoveSpecialCharactersFromAnsibleRabbitmqPasswordTwo
 end

--- a/db/migrate/20181012161000_remove_special_characters_from_ansible_rabbitmq_password_two.rb
+++ b/db/migrate/20181012161000_remove_special_characters_from_ansible_rabbitmq_password_two.rb
@@ -1,0 +1,23 @@
+require 'securerandom'
+
+class RemoveSpecialCharactersFromAnsibleRabbitmqPasswordTwo < ActiveRecord::Migration[5.0]
+  # used only in specs
+  class MiqDatabase < ActiveRecord::Base; end
+
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    auth = Authentication.in_my_region.find_by(
+      :authtype => "ansible_rabbitmq_auth",
+      :type     => "AuthUseridPassword"
+    )
+
+    return unless auth
+
+    current = MiqPassword.decrypt(auth.password)
+    auth.update_attributes!(:password => MiqPassword.encrypt(SecureRandom.hex(18))) unless current =~ /^[a-zA-Z0-9]+$/
+  end
+end

--- a/spec/migrations/20181012161000_remove_special_characters_from_ansible_rabbitmq_password_two_spec.rb
+++ b/spec/migrations/20181012161000_remove_special_characters_from_ansible_rabbitmq_password_two_spec.rb
@@ -1,6 +1,6 @@
 require_migration
 
-describe RemoveSpecialCharactersFromAnsibleRabbitmqPassword do
+describe RemoveSpecialCharactersFromAnsibleRabbitmqPasswordTwo do
   let(:database_stub)       { migration_stub(:MiqDatabase) }
   let(:authentication_stub) { migration_stub(:Authentication) }
   let(:db_id)               { database_stub.first.id }
@@ -8,7 +8,7 @@ describe RemoveSpecialCharactersFromAnsibleRabbitmqPassword do
     {
       :name          => "Ansible Rabbitmq Authentication",
       :authtype      => "ansible_rabbitmq_auth",
-      :userid        => "ansible",
+      :userid        => "tower",
       :type          => "AuthUseridPassword",
       :resource_id   => db_id,
       :resource_type => "MiqDatabase"


### PR DESCRIPTION
Previously the arguments to the find_by call were incorrect so
the migration would never find a record. The issue is that the
userid was "tower" not "ansible".

In the new version we only search by the type and authtype attributes
which should never change and are clearly defined in the application code

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1678337