### PR TITLE
Subclass EmsFolders and Datacenters by provider

### DIFF
--- a/db/migrate/20191118191722_subclass_ems_folders.rb
+++ b/db/migrate/20191118191722_subclass_ems_folders.rb
@@ -1,0 +1,55 @@
+class SubclassEmsFolders < ActiveRecord::Migration[5.1]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class EmsFolder < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "SubclassEmsFolders::ExtManagementSystem"
+  end
+
+  def up
+    %w[Microsoft Redhat Vmware].each do |provider|
+      ems_class_name = "ManageIQ::Providers::#{provider}::InfraManager"
+
+      folder_class_name = "#{ems_class_name}::Folder"
+      EmsFolder.in_my_region
+               .joins(:ext_management_system)
+               .where(:ext_management_systems => {:type => ems_class_name}, :type => nil)
+               .update_all(:type => folder_class_name)
+
+      datacenter_class_name = "#{ems_class_name}::Datacenter"
+      EmsFolder.in_my_region
+               .joins(:ext_management_system)
+               .where(:ext_management_systems => {:type => ems_class_name}, :type => "Datacenter")
+               .update_all(:type => datacenter_class_name)
+
+      storage_cluster_class_name = "#{ems_class_name}::StorageCluster"
+      EmsFolder.in_my_region
+               .joins(:ext_management_system)
+               .where(:ext_management_systems => {:type => ems_class_name}, :type => "StorageCluster")
+               .update_all(:type => storage_cluster_class_name)
+    end
+  end
+
+  def down
+    provider_folder_types = %w[Microsoft Redhat Vmware].map do |provider|
+      "ManageIQ::Providers::#{provider}::InfraManager::Folder"
+    end
+
+    provider_datacenter_types = %w[Microsoft Redhat Vmware].map do |provider|
+      "ManageIQ::Providers::#{provider}::InfraManager::Datacenter"
+    end
+
+    provider_storage_cluster_types = %w[Microsoft Redhat Vmware].map do |provider|
+      "ManageIQ::Providers::#{provider}::InfraManager::StorageCluster"
+    end
+
+    EmsFolder.in_my_region.where(:type => provider_folder_types).update_all(:type => nil)
+    EmsFolder.in_my_region.where(:type => provider_datacenter_types).update_all(:type => "Datacenter")
+    EmsFolder.in_my_region.where(:type => provider_storage_cluster_types).update_all(:type => "StorageCluster")
+  end
+end

--- a/spec/migrations/20191118191722_subclass_ems_folders_spec.rb
+++ b/spec/migrations/20191118191722_subclass_ems_folders_spec.rb
@@ -1,0 +1,68 @@
+require_migration
+
+describe SubclassEmsFolders do
+  let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
+  let(:ems_folder_stub)            { migration_stub(:EmsFolder) }
+
+  migration_context :up do
+    it "migrates folders and datacenters from all supported providers" do
+      emss = %w[Microsoft Redhat Vmware].map do |vendor|
+        ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
+      end
+
+      folders          = emss.map { |ems| ems_folder_stub.create!(:ext_management_system => ems) }
+      datacenters      = emss.map { |ems| ems_folder_stub.create!(:ext_management_system => ems, :type => "Datacenter") }
+      storage_clusters = emss.map { |ems| ems_folder_stub.create!(:ext_management_system => ems, :type => "StorageCluster") }
+
+      migrate
+
+      folders.each          { |folder| expect(folder.reload.type).to eq("#{folder.ext_management_system.type}::Folder") }
+      datacenters.each      { |dc| expect(dc.reload.type).to eq("#{dc.ext_management_system.type}::Datacenter") }
+      storage_clusters.each { |sc| expect(sc.reload.type).to eq("#{sc.ext_management_system.type}::StorageCluster") }
+    end
+
+    it "doesn't migrate an unrelated folder" do
+      ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AutomationManager")
+      inventory_group = ems_folder_stub.create!(
+        :ext_management_system => ems,
+        :type                  => "ManageIQ::Providers::AutomationManager::InventoryGroup"
+      )
+
+      migrate
+
+      expect(inventory_group.reload.type).to eq("ManageIQ::Providers::AutomationManager::InventoryGroup")
+    end
+  end
+
+  migration_context :down do
+    it "migrates folders and datacenters from all supported providers" do
+      emss = %w[Microsoft Redhat Vmware].map do |vendor|
+        ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
+      end
+
+      folders = emss.map do |ems|
+        ems_folder_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::Folder")
+      end
+      datacenters = emss.map do |ems|
+        ems_folder_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::Datacenter")
+      end
+
+      migrate
+
+      folders.each     { |folder| expect(folder.reload.type).to be_nil }
+      datacenters.each { |dc| expect(dc.reload.type).to eq("Datacenter") }
+    end
+
+    it "doesn't migrate an unrelated folder" do
+      ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AutomationManager")
+      inventory_group = ems_folder_stub.create!(
+        :ext_management_system => ems,
+        :type                  => "ManageIQ::Providers::AutomationManager::InventoryGroup"
+      )
+
+      migrate
+
+      expect(inventory_group.reload.type).to eq("ManageIQ::Providers::AutomationManager::InventoryGroup")
+    end
+  end
+end


### PR DESCRIPTION
Currently there are EmsFolder, Datacenter, and StorageCluster
classes under the base EmsFolder, in addition to ManageIQ::Providers::AutomationManager::InventoryGroup.

To allow provider specific logic to live on these we need to subclass
them by provider e.g. ManageIQ::Providers::Vmware::InfraManager::Folder.

Core issue: https://github.com/ManageIQ/manageiq/pull/19534