### PR TITLE
Add columns of price and currency to services.

### DIFF
--- a/db/migrate/20190520174739_add_price_to_services.rb
+++ b/db/migrate/20190520174739_add_price_to_services.rb
@@ -1,0 +1,6 @@
+class AddPriceToServices < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :services, :currency, :type => :bigint
+    add_column :services, :price, :float
+  end
+end


### PR DESCRIPTION
The price of a service template is set when a service author creates a catalog item or bundle and later on will be exposed when users order it.

The price of a service is set according to the catalog item/bundle price when ordering it. A service price does not change once set even when the service template price is changed later. A price of a deployed service is like a history record.

Followup of https://github.com/ManageIQ/manageiq-schema/pull/367

https://bugzilla.redhat.com/show_bug.cgi?id=1602072

@miq-bot add_label enhancement, hammer/no, changelog/yes