### PR TITLE
Fix splitting storages for archived hosts

### DIFF
--- a/db/migrate/20190729170013_split_storages_per_ems.rb
+++ b/db/migrate/20190729170013_split_storages_per_ems.rb
@@ -21,8 +21,6 @@ class SplitStoragesPerEms < ActiveRecord::Migration[5.0]
         ems_id            = hs.host&.ems_id
         datastore_ems_ref = hs.ems_ref || storage.ems_ref
 
-        next if ems_id.nil?
-
         [ems_id, datastore_ems_ref]
       end
 
@@ -44,6 +42,8 @@ class SplitStoragesPerEms < ActiveRecord::Migration[5.0]
 
       # Link up the host_storage records to the new storages
       host_storages_by_ems_id_and_ems_ref.each_key do |ems_id, ems_ref|
+        next if ems_id.nil?
+
         # Connect all of the HostStorage records to the new Storage record
         host_storages_ids = host_storages_by_ems_id_and_ems_ref[[ems_id, ems_ref]].map(&:id)
         storage = storages_by_ems_id_and_ems_ref[[ems_id, ems_ref]]

--- a/spec/migrations/20190729170013_split_storages_per_ems_spec.rb
+++ b/spec/migrations/20190729170013_split_storages_per_ems_spec.rb
@@ -120,9 +120,9 @@ describe SplitStoragesPerEms do
         end
 
         context "with an archived host" do
-          let(:archived_host) do
+          let!(:archived_host) do
             host_stub.create!.tap do |h|
-              host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, ems_ref => "datastore-3")
+              host_storage_stub.create!(:host_id => h.id, :storage_id => storage.id, :ems_ref => "datastore-3")
             end
           end
 


### PR DESCRIPTION
The spec test for the archived host would have caught this, but the
`let()` block wasn't invoked so it never created the archived host.

https://bugzilla.redhat.com/show_bug.cgi?id=1394909