### PR TITLE
Track if a Storage is in maintenance_mode or not

### DIFF
--- a/db/migrate/20191210135022_add_maintenance_mode_to_storages.rb
+++ b/db/migrate/20191210135022_add_maintenance_mode_to_storages.rb
@@ -1,0 +1,6 @@
+class AddMaintenanceModeToStorages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :storages, :maintenance, :boolean
+    add_column :storages, :maintenance_reason, :string
+  end
+end


### PR DESCRIPTION
A virtual datastore can be in maintenance mode similar to a virtual
host.  This means that no provisioning should be done to these storages.

https://bugzilla.redhat.com/show_bug.cgi?id=1394909