### PR TITLE
Remove all MiqVimBrokerWorker rows

### DIFF
--- a/db/migrate/20200103191549_remove_miq_vim_broker_worker_rows.rb
+++ b/db/migrate/20200103191549_remove_miq_vim_broker_worker_rows.rb
@@ -1,0 +1,9 @@
+class RemoveMiqVimBrokerWorkerRows < ActiveRecord::Migration[5.1]
+  class MiqWorker < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    MiqWorker.where(:type => "MiqVimBrokerWorker").delete_all
+  end
+end

--- a/spec/migrations/20200103191549_remove_miq_vim_broker_worker_rows_spec.rb
+++ b/spec/migrations/20200103191549_remove_miq_vim_broker_worker_rows_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe RemoveMiqVimBrokerWorkerRows do
+  migration_context :up do
+    let(:miq_worker) { migration_stub(:MiqWorker) }
+
+    it "deletes MiqVimBrokerWorker workers" do
+      miq_worker.create!(:type => "MiqWorker")
+      miq_worker.create!(:type => "MiqVimBrokerWorker")
+
+      migrate
+
+      expect(miq_worker.count).to      eq(1)
+      expect(miq_worker.first.type).to eq("MiqWorker")
+    end
+  end
+end


### PR DESCRIPTION
Once the VimBroker is removed we should delete any stale worker rows to prevent missing class errors

Core Issue: https://github.com/ManageIQ/manageiq/pull/19673