### PR TITLE
Remove MiqWidget with content_type set to rss

### DIFF
--- a/db/migrate/20191114131917_remove_miqwidget_rss.rb
+++ b/db/migrate/20191114131917_remove_miqwidget_rss.rb
@@ -1,0 +1,7 @@
+class RemoveMiqwidgetRss < ActiveRecord::Migration[5.1]
+  class MiqWidget < ActiveRecord::Base; end
+
+  def up
+    MiqWidget.where(:content_type => 'rss').delete_all
+  end
+end

--- a/spec/migrations/20191114131917_remove_miqwidget_rss_spec.rb
+++ b/spec/migrations/20191114131917_remove_miqwidget_rss_spec.rb
@@ -1,0 +1,21 @@
+require_migration
+
+describe RemoveMiqwidgetRss do
+  migration_context :up do
+    let(:miq_widget) { migration_stub :MiqWidget }
+
+    it 'does delete only MiqWidget with content_type set to RSS' do
+      miq_widget.create!(:content_type => 'rss')
+      miq_widget.create!(:content_type => 'menu')
+      miq_widget.create!(:content_type => 'chart')
+      miq_widget.create!(:content_type => 'report')
+
+      migrate
+
+      expect(miq_widget.where(:content_type => "rss").count).to eq 0
+      expect(miq_widget.where(:content_type => "menu").count).to eq 1
+      expect(miq_widget.where(:content_type => "chart").count).to eq 1
+      expect(miq_widget.where(:content_type => "report").count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
There's no code that handles them but they stayed in DB.

Removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/5271 and https://github.com/ManageIQ/manageiq/pull/18478 .

@miq-bot add_label ivanchuk/no, technical debt

@lpichler please have a look,  thanks :)
