### PR TITLE
Drop the quadicon settings from Users' settings as it's obsolete

### DIFF
--- a/db/migrate/20191002103406_remove_quadicon_settings.rb
+++ b/db/migrate/20191002103406_remove_quadicon_settings.rb
@@ -1,0 +1,18 @@
+class RemoveQuadiconSettings < ActiveRecord::Migration[5.0]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time("Dropping quadicon settings keys from user settings") do
+      User.where("settings like '%quadicons%'").each do |user|
+        settings = user.settings
+
+        next unless settings[:quadicons]
+
+        settings.delete(:quadicons)
+        user.update!(:settings => settings)
+      end
+    end
+  end
+end

--- a/spec/migrations/20191002103406_remove_quadicon_settings_spec.rb
+++ b/spec/migrations/20191002103406_remove_quadicon_settings_spec.rb
@@ -1,0 +1,26 @@
+require_migration
+
+describe RemoveQuadiconSettings do
+  migration_context :up do
+    let(:user_stub) { migration_stub(:User) }
+
+    it "removes the quadicon from user settings" do
+      u = user_stub.create!(:settings => { :quadicons => { :foo => :bar }, :foo => :bar })
+
+      expect(u.settings[:quadicons]).not_to be_nil
+
+      migrate
+
+      expect(u.reload.settings[:quadicons]).to be_nil
+      expect(u.settings[:foo]).to eq(:bar)
+    end
+
+    it "doesn't affect users without a quadicon setting" do
+      u = user_stub.create!(:settings => { :foo => :bar })
+
+      migrate
+
+      expect(u.reload.settings[:foo]).to eq(:bar)
+    end
+  end
+end


### PR DESCRIPTION
This is an irreversible migration as I'm deleting an obsolete key from a hash. The issue has been discussed and approved by UX [here](https://github.com/ManageIQ/manageiq-ui-classic/issues/6069) and the deletion of the per-user quadicon setting has been done [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6255).

@miq-bot add_reviewer @lpichler 
@miq-bot add_label ivanchuk/no, cleanup