### PR TITLE
Add the date of when inventory was collected

### DIFF
--- a/db/migrate/20190225142729_add_last_inventory_date_to_ems.rb
+++ b/db/migrate/20190225142729_add_last_inventory_date_to_ems.rb
@@ -1,0 +1,5 @@
+class AddLastInventoryDateToEms < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ext_management_systems, :last_inventory_date, :datetime
+  end
+end


### PR DESCRIPTION
We have a column tracking when the EMS was last successfully saved
(#last_refresh_date).  This tells us when save_inventory last finished,
but a lot of code wants to know when the inventory which was saved was
collected.

An example of this is "I just added a disk to a VM at time T1, I want to
know when this change is represented in VMDB"

You can wait until last_refresh_date >= T1, but it is possible that
save_inventory took a long time and the inventory was actually
collected at T0 and just saved at T2.

If we had a column that stored when the inventory was collected then no
matter how long the refresh sat in the queue we would know for a fact
that the EMS includes our changes.

Currently this is done by getting a task_id back with the refresh queue
item, but e.g. VMware streaming refresh doesn't use the normal queue for
refreshes so this method won't work.