### PR TITLE
Add name validation to service templates

### DIFF
--- a/db/migrate/20190228210310_service_templates_should_have_names.rb
+++ b/db/migrate/20190228210310_service_templates_should_have_names.rb
@@ -1,0 +1,12 @@
+class ServiceTemplatesShouldHaveNames < ActiveRecord::Migration[5.0]
+  class ServiceTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Checking service templates for names") do
+      ServiceTemplate.in_my_region.where(:name => [nil, ""]).each { |t| t.update_attributes!(:name => "ServiceTemplate" + SecureRandom.uuid) }
+    end
+  end
+end

--- a/spec/migrations/20190228210310_service_templates_should_have_names_spec.rb
+++ b/spec/migrations/20190228210310_service_templates_should_have_names_spec.rb
@@ -1,0 +1,20 @@
+require_migration
+
+describe ServiceTemplatesShouldHaveNames do
+  let(:service_template) { migration_stub(:ServiceTemplate) }
+
+  migration_context :up do
+    it "sets template_names" do
+      obj1 = service_template.create!
+      obj2 = service_template.create!(:name => "")
+
+      expect(obj1.reload.name).to eq(nil)
+      expect(obj2.reload.name).to eq("")
+
+      migrate
+
+      expect(obj1.reload.name).not_to eq(nil)
+      expect(obj2.reload.name).not_to eq("")
+    end
+  end
+end


### PR DESCRIPTION
We added a method to copy service_templates 21 days ago here https://github.com/ManageIQ/manageiq/commit/955f49b080ec742878d9287c218ff364036118d1#diff-9257fff45a7d1258305c9a6b7d15e322R48 and in the process discovered that it's valid for templates to not have names and I think templates should have names. 