### PR TITLE
[HAMMER] Use the gems-pending hammer branch on the schema hammer branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
-gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending", :branch => "master"
+gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending", :branch => "hammer"


### PR DESCRIPTION
This should fix spec failures like https://travis-ci.org/ManageIQ/manageiq-schema/jobs/512128840