### PR TITLE
Dialog field - set load_values_on_init to true where show_refresh_button was not enabled

### DIFF
--- a/db/migrate/20190327132620_dialog_field_load_values_on_init.rb
+++ b/db/migrate/20190327132620_dialog_field_load_values_on_init.rb
@@ -1,0 +1,11 @@
+class DialogFieldLoadValuesOnInit < ActiveRecord::Migration[5.0]
+  class DialogField < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Updating Dialog Fields") do
+      DialogField.where(:show_refresh_button => [false, nil]).update_all('load_values_on_init = true')
+    end
+  end
+end

--- a/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
+++ b/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
@@ -1,0 +1,21 @@
+require_migration
+
+describe DialogFieldLoadValuesOnInit do
+  let(:dialog_field_stub) { migration_stub(:DialogField) }
+
+  migration_context :up do
+    before do
+      [true, false, nil].each do |show|
+        [true, false, nil].each do |load|
+          dialog_field_stub.create!(:show_refresh_button => show, :load_values_on_init => load)
+        end
+      end
+
+      migrate
+    end
+
+    it "updates load_values_on_init" do
+      expect(dialog_field_stub.pluck(:load_values_on_init)).to eq([true, false, nil, true, true, true, true, true, true])
+    end
+  end
+end

--- a/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
+++ b/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
@@ -5,9 +5,9 @@ describe DialogFieldLoadValuesOnInit do
 
   migration_context :up do
     before do
-      [true, false, nil].each do |show|
-        [true, false, nil].each do |load|
-          dialog_field_stub.create!(:show_refresh_button => show, :load_values_on_init => load)
+      [true, false, nil].each do |show_button|
+        [true, false, nil].each do |load_values|
+          dialog_field_stub.create!(:show_refresh_button => show_button, :load_values_on_init => load_values)
         end
       end
 
@@ -15,7 +15,11 @@ describe DialogFieldLoadValuesOnInit do
     end
 
     it "updates load_values_on_init" do
-      expect(dialog_field_stub.pluck(:load_values_on_init)).to eq([true, false, nil, true, true, true, true, true, true])
+      expect(dialog_field_stub.sort_by(:id).pluck(:load_values_on_init)).to eq([
+        true, false, nil, # show_button was true
+        true, true, true,
+        true, true, true,
+      ])
     end
   end
 end

--- a/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
+++ b/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
@@ -5,21 +5,35 @@ describe DialogFieldLoadValuesOnInit do
 
   migration_context :up do
     before do
-      [true, false, nil].each do |show_button|
-        [true, false, nil].each do |load_values|
-          dialog_field_stub.create!(:show_refresh_button => show_button, :load_values_on_init => load_values)
-        end
+      [true, false, nil].each do |load_values|
+        dialog_field_stub.create!(:show_refresh_button => show_button, :load_values_on_init => load_values)
       end
 
       migrate
     end
 
-    it "updates load_values_on_init" do
-      expect(dialog_field_stub.sort_by(:id).pluck(:load_values_on_init)).to eq([
-        true, false, nil, # show_button was true
-        true, true, true,
-        true, true, true,
-      ])
+    context "when show_refresh_button is true" do
+      let(:show_button) { true }
+
+      it "doesnt update load_values_on_init" do
+        expect(dialog_field_stub.order(:id).pluck(:load_values_on_init)).to eq([true, false, nil])
+      end
+    end
+
+    context "when show_refresh_button is false" do
+      let(:show_button) { false }
+
+      it "updates load_values_on_init to true" do
+        expect(dialog_field_stub.order(:id).pluck(:load_values_on_init)).to eq([true, true, true])
+      end
+    end
+
+    context "when show_refresh_button is nil" do
+      let(:show_button) { nil }
+
+      it "updates load_values_on_init to true" do
+        expect(dialog_field_stub.order(:id).pluck(:load_values_on_init)).to eq([true, true, true])
+      end
     end
   end
 end

--- a/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
+++ b/spec/migrations/20190327132620_dialog_field_load_values_on_init_spec.rb
@@ -4,6 +4,8 @@ describe DialogFieldLoadValuesOnInit do
   let(:dialog_field_stub) { migration_stub(:DialogField) }
 
   migration_context :up do
+    let(:show_button) { nil }
+
     before do
       [true, false, nil].each do |load_values|
         dialog_field_stub.create!(:show_refresh_button => show_button, :load_values_on_init => load_values)


### PR DESCRIPTION
Replaces code that was previously hardcoded in the model..

```ruby
    def load_values_on_init?
      return true unless show_refresh_button
      load_values_on_init
    end
```

Needed to make it posssible to set both these fields to false,
without breaking all the old fields where the value of `load_values_on_init` previously didn't matter.

https://bugzilla.redhat.com/show_bug.cgi?id=1684575
https://bugzilla.redhat.com/show_bug.cgi?id=1684567

(Depended on by:
* (core) https://github.com/ManageIQ/manageiq/pull/18600
* (ui-components) https://github.com/ManageIQ/ui-components/pull/376
)