### PR TITLE
Handle faulty v2_key while upgrading ansible (with specs)

### DIFF
--- a/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
+++ b/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
@@ -12,6 +12,7 @@ describe MoveAwxCredentialsToAuthentications do
   let(:authentication) { migration_stub(:Authentication) }
   let(:miq_database)   { migration_stub(:MiqDatabase) }
 
+  let(:awx_conn)        { instance_double(PG::Connection) }
   let(:secret_key)      { "ecad5764714a254a619d74ccc1c4387b" }
   let(:miq_database_id) { miq_database.create.id }
 
@@ -117,8 +118,6 @@ describe MoveAwxCredentialsToAuthentications do
     end
 
     context "with an awx database connection" do
-      let(:awx_conn) { instance_double(PG::Connection) }
-
       before do
         allow(PG::Connection).to receive(:new).with(a_hash_including(:dbname => "awx")).and_return(awx_conn)
       end

--- a/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
+++ b/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
@@ -259,34 +259,77 @@ describe MoveAwxCredentialsToAuthentications do
 
         expect_authentications_migrated
       end
+
+      context "with a 'bogus' secret key (DB restore use case)" do
+        let(:secret_key) { "invalid" }
+
+        before do
+          # load the initial set of authentication records
+          auths = YAML.load_file(data_dir.join("vmdb_authentications.yaml"))
+          auths.each { |auth| authentication.create!(auth["initial"]) }
+
+          stub_awx_credentials(awx_conn, true)
+        end
+
+        it "fails to migrate real data and fails with an error" do
+          expect { migrate }.to raise_error(described_class::Fernet256::InvalidToken)
+        end
+
+        context "with $HARDCODE_ANSIBLE_PASSWORD set 'bogus'" do
+          around do |example|
+            begin
+              old_env = ENV.delete("HARDCODE_ANSIBLE_PASSWORD")
+              ENV["HARDCODE_ANSIBLE_PASSWORD"] = 'bogus'
+
+              example.run
+            ensure
+              ENV["HARDCODE_ANSIBLE_PASSWORD"] = old_env
+            end
+          end
+
+          it "sets a default if the value fails to decrypt" do
+            migrate
+            expect_authentications_migrated('bogus')
+          end
+        end
+      end
     end
   end
 
-  def stub_awx_cred_for_id(connection, id, data)
-    expect(connection).to receive(:async_exec).with("SELECT inputs FROM main_credential WHERE id = $1::BIGINT", [id]).and_return(data)
+  def stub_awx_cred_for_id(connection, id, data, rspec_allow = false)
+    query = ["SELECT inputs FROM main_credential WHERE id = $1::BIGINT", [id]]
+
+    if rspec_allow
+      allow(connection)
+    else
+      expect(connection)
+    end.to receive(:async_exec).with(*query).and_return(data)
   end
 
-  def stub_awx_credentials(connection)
+  def stub_awx_credentials(connection, rspec_allow = false)
     credentials = YAML.load_file(data_dir.join("credential_attributes.yaml"))
     credentials.each do |cred|
       data = cred["attributes"].to_json
-      stub_awx_cred_for_id(connection, cred["id"], [{"inputs" => data}])
+      stub_awx_cred_for_id(connection, cred["id"], [{"inputs" => data}], rspec_allow)
     end
   end
 
-  def expect_authentications_migrated
+  def expect_authentications_migrated(using_hardcoded_secret = nil)
     authentications = YAML.load_file(data_dir.join("vmdb_authentications.yaml"))
     authentications.each do |auth|
       attrs = auth["migrated"]
-      expected_attrs = encrypt_values(attrs)
+      expected_attrs = encrypt_values(attrs, using_hardcoded_secret)
       expect(authentication.find_by(:name => attrs["name"], :type => attrs["type"])).to have_attributes(expected_attrs)
     end
   end
 
-  def encrypt_values(attrs)
+  def encrypt_values(attrs, using_hardcoded_secret = nil)
     attrs.dup.tap do |h|
       %w[auth_key auth_key_password become_password password].each do |key|
-        h[key] = ManageIQ::Password.encrypt(h[key].chomp) if h.key?(key)
+        if h.key?(key)
+          value_to_encrypt = using_hardcoded_secret || h[key].chomp
+          h[key] = ManageIQ::Password.encrypt(value_to_encrypt)
+        end
       end
     end
   end


### PR DESCRIPTION
This is an update to #418 which adds specs (and a few minor refactor commits to support) to ensure we are working with the new code properly.  (mostly) original PR description below:


Situation:
----------

When importing a foreign database, the v2_key and therefore the ansible key is not available.  Which is good/ok since we shouldn't be able to read a customer's passwords anyway.

What is bad is there is no way to work with this scenario. The database simply can not be migrated.


Solution:
---------

Provide a way to continue even though we can't read all the ansible passwords.

run migration with env variable to just get bogus passwords

```console
$ HARDCODE_ANSIBLE_PASSWORD=bogus rake db:migrate
```

Also adds some specs around the use cases where the `secret_key` provided doesn't exist or does not match what is provided, as well as testing the workaround in those cases.


Links
-----

- original PR: https://github.com/ManageIQ/manageiq-schema/pull/385
- https://bugzilla.redhat.com/show_bug.cgi?id=1755553