### PR TITLE
Add indexes to various tables

### DIFF
--- a/db/migrate/20191017211747_add_general_indexes.rb
+++ b/db/migrate/20191017211747_add_general_indexes.rb
@@ -1,0 +1,13 @@
+class AddGeneralIndexes < ActiveRecord::Migration[5.1]
+  def change
+    add_index :miq_schedules, :updated_at
+    add_index :blacklisted_events, [:ems_id, :enabled]
+    add_index :key_pairs_vms, :vm_id
+    add_index :miq_requests, [:tenant_id, :approval_state]
+    add_index :miq_roles_features, :miq_user_role_id
+    add_index :miq_queue, [:state, :handler_type, :handler_id]
+    add_index :vms, :tenant_id
+    add_index :entitlements, :miq_group_id
+    add_index :endpoints, [:resource_id, :resource_type]
+  end
+end


### PR DESCRIPTION
Add a few miscellaneous indexes to various tables

Fixes https://github.com/ManageIQ/manageiq/issues/13888

I skipped creating index on `event_streams (type,target_id,target_type)` - those indexes are just too expensive without further analysis.

Looks like one index was already created: `network_ports (device_id,device_type)`