### PR TITLE
Remove ems_ref_obj YAML column

### DIFF
--- a/db/migrate/20191023180130_update_openstack_hosts_uid_ems.rb
+++ b/db/migrate/20191023180130_update_openstack_hosts_uid_ems.rb
@@ -5,9 +5,7 @@ class UpdateOpenstackHostsUidEms < ActiveRecord::Migration[5.1]
   end
 
   def up
-    Host.in_my_region.where(:type => "ManageIQ::Providers::Openstack::InfraManager::Host").find_each do |host|
-      next if host.ems_ref_obj.nil?
-
+    Host.in_my_region.where(:type => "ManageIQ::Providers::Openstack::InfraManager::Host").where.not(:ems_ref_obj => nil).find_each do |host|
       host.uid_ems = YAML.safe_load(host.ems_ref_obj)
       host.save!
     end

--- a/db/migrate/20191023180130_update_openstack_hosts_uid_ems.rb
+++ b/db/migrate/20191023180130_update_openstack_hosts_uid_ems.rb
@@ -1,0 +1,23 @@
+class UpdateOpenstackHostsUidEms < ActiveRecord::Migration[5.1]
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    Host.in_my_region.where(:type => "ManageIQ::Providers::Openstack::InfraManager::Host").find_each do |host|
+      next if host.ems_ref_obj.nil?
+
+      host.uid_ems = YAML.safe_load(host.ems_ref_obj)
+      host.save!
+    end
+  end
+
+  def down
+    Host.in_my_region.where(:type => "ManageIQ::Providers::Openstack::InfraManager::Host").find_each do |host|
+      host.ems_ref_obj = YAML.dump(host.uid_ems)
+      host.uid_ems     = host.ems_ref
+      host.save!
+    end
+  end
+end

--- a/db/migrate/20191023180149_add_ems_ref_type.rb
+++ b/db/migrate/20191023180149_add_ems_ref_type.rb
@@ -1,0 +1,11 @@
+class AddEmsRefType < ActiveRecord::Migration[5.1]
+  def change
+    add_column :ems_clusters, :ems_ref_type, :string
+    add_column :ems_folders, :ems_ref_type, :string
+    add_column :hosts, :ems_ref_type, :string
+    add_column :resource_pools, :ems_ref_type, :string
+    add_column :snapshots, :ems_ref_type, :string
+    add_column :storages, :ems_ref_type, :string
+    add_column :vms, :ems_ref_type, :string
+  end
+end

--- a/db/migrate/20191023180330_migrate_ems_ref_obj_to_ems_ref_type.rb
+++ b/db/migrate/20191023180330_migrate_ems_ref_obj_to_ems_ref_type.rb
@@ -45,8 +45,13 @@ class MigrateEmsRefObjToEmsRefType < ActiveRecord::Migration[5.1]
   def down
     MODELS_WITH_EMS_REF_OBJ.each do |klass|
       say_with_time("Converting ems_ref_type to ems_ref_obj for #{klass.name}") do
-        # Skip any records that have ems_ref_obj set already
-        klass.in_my_region.where(:ems_ref_type => nil, :ems_ref_obj => nil).find_each do |obj|
+        # Skip any records that have ems_ref_obj set already and don't have ems_ref_type set
+        query_params = {:ems_ref_type => nil, :ems_ref_obj => nil}
+
+        # Skip cloud VMs which never had ems_ref_obj set
+        query_params[:cloud] = [nil, false] if klass == VmOrTemplate
+
+        klass.in_my_region.where(query_params).find_each do |obj|
           obj.update!(:ems_ref_obj => "--- #{obj.ems_ref}\n")
         end
 

