### PR TITLE
Reset column information to not have data migration stub cache conflicts 

### DIFF
--- a/db/migrate/20181010134649_add_evm_owner_to_orchestration_stacks.rb
+++ b/db/migrate/20181010134649_add_evm_owner_to_orchestration_stacks.rb
@@ -1,7 +1,12 @@
 class AddEvmOwnerToOrchestrationStacks < ActiveRecord::Migration[5.0]
+  class OrchestrationStack < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
   def change
     add_reference :orchestration_stacks, :evm_owner, :type => :bigint, :index => true
     add_reference :orchestration_stacks, :miq_group, :type => :bigint, :index => true
     add_reference :orchestration_stacks, :tenant,    :type => :bigint, :index => true
+    OrchestrationStack.reset_column_information
   end
 end

--- a/spec/migrations/20181010134649_add_evm_owner_to_orchestration_stacks_spec.rb
+++ b/spec/migrations/20181010134649_add_evm_owner_to_orchestration_stacks_spec.rb
@@ -1,0 +1,18 @@
+require_migration
+
+describe AddEvmOwnerToOrchestrationStacks do
+  let(:orchestration_stack) { migration_stub(:OrchestrationStack) }
+
+  migration_context :up do
+    it "reset column information to avoid RangeError" do
+      expect(self).to receive(:clear_caches).at_least(:once)
+      stack = orchestration_stack.create!
+
+      migrate
+
+      stack.reload
+      stack.update!(:evm_owner_id => 34_000_000_000_001)
+      expect(stack.evm_owner_id).to eq(34_000_000_000_001)
+    end
+  end
+end


### PR DESCRIPTION
Schema changes, if the stub for that table is already loaded, all subsequent data migrations for that table may fail if they're using the cached schema. So we need to reset the cache if it gets populated so we're not using the old column information. 

This is for backport to solve the bz only, there will be an incoming LJ PR to add reset_col_information more generally than just for OrchestrationStacks. Since the specs protect against this happening here: https://github.com/ManageIQ/manageiq-schema/blob/5e66328b27ec65372daddcec5a9daeef76803721/spec/support/migration_helper.rb#L67 we should do a more general fix for this going forward. 

thanks @jrafanie 

Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1732808