### PR TITLE
Add provider_services_supported column to Availability Zone

### DIFF
--- a/db/migrate/20190305181255_add_provider_services_supported_to_availability_zone.rb
+++ b/db/migrate/20190305181255_add_provider_services_supported_to_availability_zone.rb
@@ -1,0 +1,5 @@
+class AddProviderServicesSupportedToAvailabilityZone < ActiveRecord::Migration[5.0]
+  def change
+    add_column :availability_zones, :provider_services_supported, :string, :array => true, :default => []
+  end
+end


### PR DESCRIPTION
This PR adds a `services` string array column to the Availability Zone table. Openstack Availability Zones are visible to particular Openstack services, and this column allows those services to be marked during inventory collection and filtered on in queries. This is a part of the implementation of https://bugzilla.redhat.com/show_bug.cgi?id=1549128.

See also https://github.com/ManageIQ/manageiq-providers-openstack/pull/447