--- a/db/migrate/20191023180330_migrate_ems_ref_obj_to_ems_ref_type.rb
+++ b/db/migrate/20191023180330_migrate_ems_ref_obj_to_ems_ref_type.rb
@@ -1,0 +1,80 @@
+class MigrateEmsRefObjToEmsRefType < ActiveRecord::Migration[5.1]
+  class EmsCluster < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+  class EmsFolder < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+  class Host < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+  class ResourcePool < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+  class Snapshot < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+  class Storage < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+  class VmOrTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    self.table_name         = "vms"
+    include ActiveRecord::IdRegions
+  end
+
+  MODELS_WITH_EMS_REF_OBJ = [EmsCluster, EmsFolder, Host, ResourcePool, Snapshot, Storage, VmOrTemplate].freeze
+
+  def up
+    MODELS_WITH_EMS_REF_OBJ.each do |klass|
+      say_with_time("Converting ems_ref_obj to ems_ref_type for #{klass.name}") do
+        klass.in_my_region.where("ems_ref_obj LIKE '%VimString%'").find_each do |obj|
+          ems_ref_type = parse_ems_ref_obj(obj.ems_ref_obj)["vimType"]
+          obj.update!(:ems_ref_type => ems_ref_type)
+        end
+      end
+    end
+  end
+
+  def down
+    MODELS_WITH_EMS_REF_OBJ.each do |klass|
+      say_with_time("Converting ems_ref_type to ems_ref_obj for #{klass.name}") do
+        klass.in_my_region.where(:ems_ref_type => nil).find_each do |obj|
+          obj.update!(:ems_ref_obj => "--- #{obj.ems_ref}\n")
+        end
+
+        klass.in_my_region.where.not(:ems_ref_type => nil).find_each do |obj|
+          ems_ref_obj = <<~EMS_REF_OBJ
+            --- !ruby/string:VimString
+            str: #{obj.ems_ref}
+            xsiType: :ManagedObjectReference
+            vimType: :#{obj.ems_ref_type}
+          EMS_REF_OBJ
+
+          obj.update!(:ems_ref_obj => ems_ref_obj)
+        end
+      end
+    end
+  end
+
+  private
+
+  def parse_ems_ref_obj(ems_ref_obj)
+    Hash[
+      ems_ref_obj.split("\n")[1..-1].map do |o|
+        key, val = o.split(": ")
+
+        # Convert symbol values from ":Type" to :Type
+        val = val[1..-1].to_sym if val[0] == ':'
+
+        [key, val]
+      end.compact
+    ]
+  end
+end

--- a/db/migrate/20191023180330_migrate_ems_ref_obj_to_ems_ref_type.rb
+++ b/db/migrate/20191023180330_migrate_ems_ref_obj_to_ems_ref_type.rb
@@ -45,7 +45,8 @@ class MigrateEmsRefObjToEmsRefType < ActiveRecord::Migration[5.1]
   def down
     MODELS_WITH_EMS_REF_OBJ.each do |klass|
       say_with_time("Converting ems_ref_type to ems_ref_obj for #{klass.name}") do
-        klass.in_my_region.where(:ems_ref_type => nil).find_each do |obj|
+        # Skip any records that have ems_ref_obj set already
+        klass.in_my_region.where(:ems_ref_type => nil, :ems_ref_obj => nil).find_each do |obj|
           obj.update!(:ems_ref_obj => "--- #{obj.ems_ref}\n")
         end
 

--- a/db/migrate/20191113200451_remove_ems_ref_obj.rb
+++ b/db/migrate/20191113200451_remove_ems_ref_obj.rb
@@ -1,0 +1,11 @@
+class RemoveEmsRefObj < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :ems_clusters, :ems_ref_obj, :string
+    remove_column :ems_folders, :ems_ref_obj, :string
+    remove_column :hosts, :ems_ref_obj, :string
+    remove_column :resource_pools, :ems_ref_obj, :string
+    remove_column :snapshots, :ems_ref_obj, :string
+    remove_column :storages, :ems_ref_obj, :string
+    remove_column :vms, :ems_ref_obj, :string
+  end
+end

--- a/spec/migrations/20191023180130_update_openstack_hosts_uid_ems_spec.rb
+++ b/spec/migrations/20191023180130_update_openstack_hosts_uid_ems_spec.rb
@@ -1,0 +1,64 @@
+require_migration
+
+describe UpdateOpenstackHostsUidEms do
+  let(:host_stub) { migration_stub(:Host) }
+
+  migration_context :up do
+    it "updates the uid_ems to be the old ems_ref_obj" do
+      host_instance_id = SecureRandom.uuid
+      host = host_stub.create!(
+        :type        => "ManageIQ::Providers::Openstack::InfraManager::Host",
+        :ems_ref     => "some-other_ref",
+        :ems_ref_obj => YAML.dump(host_instance_id),
+        :uid_ems     => "some_other_ref"
+      )
+
+      migrate
+
+      expect(host.reload.uid_ems).to eq(host_instance_id)
+    end
+
+    it "doesn't update non-openstack hosts" do
+      host = host_stub.create!(
+        :type        => "ManageIQ::Providers::Vmware::InfraManager::Host",
+        :ems_ref     => "host-123",
+        :ems_ref_obj => YAML.dump("host-123"),
+        :uid_ems     => "abcd"
+      )
+
+      migrate
+
+      expect(host.reload.uid_ems).to eq("abcd")
+    end
+  end
+
+  migration_context :down do
+    it "updates the ems_ref_obj to be the uid_ems" do
+      host_instance_id = SecureRandom.uuid
+      host = host_stub.create!(
+        :type    => "ManageIQ::Providers::Openstack::InfraManager::Host",
+        :ems_ref => "some-other_ref",
+        :uid_ems => host_instance_id
+      )
+
+      migrate
+
+      host.reload
+      expect(host.uid_ems).to     eq(host.ems_ref)
+      expect(host.ems_ref_obj).to eq(YAML.dump(host_instance_id))
+    end
+
+    it "doesn't update non-openstack hosts" do
+      host = host_stub.create!(
+        :type        => "ManageIQ::Providers::Vmware::InfraManager::Host",
+        :ems_ref     => "host-123",
+        :ems_ref_obj => YAML.dump("host-123"),
+        :uid_ems     => "abcd"
+      )
+
+      migrate
+
+      expect(host.reload.uid_ems).to eq("abcd")
+    end
+  end
+end

