### PR TITLE
Ignore update_all

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,2 +1,6 @@
 Rails/ApplicationRecord:
   Enabled: false
+
+Rails/SkipsModelValidations:
+  Whitelist:
+  - update_all

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "rubocop", "~> 0.52.1"
+  s.add_development_dependency "rubocop", "~> 0.69.0"
+  s.add_development_dependency "rubocop-performance"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
`update_all` is expected in migrations.

Fixes: #20 