### PR TITLE
Migrate with cleared schema cache

### DIFF
--- a/lib/manageiq/schema/engine.rb
+++ b/lib/manageiq/schema/engine.rb
@@ -3,6 +3,11 @@ module ManageIQ
     class Engine < ::Rails::Engine
       isolate_namespace ManageIQ::Schema
 
+      ActiveSupport.on_load(:active_record) do
+        require_relative 'migrate_with_cleared_schema_cache'
+        ActiveRecord::Migration.prepend(MigrateWithClearedSchemaCache)
+      end
+
       initializer :append_migrations do |app|
         unless app.root.to_s.match root.to_s
           config.paths["db/migrate"].expanded.each do |expanded_path|

--- a/lib/manageiq/schema/migrate_with_cleared_schema_cache.rb
+++ b/lib/manageiq/schema/migrate_with_cleared_schema_cache.rb
@@ -1,0 +1,22 @@
+module ManageIQ
+  module Schema
+    module MigrateWithClearedSchemaCache
+      def migrate(*args)
+        clearing_caches do
+          super
+        end
+      end
+
+      private
+
+      def clear_caches
+        ActiveRecord::Base.connection.schema_cache.clear!
+      end
+
+      def clearing_caches
+        clear_caches
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
Alternative to https://github.com/ManageIQ/manageiq-schema/pull/398

Wrap each migration with a clearing of the schema cache to ensure the
schema/column information is not cached.  Since migrations very often
change schema, these caches are likely to get busted.

Migration authors don't realize they may need to reset the column
information whenever they change the schema so it's often overlooked.
It often doesn't cause a problem, until it does:

```
20180424141617_azure_backslash_to_forward_slash.rb
 - loads stub: class OrchestrationStack < ActiveRecord::Base
 - orchestration_stacks table column information is cached by table name

20181010134649_add_evm_owner_to_orchestration_stacks.rb
 - adds evm_owner, miq_group, tenant references (_id columns)

20181016140921_migrate_orch_stacks_to_have_ownership_concept.rb
 - loads stub: class OrchestrationStack < ActiveRecord::Base
 - uses cached table column information
 - Blows up trying to store bigint into what rails thinks is an integer column:
   stack.update_attributes(:evm_owner_id => user.id, :tenant_id =>
   user.current_tenant.id, :miq_group_id => user.current_group.id)
   '34000000000001 is out of range for ActiveModel::Type::Integer with
   limit 4 bytes'
```

This commit eliminates the need to reset column information for any of
these migrations as we clear the schema cache for all tables before each
migration.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732808