--- a/spec/migrations/20191023180130_update_openstack_hosts_uid_ems_spec.rb
+++ b/spec/migrations/20191023180130_update_openstack_hosts_uid_ems_spec.rb
@@ -30,6 +30,19 @@ describe UpdateOpenstackHostsUidEms do
 
       expect(host.reload.uid_ems).to eq("abcd")
     end
+
+    it "skips hosts with nil ems_ref_obj" do
+      host = host_stub.create!(
+        :type        => "ManageIQ::Providers::Openstack::InfraManager::Host",
+        :ems_ref     => "some-other_ref",
+        :ems_ref_obj => nil,
+        :uid_ems     => "some_other_ref"
+      )
+
+      migrate
+
+      expect(host.reload.uid_ems).to eq("some_other_ref")
+    end
   end
 
   migration_context :down do

--- a/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
+++ b/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
@@ -83,7 +83,8 @@ describe MigrateEmsRefObjToEmsRefType do
       vm = vm_stub.create!(
         :type        => "ManageIQ::Providers::Amazon::CloudManager::Vm",
         :ems_ref     => "b7212ae9-e968-4431-bb17-cc16d5095cd0",
-        :ems_ref_obj => nil
+        :ems_ref_obj => nil,
+        :cloud       => true
       )
 
       migrate
@@ -124,6 +125,19 @@ describe MigrateEmsRefObjToEmsRefType do
       migrate
 
       expect(host.reload.ems_ref_obj).to eq(ems_ref_obj)
+    end
+
+    it "ignores cloud vms" do
+      vm = vm_stub.create!(
+        :type        => "ManageIQ::Providers::Amazon::CloudManager::Vm",
+        :ems_ref     => "b7212ae9-e968-4431-bb17-cc16d5095cd0",
+        :ems_ref_obj => nil,
+        :cloud       => true
+      )
+
+      migrate
+
+      expect(vm.reload.ems_ref_obj).to be_nil
     end
   end
 end

--- a/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
+++ b/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
@@ -78,6 +78,20 @@ describe MigrateEmsRefObjToEmsRefType do
 
       expect(vm.reload.ems_ref_type).to be_nil
     end
+
+    it "ignores ems_ref_obj if it is nil" do
+      vm = vm_stub.create!(
+        :type        => "ManageIQ::Providers::Amazon::CloudManager::Vm",
+        :ems_ref     => "b7212ae9-e968-4431-bb17-cc16d5095cd0",
+        :ems_ref_obj => nil
+      )
+
+      migrate
+
+      vm.reload
+      expect(vm.ems_ref_type).to be_nil
+      expect(vm.ems_ref).to eq("b7212ae9-e968-4431-bb17-cc16d5095cd0")
+    end
   end
 
   migration_context :down do

--- a/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
+++ b/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
@@ -97,5 +97,19 @@ describe MigrateEmsRefObjToEmsRefType do
       migrate
       expect(vm.reload.ems_ref_obj).to eq("--- b7212ae9-e968-4431-bb17-cc16d5095cd0\n")
     end
+
+    it "ignores hosts that have ems_ref_obj set already" do
+      host_instance_uuid = SecureRandom.uuid
+      ems_ref_obj        = YAML.dump(host_instance_uuid)
+      host = host_stub.create!(
+        :type        => "ManageIQ::Providers::Openstack::InfraManager::Host",
+        :ems_ref_obj => ems_ref_obj,
+        :ems_ref     => "host-123"
+      )
+
+      migrate
+
+      expect(host.reload.ems_ref_obj).to eq(ems_ref_obj)
+    end
   end
 end

