### PR TITLE
Remove container deployments and container deployment nodes

### DIFF
--- a/db/migrate/20190306235417_drop_container_deployments_and_nodes.rb
+++ b/db/migrate/20190306235417_drop_container_deployments_and_nodes.rb
@@ -1,0 +1,34 @@
+class DropContainerDeploymentsAndNodes < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :container_deployments
+    drop_table :container_deployment_nodes
+  end
+
+  def down
+    create_table :container_deployments do |t|
+      t.string     :kind
+      t.string     :version
+      t.boolean    :containerized
+      t.string     :method_type
+      t.string     :metrics_endpoint
+      t.text       :customizations
+      t.boolean    :deploy_metrics
+      t.boolean    :deploy_registry
+      t.belongs_to :automation_task, :type => :bigint
+      t.belongs_to :deployed_ems,    :type => :bigint
+      t.belongs_to :deployed_on_ems, :type => :bigint
+      t.timestamps
+    end
+    create_table :container_deployment_nodes do |t|
+      t.string     :address
+      t.string     :name
+      t.text       :labels
+      t.belongs_to :container_deployment, :type => :bigint
+      t.belongs_to :vm, :type => :bigint
+      t.text       :docker_storage_devices, :array => true, :default => []
+      t.bigint     :docker_storage_data_size
+      t.text       :customizations
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190307131832_removing_authentication_for_container_deployments.rb
+++ b/db/migrate/20190307131832_removing_authentication_for_container_deployments.rb
@@ -1,0 +1,18 @@
+class RemovingAuthenticationForContainerDeployments < ActiveRecord::Migration[5.0]
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Removing Authentications") do
+      Authentication.where(:type => 'AuthenticationAllowAll').delete_all
+      Authentication.where(:type => 'AuthenticationGithub').delete_all
+      Authentication.where(:type => 'AuthenticationGoogle').delete_all
+      Authentication.where(:type => 'AuthenticationHtpasswd').delete_all
+      Authentication.where(:type => 'AuthenticationLdap').delete_all
+      Authentication.where(:type => 'AuthenticationOpenId').delete_all
+      Authentication.where(:type => 'AuthenticationRequestHeader').delete_all
+      Authentication.where(:type => 'AuthenticationRhsm').delete_all
+    end
+  end
+end

--- a/spec/migrations/20190307131832_removing_authentication_for_container_deployments_spec.rb
+++ b/spec/migrations/20190307131832_removing_authentication_for_container_deployments_spec.rb
@@ -1,0 +1,28 @@
+require_migration
+
+describe RemovingAuthenticationForContainerDeployments do
+  let(:auth_stub) { migration_stub :Authentication }
+
+  migration_context :up do
+    before do
+      auth_stub.create!(:type => 'AuthenticationAllowAll', :name => 'bad')
+      auth_stub.create!(:type => 'AuthenticationGithub', :name => 'bad1')
+      auth_stub.create!(:type => 'AuthenticationGoogle', :name => 'bad2')
+      auth_stub.create!(:type => 'AuthenticationHtpasswd', :name => 'bad3')
+      auth_stub.create!(:type => 'AuthenticationLdap', :name => 'bad4')
+      auth_stub.create!(:type => 'AuthenticationOpenId', :name => 'bad5')
+      auth_stub.create!(:type => 'AuthenticationRequestHeader', :name => 'bad6')
+      auth_stub.create!(:type => 'AuthenticationRhsm', :name => 'bad7')
+      auth_stub.create!(:type => 'AuthToken', :name => 'good')
+      migrate
+    end
+
+    it "deletes authentication records" do
+      expect(auth_stub.pluck(:name)).not_to include('bad', 'bad1', 'bad2', 'bad3', 'bad4', 'bad5', 'bad6', 'bad7')
+    end
+
+    it "doesn't delete unrelated records" do
+      expect(auth_stub.pluck(:name).sort).to eq(%w[good])
+    end
+  end
+end


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1672937 we're removing container deployment.

There are two commits here because we're also removing the Auth classes that were a part of the original container deployment PRs so this includes a data migration to remove those. 

Most of the relevant files in core were introduced in https://github.com/ManageIQ/manageiq/pull/7021. 

~~The UI PR that originally added container deployments was https://github.com/ManageIQ/manageiq/pull/7620.~~
Most of that code was removed already in 
~~https://github.com/ManageIQ/manageiq/pull/18095~~ and 
~~https://github.com/ManageIQ/manageiq-ui-classic/pull/4770~~

Bunch of related deletion PRs:

## Related: 
https://github.com/ManageIQ/manageiq/pull/18515
~~https://github.com/ManageIQ/manageiq-automation_engine/pull/301~~
~~https://github.com/ManageIQ/manageiq-content/pull/511~~
~~https://github.com/ManageIQ/manageiq-api/pull/560~~


**TLDR: take the code out, put it back in, take it out, soap on, soap off, no I don't even know where that reference is from...**