### PR TITLE
Subclass Storages by provider

### DIFF
--- a/db/migrate/20191210162908_add_type_to_storages.rb
+++ b/db/migrate/20191210162908_add_type_to_storages.rb
@@ -1,0 +1,5 @@
+class AddTypeToStorages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :storages, :type, :string
+  end
+end

--- a/db/migrate/20191210163518_subclass_storages.rb
+++ b/db/migrate/20191210163518_subclass_storages.rb
@@ -1,0 +1,32 @@
+class SubclassStorages < ActiveRecord::Migration[5.1]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Storage < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "SubclassStorages::ExtManagementSystem"
+  end
+
+  def up
+    [
+      'Microsoft',
+      'Redhat',
+      'Vmware',
+    ].each do |provider|
+      ems_class_name = "ManageIQ::Providers::#{provider}::InfraManager"
+      storage_class_name = "#{ems_class_name}::Storage"
+      Storage.in_my_region
+             .joins(:ext_management_system)
+             .where(:ext_management_systems => {:type => ems_class_name})
+             .update_all(:type => storage_class_name)
+    end
+  end
+
+  def down
+    Storage.in_my_region.update_all(:type => nil)
+  end
+end

--- a/spec/migrations/20191210163518_subclass_storages_spec.rb
+++ b/spec/migrations/20191210163518_subclass_storages_spec.rb
@@ -1,0 +1,60 @@
+require_migration
+
+describe SubclassStorages do
+  let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
+  let(:storage_stub)               { migration_stub(:Storage) }
+
+  migration_context :up do
+    it "migrates storages from all supported providers" do
+      emss = %w[Microsoft Redhat Vmware].map do |vendor|
+        ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
+      end
+
+      storages = emss.map do |ems|
+        storage_stub.create!(:ext_management_system => ems)
+      end
+
+      migrate
+
+      storages.each do |storage|
+        expect(storage.reload.type).to eq("#{storage.ext_management_system.type}::Storage")
+      end
+    end
+
+    it "doesn't migrate storages from other providers" do
+      ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AnotherManager::InfraManager")
+      storage = storage_stub.create!(:ext_management_system => ems)
+
+      migrate
+
+      expect(storage.reload.type).to be_nil
+    end
+  end
+
+  migration_context :down do
+    it "migrates storages from all supported providers" do
+      emss = %w[Microsoft Redhat Vmware].map do |vendor|
+        ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
+      end
+
+      storages = emss.map do |ems|
+        storage_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::Storage")
+      end
+
+      migrate
+
+      storages.each do |storage|
+        expect(storage.reload.type).to be_nil
+      end
+    end
+
+    it "doesn't migrate storages from other providers" do
+      ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AnotherManager::InfraManager")
+      storage = storage_stub.create!(:ext_management_system => ems)
+
+      migrate
+
+      expect(storage.reload.type).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Now that a Storage record belongs_to an EMS we can subclass the storages
by provider.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/35

https://github.com/ManageIQ/manageiq/issues/19440