### PR TITLE
Don't set version restriction for 'pg' gem

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord-id_regions", "~> 0.2.2"
   s.add_dependency "manageiq-password", "~> 0.2.0"
   s.add_dependency "more_core_extensions", "~> 3.5"
-  s.add_dependency "pg", "~> 0.18.2"
+  s.add_dependency "pg"
   s.add_dependency "pg-pglogical", "~> 2.1.1"
   s.add_dependency "rails", "~>5.0.7.1"
 


### PR DESCRIPTION
As per discussion with @Fryguy and @carbonin, removing the `pg` gem version restriction as our code doesn't depend on a particular version.

Related PR: https://github.com/ManageIQ/manageiq/pull/18548