### PR TITLE
Rename service display column to visible.

### DIFF
--- a/db/migrate/20190827141149_rename_service_display_to_visible.rb
+++ b/db/migrate/20190827141149_rename_service_display_to_visible.rb
@@ -1,0 +1,5 @@
+class RenameServiceDisplayToVisible < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :services, :display, :visible
+  end
+end


### PR DESCRIPTION
To avoid the name conflict with Kernel#display method.

Blocks https://github.com/ManageIQ/manageiq/pull/19211.
https://bugzilla.redhat.com/show_bug.cgi?id=1737559

@miq-bot add_label bug, ivanchuk/no, changelog/yes