--- a/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
+++ b/spec/migrations/20191023180330_migrate_ems_ref_obj_to_ems_ref_type_spec.rb
@@ -1,0 +1,101 @@
+require_migration
+
+describe MigrateEmsRefObjToEmsRefType do
+  let(:cluster_stub)       { migration_stub(:EmsCluster) }
+  let(:folder_stub)        { migration_stub(:EmsFolder) }
+  let(:host_stub)          { migration_stub(:Host) }
+  let(:resource_pool_stub) { migration_stub(:ResourcePool) }
+  let(:storage_stub)       { migration_stub(:Storage) }
+  let(:vm_stub)            { migration_stub(:VmOrTemplate) }
+
+  migration_context :up do
+    it "migrates ems_ref_obj to ems_ref_type" do
+      vm = vm_stub.create!(
+        :type        => "ManageIQ::Providers::Vmware::InfraManager::Vm",
+        :ems_ref     => "vm-123",
+        :ems_ref_obj => <<~EMS_REF_OBJ
+          --- !ruby/string:VimString
+          str: vm-1234
+          xsiType: :ManagedObjectReference
+          vimType: :VirtualMachine
+        EMS_REF_OBJ
+      )
+      host = host_stub.create!(
+        :type        => "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
+        :ems_ref     => "host-123",
+        :ems_ref_obj => <<~EMS_REF_OBJ
+          --- !ruby/string:VimString
+          str: host-1234
+          xsiType: :ManagedObjectReference
+          vimType: :HostSystem
+        EMS_REF_OBJ
+      )
+      cluster = cluster_stub.create!(
+        :ems_ref     => "domain-c1234",
+        :ems_ref_obj => <<~EMS_REF_OBJ
+          --- !ruby/string:VimString
+          str: domain-c1234
+          xsiType: :ManagedObjectReference
+          vimType: :ClusterComputeResource
+        EMS_REF_OBJ
+      )
+      respool = resource_pool_stub.create!(
+        :ems_ref     => "resgroup-1234",
+        :ems_ref_obj => <<~EMS_REF_OBJ
+          --- !ruby/string:VimString
+          str: resgroup-1234
+          xsiType: :ManagedObjectReference
+          vimType: :ResourcePool
+        EMS_REF_OBJ
+      )
+      storage = storage_stub.create!(
+        :ems_ref     => "datastore-1234",
+        :ems_ref_obj => <<~EMS_REF_OBJ
+          --- !ruby/string:VimString
+          str: datastore-1234
+          xsiType: :ManagedObjectReference
+          vimType: :Datastore
+        EMS_REF_OBJ
+      )
+
+      migrate
+
+      expect(vm.reload.ems_ref_type).to      eq("VirtualMachine")
+      expect(host.reload.ems_ref_type).to    eq("HostSystem")
+      expect(cluster.reload.ems_ref_type).to eq("ClusterComputeResource")
+      expect(respool.reload.ems_ref_type).to eq("ResourcePool")
+      expect(storage.reload.ems_ref_type).to eq("Datastore")
+    end
+
+    it "ignores ems_ref_obj if it isn't a VimString" do
+      vm = vm_stub.create!(
+        :type        => "ManageIQ::Providers::Redhat::InfraManager::Vm",
+        :ems_ref     => "b7212ae9-e968-4431-bb17-cc16d5095cd0",
+        :ems_ref_obj => "--- b7212ae9-e968-4431-bb17-cc16d5095cd0\n"
+      )
+
+      migrate
+
+      expect(vm.reload.ems_ref_type).to be_nil
+    end
+  end
+
+  migration_context :down do
+    it "migrates an ems_ref_type to an ems_ref_obj" do
+      vm = vm_stub.create!(:ems_ref => "vm-1234", :ems_ref_type => "VirtualMachine")
+      migrate
+      expect(vm.reload.ems_ref_obj).to eq <<~EMS_REF_OBJ
+        --- !ruby/string:VimString
+        str: vm-1234
+        xsiType: :ManagedObjectReference
+        vimType: :VirtualMachine
+      EMS_REF_OBJ
+    end
+
+    it "sets to a simple yaml string if ems_ref_type is nil" do
+      vm = vm_stub.create!(:ems_ref => "b7212ae9-e968-4431-bb17-cc16d5095cd0")
+      migrate
+      expect(vm.reload.ems_ref_obj).to eq("--- b7212ae9-e968-4431-bb17-cc16d5095cd0\n")
+    end
+  end
+end


### PR DESCRIPTION
Currently we store a YAML serialized `VimString` `ManagedObjectReference` that includes the `vimType` (e.g. `VirtualMachine`/`HostSystem`/`ClusterComputeResource`) because the `ems_ref` and model are not enough information to accurately represent a VMware object, you need the VIM class name as well.

Rather than serializing a full `VMwareWebService/VimType` we can store the VIM class in a string e.g. `'VirtualMachine`.  This gives us enough information to indicate a `VMware` `ManagedObject` without requiring the `VMwareWebService` gem in core to allow for deserialization of `ems_ref_obj`.

https://github.com/ManageIQ/manageiq/issues/18428