### PR TITLE
Upgrade existing dropbox depots to the support tool

### DIFF
--- a/db/migrate/20200122215829_upgrade_dropbox_to_support_tool.rb
+++ b/db/migrate/20200122215829_upgrade_dropbox_to_support_tool.rb
@@ -1,0 +1,14 @@
+class UpgradeDropboxToSupportTool < ActiveRecord::Migration[5.1]
+  class FileDepot < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def change
+    # update_all is used here to avoid instantiating a possibly undefined class
+    FileDepot.where(:type => "FileDepotFtpAnonymousRedhatDropbox").update_all(
+      :type => "FileDepotRedhatSupport",
+      :name => "Red Hat Support",
+      :uri  => "support://redhat.com"
+    )
+  end
+end

--- a/spec/migrations/20200122215829_upgrade_dropbox_to_support_tool_spec.rb
+++ b/spec/migrations/20200122215829_upgrade_dropbox_to_support_tool_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe UpgradeDropboxToSupportTool do
+  let(:file_depot) { migration_stub(:FileDepot) }
+
+  migration_context :up do
+    it "upgrades only existing dropbox depots to support tool" do
+      dropbox_depot = file_depot.create!(
+        :type => "FileDepotFtpAnonymousRedhatDropbox",
+        :name => "Red Hat Dropbox"
+      )
+
+      ftp_depot = file_depot.create!(:type => "FileDepotFtp")
+
+      migrate
+
+      dropbox_depot.reload
+      expect(dropbox_depot.type).to eq "FileDepotRedhatSupport"
+      expect(dropbox_depot.name).to eq "Red Hat Support"
+
+      ftp_depot.reload
+      expect(ftp_depot.type).to eq "FileDepotFtp"
+    end
+  end
+end


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1720142

In the above bug, the dropbox option was removed, with the support tool being
the replacement.  This commit upgrades any existing dropbox depots to the
support tool.