### PR TITLE
Add state to services

### DIFF
--- a/db/migrate/20190325160127_add_state_to_services.rb
+++ b/db/migrate/20190325160127_add_state_to_services.rb
@@ -1,0 +1,5 @@
+class AddStateToServices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :services, :state, :string
+  end
+end


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1677571 services need a state column that we can jack for provisioning n retirement and whatever else might change state of a service. Booya. 

_Actually I just wanted to see if anyone would read it, that's why there's a booya._ 