### PR TITLE
Run bundle install in `bin/setup`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '10'
-before_install: bin/setup
-before_script: bundle exec rake spec:setup
+install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,10 @@
 #!/bin/bash
 if [[ -n "$CI" ]]; then
   echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc
+  bundle config --local path $(pwd)/vendor/bundle
+
   psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
-else
-  bundle exec rake spec:setup
 fi
+
+bundle update --jobs=3
+bundle exec rake spec:setup


### PR DESCRIPTION
Running manageiq-schema from cross-repo tests fails because we do not run `bundle install` from `bin/setup`

Ref: https://travis-ci.org/ManageIQ/manageiq-cross_repo-tests/jobs/614581288#L293