### PR TITLE
Add EmsLicense and EmsExtension tables

### DIFF
--- a/db/migrate/20190528160313_add_ems_licenses.rb
+++ b/db/migrate/20190528160313_add_ems_licenses.rb
@@ -1,0 +1,16 @@
+class AddEmsLicenses < ActiveRecord::Migration[5.0]
+  def change
+    create_table :ems_licenses, :id => :bigserial, :force => :cascade do |t|
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+
+      t.string  :ems_ref
+      t.string  :name
+      t.string  :license_key
+      t.string  :license_edition
+      t.integer :total_licenses
+      t.integer :used_licenses
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190528161746_add_ems_extensions.rb
+++ b/db/migrate/20190528161746_add_ems_extensions.rb
@@ -1,0 +1,16 @@
+class AddEmsExtensions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :ems_extensions, :id => :bigserial, :force => :cascade do |t|
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+
+      t.string :ems_ref
+      t.string :key
+      t.string :company
+      t.string :label
+      t.string :summary
+      t.string :version
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Add tables to track licenses and extensions off of an
ext_management_system.

Modeling: https://github.com/ManageIQ/manageiq/pull/18816
Provider collector: https://github.com/ManageIQ/manageiq-providers-vmware/pull/404

```
#<EmsLicense:0x00005626593b0d78
 id: 6,
 ems_id: 1,
 ems_ref: "0041L-4CKEL-18U9N-021HP-809KJ",
 name: "VMware vCenter Server 6 Standard",
 license_key: "0041L-4CKEL-18U9N-021HP-809KJ",
 license_edition: "vc.standard.instance",
 total_licenses: 6,
 used_licenses: 1,
 created_at: Tue, 28 May 2019 17:11:20 UTC +00:00,
 updated_at: Tue, 28 May 2019 17:11:20 UTC +00:00>
```

```
#<EmsExtension:0x0000562659236420
 id: 22,
 ems_id: 1,
 ems_ref: "com.vmware.vim.sms",
 key: "com.vmware.vim.sms",
 company: "VMware Inc.",
 label: "VMware vCenter Storage Monitoring Service",
 summary: "Storage Monitoring and Reporting",
 version: "6.7.0",
 created_at: Tue, 28 May 2019 17:42:48 UTC +00:00,
 updated_at: Tue, 28 May 2019 17:42:48 UTC +00:00>
 ```