### PR TITLE
Add zone to service templates.

### DIFF
--- a/db/migrate/20190318190517_add_zone_to_service_templates.rb
+++ b/db/migrate/20190318190517_add_zone_to_service_templates.rb
@@ -1,0 +1,5 @@
+class AddZoneToServiceTemplates < ActiveRecord::Migration[5.0]
+  def change
+    add_column :service_templates, :zone_id, :bigint
+  end
+end


### PR DESCRIPTION
Add zone to service templates to allow the running of service-related automate tasks in a specific zone.

Blocks https://github.com/ManageIQ/manageiq/pull/18601
https://bugzilla.redhat.com/show_bug.cgi?id=1415106

@miq-bot add_label enhancement
cc @tinaafitz 