### PR TITLE
Create join table between service templates and tenants

### DIFF
--- a/db/migrate/20190314110421_create_join_table_service_template_tenant.rb
+++ b/db/migrate/20190314110421_create_join_table_service_template_tenant.rb
@@ -1,0 +1,11 @@
+class CreateJoinTableServiceTemplateTenant < ActiveRecord::Migration[5.0]
+  def change
+    create_table :service_template_tenants do |t|
+      t.bigint :service_template_id
+      t.bigint :tenant_id
+      t.index :service_template_id, :name => 'index_service_template_id'
+      t.index :tenant_id, :name => 'index_tenant_id'
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
From BZ:
> As a Service Author, when I create a Service(`ServiceTemplate`) I can select Tenants where the service will be available

so we need to model possibility to store `N` tenants for `ServiceTemplates` and it leads to create M:N relation between `ServiceTemplates` and `Tenants`.

cc @gtanzillo 

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1678123
