### PR TITLE
Allow up to 5.1 versioned migrations

### DIFF
--- a/db/migrate/20160127210622_migrate_old_configuration_settings.rb
+++ b/db/migrate/20160127210622_migrate_old_configuration_settings.rb
@@ -58,7 +58,7 @@ class MigrateOldConfigurationSettings < ActiveRecord::Migration[4.2]
     return if roles.include?('user_interface')
 
     roles << 'user_interface'
-    config.store_path(:server, :role, roles.join(','))
+    config.store_path(:server, :role, roles.sort.join(','))
   end
 
   def update_old_web_service_worker_settings!(config)
@@ -68,7 +68,7 @@ class MigrateOldConfigurationSettings < ActiveRecord::Migration[4.2]
     return if roles.include?('web_services')
 
     roles << 'web_services'
-    config.store_path(:server, :role, roles.join(','))
+    config.store_path(:server, :role, roles.sort.join(','))
   end
 
   def update_old_event_catcher_settings!(config)

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "more_core_extensions", "~> 3.5"
   s.add_dependency "pg"
   s.add_dependency "pg-pglogical", "~> 2.1.1"
-  s.add_dependency "rails", ">= 5.0.7.1", "!= 5.2.0.x", "!= 5.2.1.0", "< 5.3"
+  s.add_dependency "rails", ">= 5.0.7.1", "!= 5.1.6.x", "< 5.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
- [x] can be merged earlier than [rails 5.1 support in manageiq](https://github.com/ManageIQ/manageiq/pull/18076)  since 5.1 versioned migrations is no worse than 5.2

PR #365 added support for rails 5.1 and 5.2 to schema.  Unfortunately,
manageiq isn't yet on rails 5.2 so it can't process 5.2 versioned
migrations as seen in #379.

https://github.com/ManageIQ/manageiq/pull/18076 is adding rails 5.1
support to manageiq, so let's change schema to 5.1 for now while we work
on 5.2 for manageiq.