### PR TITLE
Add a speed column to guest_devices

### DIFF
--- a/db/migrate/20190830133434_add_speed_to_guest_devices.rb
+++ b/db/migrate/20190830133434_add_speed_to_guest_devices.rb
@@ -1,0 +1,5 @@
+class AddSpeedToGuestDevices < ActiveRecord::Migration[5.1]
+  def change
+    add_column :guest_devices, :speed, :bigint
+  end
+end


### PR DESCRIPTION
Add a column tracking the speed of a guest_device in bits-per-second.
Both NICs and Storage Adapters have a speed associated with them and
this is important information to know.