### PR TITLE
Existing services should have a lifecycle state of provisioned

### DIFF
--- a/db/migrate/20190712135032_set_provisioned_state_to_services.rb
+++ b/db/migrate/20190712135032_set_provisioned_state_to_services.rb
@@ -1,0 +1,12 @@
+class SetProvisionedStateToServices < ActiveRecord::Migration[5.1]
+  class Service < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Update service lifecycle state values") do
+      Service.in_my_region.where(:lifecycle_state => nil, :retired => nil).update_all(:lifecycle_state => 'provisioned')
+    end
+  end
+end

--- a/spec/migrations/20190712135032_set_provisioned_state_to_services_spec.rb
+++ b/spec/migrations/20190712135032_set_provisioned_state_to_services_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe SetProvisionedStateToServices do
+  let(:service) { migration_stub(:Service) }
+
+  migration_context :up do
+    it "sets lifecycle state" do
+      obj1 = service.create!(:lifecycle_state => nil)
+
+      expect(obj1.reload.lifecycle_state).to eq(nil)
+
+      migrate
+
+      expect(obj1.reload.lifecycle_state).to eq('provisioned')
+    end
+  end
+end


### PR DESCRIPTION
Any existing service that isn't retired but is provisioned should have a lifecycle state of provisioned. 

I really wish this had been done as part of the earlier work for https://bugzilla.redhat.com/show_bug.cgi?id=1595511. 

@tinaafitz @lfu @gmcculloug 

This blocks https://github.com/ManageIQ/manageiq/pull/18943

@jrafanie please review? 