### PR TITLE
Fix ActiveRecord Migration version

### DIFF
--- a/db/migrate/20190531161732_add_guid_to_miq_databases.rb
+++ b/db/migrate/20190531161732_add_guid_to_miq_databases.rb
@@ -1,4 +1,4 @@
-class AddGuidToMiqDatabases < ActiveRecord::Migration[5.2]
+class AddGuidToMiqDatabases < ActiveRecord::Migration[5.0]
   class MiqDatabase < ActiveRecord::Base
   end
 


### PR DESCRIPTION
ActiveRecord version 5.2 is unsupported by manageiq:
```
ArgumentError: Unknown migration version "5.2"; expected one of "4.2", "5.0"
/var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/migration/compatibility.rb:9:in `find'
/var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/migration.rb:528:in `[]'
...
```

Introduced by https://github.com/ManageIQ/manageiq-schema/pull/377