### PR TITLE
Move the embedded ansible proxy settings to a top level git repo key

### DIFF
--- a/db/migrate/20190809193031_move_embedded_ansible_proxy_setting_to_git_repository_proxy_settings.rb
+++ b/db/migrate/20190809193031_move_embedded_ansible_proxy_setting_to_git_repository_proxy_settings.rb
@@ -1,0 +1,23 @@
+class MoveEmbeddedAnsibleProxySettingToGitRepositoryProxySettings < ActiveRecord::Migration[5.1]
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  def up
+    say_with_time("Moving embedded ansible proxy settings to git repository proxy settings") do
+      SettingsChange.where("key LIKE ?", "/http_proxy/embedded_ansible/%").each do |s|
+        s.key = s.key.sub("/http_proxy/embedded_ansible", "/git_repository_proxy")
+        s.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time("Moving git repository proxy settings to embedded ansible proxy settings") do
+      SettingsChange.where("key LIKE ?", "/git_repository_proxy/%").each do |s|
+        s.key = s.key.sub("/git_repository_proxy", "/http_proxy/embedded_ansible")
+        s.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20190809193031_move_embedded_ansible_proxy_setting_to_git_repository_proxy_settings_spec.rb
+++ b/spec/migrations/20190809193031_move_embedded_ansible_proxy_setting_to_git_repository_proxy_settings_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe MoveEmbeddedAnsibleProxySettingToGitRepositoryProxySettings do
+  let(:settings_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "moves the embedded ansible settings to git repository settings" do
+      settings_stub.create!(:key => "/http_proxy/embedded_ansible/host", :value => "example.com")
+      settings_stub.create!(:key => "/http_proxy/embedded_ansible/password", :value => "password")
+      settings_stub.create!(:key => "/http_proxy/embedded_ansible/port", :value => 80)
+      settings_stub.create!(:key => "/http_proxy/embedded_ansible/user", :value => "root")
+      settings_stub.create!(:key => "/http_proxy/embedded_ansible/scheme", :value => "http")
+
+      migrate
+
+      expect(settings_stub.where(:key => "/git_repository_proxy/host").first.value).to eq("example.com")
+      expect(settings_stub.where(:key => "/git_repository_proxy/password").first.value).to eq("password")
+      expect(settings_stub.where(:key => "/git_repository_proxy/port").first.value).to eq(80)
+      expect(settings_stub.where(:key => "/git_repository_proxy/user").first.value).to eq("root")
+      expect(settings_stub.where(:key => "/git_repository_proxy/scheme").first.value).to eq("http")
+    end
+  end
+
+  migration_context :down do
+    it "moves the git repository settings to embedded ansible settings" do
+      settings_stub.create!(:key => "/git_repository_proxy/host", :value => "example.com")
+      settings_stub.create!(:key => "/git_repository_proxy/password", :value => "password")
+      settings_stub.create!(:key => "/git_repository_proxy/port", :value => 80)
+      settings_stub.create!(:key => "/git_repository_proxy/user", :value => "root")
+      settings_stub.create!(:key => "/git_repository_proxy/scheme", :value => "http")
+
+      migrate
+
+      expect(settings_stub.where(:key => "/http_proxy/embedded_ansible/host").first.value).to eq("example.com")
+      expect(settings_stub.where(:key => "/http_proxy/embedded_ansible/password").first.value).to eq("password")
+      expect(settings_stub.where(:key => "/http_proxy/embedded_ansible/port").first.value).to eq(80)
+      expect(settings_stub.where(:key => "/http_proxy/embedded_ansible/user").first.value).to eq("root")
+      expect(settings_stub.where(:key => "/http_proxy/embedded_ansible/scheme").first.value).to eq("http")
+    end
+  end
+end


### PR DESCRIPTION
Without this there is no real way to determine which git repository
instances should pass the proxy settings and which shouldn't.

By making this change we are assuming that if you want a proxy
for getting to your git repositories for embedded ansible you
will likely also want to use that proxy for accessing automate
domain git repos. I think this is a fair assumption.

https://bugzilla.redhat.com/show_bug.cgi?id=1735712