### PR TITLE
Add price to service templates.

### DIFF
--- a/db/migrate/20190513155251_add_price_to_service_templates.rb
+++ b/db/migrate/20190513155251_add_price_to_service_templates.rb
@@ -1,0 +1,6 @@
+class AddPriceToServiceTemplates < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :service_templates, :currency, :type => :bigint
+    add_column :service_templates, :price, :float
+  end
+end


### PR DESCRIPTION
Add columns for price and currency to service templates. So a service author can specify the price when creating a service template.

Part of https://github.com/ManageIQ/manageiq/pull/18754

https://bugzilla.redhat.com/show_bug.cgi?id=1602072

@miq-bot add_label enhancement, hammer/no, changelog/yes