### PR TITLE
Add description_string to MiqGroup

### DIFF
--- a/db/migrate/20200109190758_add_desc_string_to_miq_group.rb
+++ b/db/migrate/20200109190758_add_desc_string_to_miq_group.rb
@@ -1,0 +1,5 @@
+class AddDescStringToMiqGroup < ActiveRecord::Migration[5.1]
+  def change
+    add_column :miq_groups, :description_string, :string
+  end
+end

--- a/db/migrate/20200109190758_add_desc_string_to_miq_group.rb
+++ b/db/migrate/20200109190758_add_desc_string_to_miq_group.rb
@@ -1,5 +1,5 @@
 class AddDescStringToMiqGroup < ActiveRecord::Migration[5.1]
   def change
-    add_column :miq_groups, :description_string, :string
+    add_column :miq_groups, :detailed_description, :string
   end
 end


### PR DESCRIPTION
This PR adds a description text string to MiqGroup.

Doing this will provide the backend work needed to allow the front end to add support for
this  RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1784243


