### PR TITLE
[WIP] Move ConfigurationScriptSource#authentication to GitRepository

### DIFF
--- a/db/migrate/20190723023214_add_authentication_id_to_git_repository.rb
+++ b/db/migrate/20190723023214_add_authentication_id_to_git_repository.rb
@@ -1,0 +1,5 @@
+class AddAuthenticationIdToGitRepository < ActiveRecord::Migration[5.1]
+  def change
+    add_column :git_repositories, :authentication_id, :bigint
+  end
+end

--- a/db/migrate/20190723023241_move_configuration_script_source_authentication_to_git_repository.rb
+++ b/db/migrate/20190723023241_move_configuration_script_source_authentication_to_git_repository.rb
@@ -1,0 +1,31 @@
+class MoveConfigurationScriptSourceAuthenticationToGitRepository < ActiveRecord::Migration[5.1]
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class GitRepository < ActiveRecord::Base
+    belongs_to :authentication, :class_name => parent::Authentication.name
+  end
+
+  class ConfigurationScriptSource < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :authentication, :class_name => parent::Authentication.name
+    belongs_to :git_repository, :class_name => parent::GitRepository.name
+  end
+
+  def up
+    say_with_time("Moving embedded ansible configuration_script_source authentication to git_repository") do
+      ConfigurationScriptSource.where(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource").each do |css|
+        unless css.git_repository
+          css.update!(:git_repository => GitRepository.create!(:url => scm_url))
+        end
+
+        if css.authentication
+          css.git_repository.update!(:authentication => css.authentication)
+          css.update!(:authentication_id => nil)  # TODO: Do we need this?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt to deal with the "double ownership problem" with ConfigurationScriptSource#authentication and GitRepository.  The idea is that in the model we can delegate authentication stuff to the GitRepository.  Thus, this migration first ensures that a git_repository exists, then moves the authentication over to it.

In GitRepository model, while it might have it's own authentication via AuthenticationMixin, we also add a separate `belongs_to :authentication` which is a referenced authentication.  This way we can support both directly owned authentications and not-owned authentications.

cc @gtanzillo @carbonin @agrare @NickLaMuro 