### PR TITLE
[WIP] Removing deleted Custom Buttons

### DIFF
--- a/db/migrate/20190509142148_update_custom_button_sets.rb
+++ b/db/migrate/20190509142148_update_custom_button_sets.rb
@@ -1,0 +1,21 @@
+class UpdateCustomButtonSets < ActiveRecord::Migration[5.0]
+  class MiqSet < ActiveRecord::Base
+    serialize :set_data
+  end
+
+  class CustomButton < ActiveRecord::Base; end
+
+  def up
+    say_with_time("Removing deleted buttons from Custom Button Sets") do
+      MiqSet.select(:id, :set_data).where(:set_type => 'CustomButtonSet').each do |cbs|
+        next if cbs.set_data[:button_order].blank?
+        existing_buttons = CustomButton
+          .where(:id => cbs.set_data[:button_order])
+          .order("position(id::text in '#{cbs.set_data[:button_order].join(',')}')")
+          .ids
+        cbs.set_data[:button_order] = existing_buttons
+        cbs.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20190509142148_update_custom_button_sets_spec.rb
+++ b/spec/migrations/20190509142148_update_custom_button_sets_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe UpdateCustomButtonSets do
+  let(:custom_button_set_stub) { migration_stub :MiqSet }
+  let(:custom_button_stub) { migration_stub :CustomButton }
+
+  migration_context :up do
+    it 'Removes non-existing buttons while keeping the buttons sorted' do
+      cb1 = custom_button_stub.create!(:id => 1)
+      cb2 = custom_button_stub.create!(:id => 2)
+      cb4 = custom_button_stub.create!(:id => 4)
+      cb5 = custom_button_stub.create!(:id => 5)
+      cb7 = custom_button_stub.create!(:id => 7)
+      cbs = custom_button_set_stub.create!(
+        :set_type => 'CustomButtonSet',
+        :set_data => { :button_order => [
+          cb1.id, cb7.id, cb2.id, cb4.id, 6, cb5.id, 3]})
+
+      migrate
+
+      cbs.reload
+      expect(cbs.set_data[:button_order]).to eql([cb1.id, cb7.id, cb2.id, cb4.id, cb5.id])
+    end
+  end
+end


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq/pull/18368 the purpose of `set_data[:button_order]`
has been changed, and an error is raised after going through an array,
where the button does not exist anymore

TODO:

before merging, this needs to 
  - update two forms
     1. (Automation -> Automate -> Generic Object) -> Add a new Button
     2. (Automation -> Automate -> Customization -> Buttons) -> Add a new Button
  - add a hook to remove id from CustomButtonSet every time CustomButton is removed

cc/ @lpichler @himdel 