### PR TITLE
Connect CloudNetwork, NetworkPort and SecurityGroup to ResourceGroup

### DIFF
--- a/db/migrate/20190930054405_add_resource_group_id_to_cloud_network.rb
+++ b/db/migrate/20190930054405_add_resource_group_id_to_cloud_network.rb
@@ -1,0 +1,5 @@
+class AddResourceGroupIdToCloudNetwork < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :cloud_networks, :resource_group, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20190930054416_add_resource_group_id_to_network_port.rb
+++ b/db/migrate/20190930054416_add_resource_group_id_to_network_port.rb
@@ -1,0 +1,5 @@
+class AddResourceGroupIdToNetworkPort < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :network_ports, :resource_group, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20190930054424_add_resource_group_id_to_security_group.rb
+++ b/db/migrate/20190930054424_add_resource_group_id_to_security_group.rb
@@ -1,0 +1,5 @@
+class AddResourceGroupIdToSecurityGroup < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :security_groups, :resource_group, :type => :bigint, :index => true
+  end
+end


### PR DESCRIPTION
In this PR we provide three simple migrations that add a reference to a `ResourceGroup` for `CloudNetwork`, `NetworkPort` and `SecurityGroup` models. So far, only VMs have a reference to the resource group they belong to. 

This change is proposed to allow simpler inventorying process in AzureStack provider later on. In Azure and AzureStack, these entities are always managed as a part of a resource group, and we aim to support a resource group refresh target. Without this change, we would need to infer the related targets based on individual resource's `ems_ref`, which contains the resource group name.

@miq-bot assign @agrare