### PR TITLE
Remove rails_server setting

### DIFF
--- a/db/migrate/20190918133037_remove_rails_server_from_settings.rb
+++ b/db/migrate/20190918133037_remove_rails_server_from_settings.rb
@@ -1,0 +1,10 @@
+class RemoveRailsServerFromSettings < ActiveRecord::Migration[5.1]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Remove rails_server settings") do
+      SettingsChange.where(:key => "/server/rails_server").delete_all
+    end
+  end
+end

--- a/spec/migrations/20190918133037_remove_rails_server_from_settings_spec.rb
+++ b/spec/migrations/20190918133037_remove_rails_server_from_settings_spec.rb
@@ -1,0 +1,19 @@
+require_migration
+
+describe RemoveRailsServerFromSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    let(:worker_stub) { migration_stub(:MiqWorker) }
+
+    it "removes rows with /server/rails_server key" do
+      setting_changed = settings_change_stub.create!(:key => "/server/rails_server", :value => "thin")
+      setting_ignored = settings_change_stub.create!(:key => "/server/other_key", :value => "something")
+
+      migrate
+
+      expect { setting_changed.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(setting_ignored.reload.value).to eq("something")
+    end
+  end
+end


### PR DESCRIPTION
```rails_server``` setting not in use anymore, since we are always using ```puma```

need to remove not used records after https://github.com/ManageIQ/manageiq/pull/19304

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1752870

