### PR TITLE
Introduce :firmware_registry and :firmware_binary tables

### DIFF
--- a/db/migrate/20190514115219_create_firmware_registries.rb
+++ b/db/migrate/20190514115219_create_firmware_registries.rb
@@ -1,0 +1,11 @@
+class CreateFirmwareRegistries < ActiveRecord::Migration[5.0]
+  def change
+    create_table :firmware_registries do |t|
+      t.string   :name
+      t.datetime :last_refresh_on
+      t.text     :last_refresh_error
+      t.string   :type
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190514124322_create_firmware_binaries.rb
+++ b/db/migrate/20190514124322_create_firmware_binaries.rb
@@ -1,0 +1,13 @@
+class CreateFirmwareBinaries < ActiveRecord::Migration[5.0]
+  def change
+    create_table :firmware_binaries do |t|
+      t.string     :name
+      t.string     :external_ref
+      t.text       :description
+      t.string     :version
+      t.string     :type
+      t.references :firmware_registry, :type => :bigint, :index => true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190517093412_create_firmware_targets.rb
+++ b/db/migrate/20190517093412_create_firmware_targets.rb
@@ -1,0 +1,9 @@
+class CreateFirmwareTargets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :firmware_targets do |t|
+      t.string :manufacturer
+      t.string :model
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190517093516_create_firmware_binary_firmware_targets.rb
+++ b/db/migrate/20190517093516_create_firmware_binary_firmware_targets.rb
@@ -1,0 +1,10 @@
+class CreateFirmwareBinaryFirmwareTargets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :firmware_binaries_firmware_targets do |t|
+      t.references :firmware_binary, :type => :bigint, :index => false
+      t.references :firmware_target, :type => :bigint, :index => false
+
+      t.index %i[firmware_binary_id firmware_target_id], :unique => true, :name => :index_firmware_binaries_firmware_targets
+    end
+  end
+end


### PR DESCRIPTION
We introduce four new tables that correspond to three new Rails models needed for managing infrastructure firmware:

```
FirmwareRegistry
  .name             # unique name
  .last_refresh_on  # when relationships were last invoked
  .type             # needed for STI

FirmwareBinary
  .name        # freeform name
  .description # freeform description
  .version     # firmware version
  .type        # needed for STI

FirmwareTarget
      .manufacturer # physical component's manufacturer
      .model        # physical component's model name
```
The Binary and the Target are connected into many-to-many relation.

Needed for https://github.com/ManageIQ/manageiq/pull/18774

@miq-bot add_label schema,enhancement
@miq-bot assign @agrare

/cc @tadeboro @matejar