### PR TITLE
Add guid to miq_databases

### DIFF
--- a/db/migrate/20190531161732_add_guid_to_miq_databases.rb
+++ b/db/migrate/20190531161732_add_guid_to_miq_databases.rb
@@ -1,0 +1,16 @@
+class AddGuidToMiqDatabases < ActiveRecord::Migration[5.2]
+  class MiqDatabase < ActiveRecord::Base
+  end
+
+  def up
+    add_column :miq_databases, :guid, :string, :limit => 36
+
+    say_with_time("Create default guids for miq_databases") do
+      MiqDatabase.all.each { |d| d.update!(:guid => SecureRandom.uuid) }
+    end
+  end
+
+  def down
+    remove_column :miq_databases, :guid
+  end
+end

--- a/spec/migrations/20190531161732_add_guid_to_miq_databases_spec.rb
+++ b/spec/migrations/20190531161732_add_guid_to_miq_databases_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe AddGuidToMiqDatabases do
+  let(:miq_database) { migration_stub(:MiqDatabase) }
+
+  migration_context :up do
+    it "sets miq_database guids" do
+      db = miq_database.create!
+
+      migrate
+
+      expect(db.reload.guid).to be_guid
+    end
+  end
+end


### PR DESCRIPTION
It turns out the only real "product-wide" guid we have is in
miq_regions, but the problem with miq_regions is that it's replicated,
so it's slightly complicated to find my_region.guid.  Instead, let's
have a miq_databases.guid.

@agrare @jrafanie Please review.

Note that some of the motivation is for identification via the Red Hat Cloud Services stuff.