### PR TITLE
Don't sync the schema_migrations_ran table when adding it

### DIFF
--- a/db/migrate/20171031010000_add_schema_migrations_ran.rb
+++ b/db/migrate/20171031010000_add_schema_migrations_ran.rb
@@ -10,7 +10,9 @@ class AddSchemaMigrationsRan < ActiveRecord::Migration[5.0]
 
     pglogical = ActiveRecord::Base.connection.pglogical
     if pglogical.enabled? && pglogical.replication_sets.include?('miq')
-      pglogical.replication_set_add_table('miq', "schema_migrations_ran", true)
+      # don't do an initial data sync for this table
+      # we want the data do come in as it's replicated rather than in bulk
+      pglogical.replication_set_add_table('miq', "schema_migrations_ran", false)
     end
   end
 


### PR DESCRIPTION
The purpose of the table is to track when migrations are run on
remote regions. If we sync the whole table outside of the scope
of the transaction based replication then we're violating the
assumption that the migration version number only appears in the
global region when the data from that migration was replicated
up to the global region.

This was causing a timing issue where the sync could take place
just before the global region runs its migrations. Then the global
would blaze past migrations without successfully replicating up
the data needed for a particular schema version.

This could lead to an irrecoverable situation in replication where
the subscription would have to be removed and re-added.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1721596