### PR TITLE
Fix issue with orch stacks still having references to deleted ems

### DIFF
--- a/db/migrate/20181016140921_migrate_orch_stacks_to_have_ownership_concept.rb
+++ b/db/migrate/20181016140921_migrate_orch_stacks_to_have_ownership_concept.rb
@@ -114,7 +114,7 @@ class MigrateOrchStacksToHaveOwnershipConcept < ActiveRecord::Migration[5.0]
       OrchestrationStack.find_each do |stack|
         user = if stack.service.present?
                  stack.service.tenant_identity
-               elsif !stack.ems_id.nil?
+               elsif stack.ext_management_system
                  stack.ext_management_system.tenant_identity
                else
                  User.super_admin

--- a/spec/migrations/20181016140921_migrate_orch_stacks_to_have_ownership_concept_spec.rb
+++ b/spec/migrations/20181016140921_migrate_orch_stacks_to_have_ownership_concept_spec.rb
@@ -30,6 +30,16 @@ describe MigrateOrchStacksToHaveOwnershipConcept do
       expect(stack).to have_attributes(:tenant_id => ext_ms.tenant_id, :evm_owner_id => ext_ms.tenant_identity.id, :miq_group_id => ext_ms.tenant_identity.current_group.id)
     end
 
+    it "sets owner, tenant, and group from the user if the ems was deleted but the stack ems id is still set" do
+      stack = orchestration_stack.create!(:ems_id => -2)
+      expect(orchestration_stack.count).to eq(1)
+
+      migrate
+      stack.reload
+
+      expect(stack).to have_attributes(:tenant_id => user.current_tenant.id, :evm_owner_id => user.id, :miq_group_id => user.current_group.id)
+    end
+
     it "sets owner, tenant, and group from the service if the service exists and ems doesn't" do
       svc = service.create!(:tenant_id => tenant.id, :miq_group_id => group.id)
       stack = orchestration_stack.create!(:direct_services => [svc])


### PR DESCRIPTION
The [migration from last year 👻](https://github.com/ManageIQ/manageiq-schema/pull/288)  to add owners to stacks can fail if you have deleted emses because we don't have anything currently that removes those id references from the stacks when the ems get deleted, yay us, so support found this fun: `undefined method 'tenant_identity' for nil:NilClass` 😭 and decided just to comment the case in question out completely which feels wrong. 

I apparently can't rely on the presence of the `ems_id` so let's check for the existence of the object itself. 

Introduced in https://github.com/ManageIQ/manageiq-schema/pull/288

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1793112

@miq-bot add_reviewer @kbrock 
Sorry Keenan, my mistake, any chance you could review for me please? 


edit -- sorry but two things that I don't like here: [our orch stack tests assume the existence of an ems](https://github.com/ManageIQ/manageiq/blob/cf53efab0b617f7ec993cac4e07b3cc7cbf45162/spec/factories/orchestration_stack.rb#L3), I don't know why the model isn't consistent with that assumption (`OrchestrationStack.create!` works, ugh), ~~and I guess I wish we'd done the dependent destroy thing or ... like [had a relationship on the ems side to match that stacks belong to emses?](https://github.com/ManageIQ/manageiq/blob/cf53efab0b617f7ec993cac4e07b3cc7cbf45162/app/models/orchestration_stack.rb#L22) Is it even valid to have a stack that isn't connected to an ems, or connected to one that no longer exists? My guess is _no_.~~ fine, we do, it was just hiding 