### PR TITLE
Add miq_worker_types table

### DIFF
--- a/db/migrate/20191115164358_create_miq_worker_types.rb
+++ b/db/migrate/20191115164358_create_miq_worker_types.rb
@@ -1,0 +1,11 @@
+class CreateMiqWorkerTypes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :miq_worker_types do |t|
+      t.string  :worker_type, :null => false
+      t.string  :bundler_groups, :array => true
+      t.integer :kill_priority
+
+      t.index :worker_type, :unique => true
+    end
+  end
+end


### PR DESCRIPTION
This table will be seeded to include all leaf subclasses of MiqWorker

On the first pass it will be a replacement for the information currently
stored in the MIQ_WORKER_TYPES constants, but will be extended to
contain all the metadata concerning when workers of each type should
be running (for example, required roles, worker scope, provider type, etc.)

The ultimate goal is to separate out worker management into a standalone
process distinct from the current code-base where a subset of models
will be the primary API between the "worker orchestrator" and the
server which will determine *how* to start the workers it was told
to run.

This will allow for sharing the core logic of when and where to run
workers across different platforms and runtimes such as systemd, fork,
containers, etc.