### PR TITLE
Set zone's visible column default true and update existing rows

### DIFF
--- a/db/migrate/20190909195908_set_zone_visible_column_default_true.rb
+++ b/db/migrate/20190909195908_set_zone_visible_column_default_true.rb
@@ -1,0 +1,9 @@
+class SetZoneVisibleColumnDefaultTrue < ActiveRecord::Migration[5.0]
+  class Zone < ActiveRecord::Base
+  end
+
+  def change
+    change_column_default(:zones, :visible, :from => nil, :to => true)
+    Zone.where(:visible => nil).update_all(:visible => true)
+  end
+end

--- a/spec/migrations/20190909195908_set_zone_visible_column_default_true_spec.rb
+++ b/spec/migrations/20190909195908_set_zone_visible_column_default_true_spec.rb
@@ -1,0 +1,30 @@
+require_migration
+
+describe SetZoneVisibleColumnDefaultTrue do
+  let(:zone_stub) { migration_stub(:Zone) }
+
+  migration_context :up do
+    it "changes visible => nil to true" do
+      zone = zone_stub.create(:visible => nil)
+      migrate
+      zone.reload
+      expect(zone.visible).to be true
+    end
+  end
+
+  migration_context :down do
+    it "leaves visible => true as true because we can't assume it was previously nil" do
+      zone = zone_stub.create(:visible => true)
+      migrate
+      zone.reload
+      expect(zone.visible).to be true
+    end
+
+    it "changes visible => nil to true, it doesn't reverse the update_all when running it" do
+      zone = zone_stub.create(:visible => nil)
+      migrate
+      zone.reload
+      expect(zone.visible).to be true
+    end
+  end
+end


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1749694

With hammer (rails 5.0), Zone.seed was not creating the default zone with visible => true, causing it to remain nil. The hammer UI code wasn't checking this when displaying zones in the UI.

When we upgraded to Ivanchuk/rails 5.1, the UI now checks for visible and these visible => nil zones created in hammer would not be visible.  Note, Ivanchuk (rails 5.1),  Zone.seed does create the default zone with visible => true.

To be safe, this migration not only relies on postgresql's column default to set Zone visible but also updates existing records from visible => nil to visible => true.