### PR TITLE
Add restart_needed field to vms

### DIFF
--- a/db/migrate/20191128111630_add_restart_needed_to_vms.rb
+++ b/db/migrate/20191128111630_add_restart_needed_to_vms.rb
@@ -1,0 +1,5 @@
+class AddRestartNeededToVms < ActiveRecord::Migration[5.1]
+  def change
+    add_column :vms, :restart_needed, :boolean
+  end
+end


### PR DESCRIPTION
Sometimes VMs need to be restarted to apply not hotpluggable configuration
changes and the user needs to be aware of that.
Changes to a VM can be applied through ManageIQ but also by the
external the external system

This is part of the RFE
https://bugzilla.redhat.com/show_bug.cgi?id=1572649