### PR TITLE
Fix sporadic failure when role order is different

### DIFF
--- a/spec/migrations/20160127210622_migrate_old_configuration_settings_spec.rb
+++ b/spec/migrations/20160127210622_migrate_old_configuration_settings_spec.rb
@@ -62,7 +62,8 @@ describe MigrateOldConfigurationSettings do
 
       migrate
 
-      expect(config_stub.first.settings).to eq new_settings
+      settings = adjust_role!(config_stub.first.settings)
+      expect(settings).to eq new_settings
     end
 
     it "with newer configuration data" do
@@ -70,7 +71,8 @@ describe MigrateOldConfigurationSettings do
 
       migrate
 
-      expect(config_stub.first.settings).to eq new_settings
+      settings = adjust_role!(config_stub.first.settings)
+      expect(settings).to eq new_settings
     end
 
     it "will not modify the server roles if the ui_worker key is present" do
@@ -78,7 +80,16 @@ describe MigrateOldConfigurationSettings do
 
       migrate
 
-      expect(config_stub.first.settings).to eq new_settings_with_web_server_worker_keys
+      settings = adjust_role!(config_stub.first.settings)
+      expect(settings).to eq new_settings_with_web_server_worker_keys
     end
+  end
+
+  # Adjust the value of role to avoid sporadic test failures on the order of the roles
+  def adjust_role!(settings)
+    if (role = settings.fetch_path(:settings, :role))
+      settings.store_path(:settings, :role, role.split(",").sort.join(","))
+    end
+    settings
   end
 end


### PR DESCRIPTION
Example failure:

```
  1) MigrateOldConfigurationSettings#up with really old configuration data
     Failure/Error: expect(config_stub.first.settings).to eq new_settings

       expected: {:api=>{:token_ttl=>"5.minutes"}, :server=>{:role=>"role1,role2,user_interface,web_services"} ...
            got: {:api=>{:token_ttl=>"5.minutes"}, :server=>{:role=>"role1,role2,web_services,user_interface"} ...

       (compared using ==)

       Diff:
       @@ -1,4 +1,4 @@
        :api => {:token_ttl=>"5.minutes"},
       -:server => {:role=>"role1,role2,user_interface,web_services"},
       +:server => {:role=>"role1,role2,web_services,user_interface"},
        :workers => {:worker_base=>{:event_catcher=>...
```

@jrafanie Please review,.