### PR TITLE
[WIP] Add service template name unique check

### DIFF
--- a/db/migrate/20191112150337_add_service_template_name_uniq_validation.rb
+++ b/db/migrate/20191112150337_add_service_template_name_uniq_validation.rb
@@ -1,0 +1,13 @@
+class AddServiceTemplateNameUniqValidation < ActiveRecord::Migration[5.1]
+  class ServiceTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    validates :name, :uniqueness => true
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    say_with_time("Checking service templates for name uniqueness") do
+      ServiceTemplate.in_my_region.where(:name => ServiceTemplate.in_my_region.select(:name).group(:name).having("count(*) > 1").pluck(:name)).order(:id).drop(1).each { |s| s.update!(:name => s.name + SecureRandom.uuid) }
+    end
+  end
+end

--- a/spec/migrations/20191112150337_add_service_template_name_uniq_validation_spec.rb
+++ b/spec/migrations/20191112150337_add_service_template_name_uniq_validation_spec.rb
@@ -1,0 +1,26 @@
+require_migration
+
+describe AddServiceTemplateNameUniqValidation do
+  let(:template) { migration_stub(:ServiceTemplate) }
+
+  migration_context :up do
+    it "ServiceTemplate dup resets name" do
+      name1 = SecureRandom.uuid
+      obj1 = template.create!(:name => name1)
+      obj2 = template.new(:name => name1)
+
+      obj2.save(:validate => false)
+      obj3 = template.create!(:name => SecureRandom.uuid)
+      name2 = obj3.name
+
+      expect(obj1.reload.name).to eq(name1)
+      expect(obj2.reload.name).to eq(name1)
+
+      migrate
+
+      expect(obj1.reload.name).to eq(name1)
+      expect(obj2.reload.name).not_to eq(name1)
+      expect(obj3.reload.name).to eq(name2)
+    end
+  end
+end


### PR DESCRIPTION
Service template names should be unique by region. 

It shouldn't get merged till the specs on the main PR have been fixed, so possibly sometime in 2039.


Related:
https://github.com/ManageIQ/manageiq/pull/19495


Edit, closing: see the edit in https://github.com/ManageIQ/manageiq/pull/19495#issue-339964377