### PR TITLE
Replace the server capabilities serialized column with has_vix_disk_lib

### DIFF
--- a/db/migrate/20191122203218_replace_server_capabilities_with_vix_disk_lib.rb
+++ b/db/migrate/20191122203218_replace_server_capabilities_with_vix_disk_lib.rb
@@ -1,0 +1,30 @@
+class ReplaceServerCapabilitiesWithVixDiskLib < ActiveRecord::Migration[5.1]
+  class MiqServer < ActiveRecord::Base
+    serialize :capabilities
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    add_column :miq_servers, :has_vix_disk_lib, :boolean
+
+    MiqServer.in_my_region.each do |miq_server|
+      miq_server.update(
+        :has_vix_disk_lib => miq_server.capabilities.try(:[], :vixDisk) || false
+      )
+    end
+
+    remove_column :miq_servers, :capabilities
+  end
+
+  def down
+    add_column :miq_servers, :capabilities, :text
+
+    MiqServer.in_my_region.each do |miq_server|
+      miq_server.update(
+        :capabilities => { :vixDisk => miq_server.has_vix_disk_lib || false }
+      )
+    end
+
+    remove_column :miq_servers, :has_vix_disk_lib
+  end
+end

--- a/spec/migrations/20191122203218_replace_server_capabilities_with_vix_disk_lib_spec.rb
+++ b/spec/migrations/20191122203218_replace_server_capabilities_with_vix_disk_lib_spec.rb
@@ -1,0 +1,35 @@
+require_migration
+
+describe ReplaceServerCapabilitiesWithVixDiskLib do
+  let(:miq_server_stub) { migration_stub :MiqServer }
+
+  migration_context :up do
+    it "migrates from capabilities to vix disk column" do
+      cap_true  = miq_server_stub.create(:capabilities => {:vixDisk => true})
+      cap_false = miq_server_stub.create(:capabilities => {:vixDisk => false})
+      cap_empty = miq_server_stub.create(:capabilities => {})
+      cap_nil   = miq_server_stub.create(:capabilities => nil)
+
+      migrate
+
+      expect(cap_true.reload.has_vix_disk_lib).to be_truthy
+      expect(cap_false.reload.has_vix_disk_lib).to be_falsey
+      expect(cap_empty.reload.has_vix_disk_lib).to be_falsey
+      expect(cap_nil.reload.has_vix_disk_lib).to be_falsey
+    end
+  end
+
+  migration_context :down do
+    it "migrates from vix disk column to capabilities" do
+      vix_true  = miq_server_stub.create(:has_vix_disk_lib => true)
+      vix_false = miq_server_stub.create(:has_vix_disk_lib => false)
+      vix_nil   = miq_server_stub.create(:has_vix_disk_lib => nil)
+
+      migrate
+
+      expect(vix_true.reload.capabilities[:vixDisk]).to be_truthy
+      expect(vix_false.reload.capabilities[:vixDisk]).to be_falsey
+      expect(vix_nil.reload.capabilities[:vixDisk]).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This column only contained two keys, one was an unnecessary cache
of the number of MiqSmartProxyWorkers and the other is a flag for
whether the server has VixDiskLib installed or not.

In the interest of limiting the number of serialized columns
I'm moving the vixDisk flag to its own column