### PR TITLE
Migration for checking guid uniqueness

### DIFF
--- a/db/migrate/20190226184255_check_guid_uniqueness.rb
+++ b/db/migrate/20190226184255_check_guid_uniqueness.rb
@@ -1,0 +1,54 @@
+class CheckGuidUniqueness < ActiveRecord::Migration[5.0]
+  # several models already have unique constraints on index so we don't have to deal with them in this migration:
+  # vm, miq_set, scan_item, miq_worker, miq_server, miq_event_definition, miq_action, lifecycle event, job, host, ems
+
+  class AutomateWorkspace < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true, :presence => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqAeWorkspace < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqPolicy < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqRegion < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqWidget < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class Service < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class ServiceTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    [AutomateWorkspace, MiqAeWorkspace, MiqPolicy, MiqRegion, MiqWidget, Service, ServiceTemplate].each do |thing|
+      say_with_time("Checking #{thing} for guid uniqueness") do
+        thing.in_my_region.where(:guid => thing.in_my_region.select(:guid).group(:guid).having("count(*) > 1").pluck(:guid)).order(:id).drop(1).each { |obj| obj.update_attributes!(:guid => SecureRandom.uuid) }
+      end
+    end
+  end
+end

--- a/db/migrate/20190304192641_add_provider_guids.rb
+++ b/db/migrate/20190304192641_add_provider_guids.rb
@@ -1,0 +1,11 @@
+class AddProviderGuids < ActiveRecord::Migration[5.0]
+  class Provider < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :guid, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    Provider.in_my_region.where(:guid => nil).each { |provider| provider.update_attributes!(:guid => SecureRandom.uuid) }
+  end
+end

--- a/spec/migrations/20190226184255_check_guid_uniqueness_spec.rb
+++ b/spec/migrations/20190226184255_check_guid_uniqueness_spec.rb
@@ -1,0 +1,34 @@
+require_migration
+
+describe CheckGuidUniqueness do
+  let(:automate_workspace) { migration_stub(:AutomateWorkspace) }
+  let(:miq_ae_workspace) { migration_stub(:MiqAeWorkspace) }
+  let(:miq_policy) { migration_stub(:MiqPolicy) }
+  let(:miq_region) { migration_stub(:MiqRegion) }
+  let(:miq_widget) { migration_stub(:MiqWidget) }
+  let(:service) { migration_stub(:Service) }
+  let(:service_template) { migration_stub(:ServiceTemplate) }
+
+  migration_context :up do
+    %i[automate_workspace miq_ae_workspace miq_policy miq_region miq_widget service service_template].each do |obj|
+      it "#{obj} dup resets guid" do
+        guid = SecureRandom.uuid
+        klass = send(obj)
+        obj1 = klass.create!(:guid => guid)
+        obj2 = klass.new(:guid => guid)
+        obj2.save(:validate => false)
+        obj3 = klass.create!(:guid => SecureRandom.uuid)
+        guid2 = obj3.guid
+
+        expect(obj1.reload.guid).to eq(guid)
+        expect(obj2.reload.guid).to eq(guid)
+
+        migrate
+
+        expect(obj1.reload.guid).to eq(guid)
+        expect(obj2.reload.guid).not_to eq(guid)
+        expect(obj3.reload.guid).to eq(guid2)
+      end
+    end
+  end
+end

--- a/spec/migrations/20190304192641_add_provider_guids_spec.rb
+++ b/spec/migrations/20190304192641_add_provider_guids_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe AddProviderGuids do
+  let(:provider) { migration_stub(:Provider) }
+
+  migration_context :up do
+    it "sets provider guids" do
+      obj1 = provider.create!
+
+      expect(obj1.reload.guid).to eq(nil)
+
+      migrate
+
+      expect(obj1.reload.guid).not_to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
All the things that have the uuid mixin should validate that the guids generated are unique, I know it's a ridiculously stupid nit, and I know that we are so unlikely to ever find a case in which this migration is necessary (outside of ```dup``` which will be dealt with in the related PR) that I'm better off buying a lottery ticket for the three mill run today or whatever, but I wanted the satisfaction of having dealt with this so... 

TLDR blame Brandon. 

also, ```guidniqueness```?

Related:
https://github.com/ManageIQ/manageiq/pull/18492

There are two commits in this PR because providers currently have no validations on guids, nor are they required to have guids, and so since in the main repo PR we're adding the mixin to providers, which has a guid presence validation, this PR also checks to make sure that all providers do in fact have guids. 