### PR TITLE
Remove VimTypes from EmsEvent#full_data

### DIFF
--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -1,34 +1,34 @@
-module VimType
-  def vimType
-    @vimType.nil? ? nil : @vimType.to_s
-  end
-
-  def vimType=(val)
-    @vimType = val.nil? ? nil : val.to_sym
-  end
-
-  def xsiType
-    @xsiType.nil? ? nil : @xsiType.to_s
-  end
-
-  def xsiType=(val)
-    @xsiType = val.nil? ? nil : val.to_sym
-  end
-end
-
-class VimHash < Hash
-  include VimType
-end
-
-class VimArray < Array
-  include VimType
-end
-
-class VimString < String
-  include VimType
-end
-
 class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
+  module VimType
+    def vimType
+      @vimType.nil? ? nil : @vimType.to_s
+    end
+
+    def vimType=(val)
+      @vimType = val.nil? ? nil : val.to_sym
+    end
+
+    def xsiType
+      @xsiType.nil? ? nil : @xsiType.to_s
+    end
+
+    def xsiType=(val)
+      @xsiType = val.nil? ? nil : val.to_sym
+    end
+  end
+
+  class VimHash < Hash
+    include VimType
+  end
+
+  class VimArray < Array
+    include VimType
+  end
+
+  class VimString < String
+    include VimType
+  end
+
   class EventStream < ActiveRecord::Base
     include ActiveRecord::IdRegions
 
@@ -36,13 +36,33 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
   end
 
   def up
+    vim_hash_backup   = const_replace(:VimHash, VimHash)
+    vim_string_backup = const_replace(:VimString, VimString)
+    vim_array_backup  = const_replace(:VimArray, VimArray)
+
     EventStream.in_my_region.where(:source => "VC").find_each do |event|
       full_data = YAML.load(event.full_data)
       event.update!(:full_data => vim_types_to_basic_types(full_data).to_yaml)
     end
+
+    const_replace(:VimHash, vim_hash_backup)
+    const_replace(:VimString, vim_string_backup)
+    const_replace(:VimArray, vim_array_backup)
   end
 
   private
+
+  def const_replace(const_name, new_const)
+    old_const = const_remove(const_name)
+    Object.const_set(const_name, new_const)
+    old_const
+  end
+
+  def const_remove(const_name)
+    return unless Object.const_defined?(const_name)
+    old_const = Object.const_get(const_name)
+    Object.send(:remove_const, const_name)
+  end
 
   def vim_types_to_basic_types(obj)
     case obj

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -35,7 +35,7 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
   def up
     with_replaced_constants(:VimHash => VimHash, :VimString => VimString, :VimArray => VimArray) do
       say_with_time("Removing Vim Types from EmsEvents") do
-        base_relation = EventStream.in_my_region.where(:source => "VC")
+        base_relation = EventStream.in_my_region.where(:source => "VC").where("full_data LIKE ?", "%hash-with-ivars:VimHash%")
         say_batch_started(base_relation.size)
 
         base_relation.find_in_batches(batch_size: BATCH_SIZE) do |events|

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -33,30 +33,31 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
   end
 
   def up
-    vim_hash_backup   = const_replace(:VimHash, VimHash)
-    vim_string_backup = const_replace(:VimString, VimString)
-    vim_array_backup  = const_replace(:VimArray, VimArray)
+    with_replaced_constants(:VimHash => VimHash, :VimString => VimString, :VimArray => VimArray) do
+      say_with_time("Removing Vim Types from EmsEvents") do
+        base_relation = EventStream.in_my_region.where(:source => "VC")
+        say_batch_started(base_relation.size)
 
-    say_with_time("Removing Vim Types from EmsEvents") do
-      base_relation = EventStream.in_my_region.where(:source => "VC")
-      say_batch_started(base_relation.size)
+        processed_count = 0
+        base_relation.find_each(batch_size: BATCH_SIZE) do |event|
+          full_data = YAML.load(event.full_data)
+          event.update!(:full_data => vim_types_to_basic_types(full_data).to_yaml)
 
-      processed_count = 0
-      base_relation.find_each(batch_size: BATCH_SIZE) do |event|
-        full_data = YAML.load(event.full_data)
-        event.update!(:full_data => vim_types_to_basic_types(full_data).to_yaml)
-
-        processed_count += 1
-        say_batch_processed(processed_count) if processed_count % BATCH_SIZE == 0
+          processed_count += 1
+          say_batch_processed(processed_count) if processed_count % BATCH_SIZE == 0
+        end
       end
     end
-
-    const_replace(:VimHash, vim_hash_backup)
-    const_replace(:VimString, vim_string_backup)
-    const_replace(:VimArray, vim_array_backup)
   end
 
   private
+
+  def with_replaced_constants(constants)
+    backed_up_constants = Hash[constants.map { |sym, klass| [sym, const_replace(sym, klass)] }]
+    yield
+  ensure
+    backed_up_constants.each { |sym, klass| const_replace(sym, klass) }
+  end
 
   def const_replace(const_name, new_const)
     old_const = const_remove(const_name)
@@ -66,7 +67,6 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
 
   def const_remove(const_name)
     return unless Object.const_defined?(const_name)
-    old_const = Object.const_get(const_name)
     Object.send(:remove_const, const_name)
   end
 

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -58,7 +58,7 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
     backed_up_constants = Hash[constants.map { |sym, klass| [sym, const_replace(sym, klass)] }]
     yield
   ensure
-    backed_up_constants.each { |sym, klass| const_replace(sym, klass) }
+    backed_up_constants.each { |sym, klass| const_replace(sym, klass) unless klass.nil? }
   end
 
   def const_replace(const_name, new_const)

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -1,0 +1,60 @@
+module VimType
+  def vimType
+    @vimType.nil? ? nil : @vimType.to_s
+  end
+
+  def vimType=(val)
+    @vimType = val.nil? ? nil : val.to_sym
+  end
+
+  def xsiType
+    @xsiType.nil? ? nil : @xsiType.to_s
+  end
+
+  def xsiType=(val)
+    @xsiType = val.nil? ? nil : val.to_sym
+  end
+end
+
+class VimHash < Hash
+  include VimType
+end
+
+class VimArray < Array
+  include VimType
+end
+
+class VimString < String
+  include VimType
+end
+
+class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
+  class EventStream < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    EventStream.in_my_region.where(:source => "VC").find_each do |event|
+      full_data = YAML.load(event.full_data)
+      event.update!(:full_data => vim_types_to_basic_types(full_data).to_yaml)
+    end
+  end
+
+  private
+
+  def vim_types_to_basic_types(obj)
+    case obj
+    when VimString
+      obj = obj.to_s
+    when VimHash
+      obj = obj.to_h
+      obj.each { |key, val| obj[key] = vim_types_to_basic_types(val) }
+    when VimArray
+      obj = obj.map { |v| vim_types_to_basic_types(v) }
+    end
+
+    obj
+  end
+end

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -79,6 +79,7 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
       obj = obj.to_h
       obj.transform_values! { |val| vim_types_to_basic_types(val) }
     when VimArray
+      obj = obj.to_a
       obj.map! { |v| vim_types_to_basic_types(v) }
     end
 

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -44,7 +44,10 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
           event.update!(:full_data => vim_types_to_basic_types(full_data).to_yaml)
 
           processed_count += 1
-          say_batch_processed(processed_count) if processed_count % BATCH_SIZE == 0
+          if (processed_count % BATCH_SIZE).zero?
+            say_batch_processed(processed_count)
+            processed_count = 0
+          end
         end
       end
     end

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -76,9 +76,9 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
       obj = obj.to_s
     when VimHash
       obj = obj.to_h
-      obj.each { |key, val| obj[key] = vim_types_to_basic_types(val) }
+      obj.transform_values! { |val| vim_types_to_basic_types(val) }
     when VimArray
-      obj = obj.map { |v| vim_types_to_basic_types(v) }
+      obj.map! { |v| vim_types_to_basic_types(v) }
     end
 
     obj

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -11,13 +11,30 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
   def up
     say_with_time("Removing Vim Types from EmsEvents") do
       base_relation = EventStream.in_my_region.where(:source => "VC")
-                        .where("full_data LIKE ?", "%hash-with-ivars:VimHash%")
+        .where("full_data LIKE ?", "%hash-with-ivars:VimHash%")
       say_batch_started(base_relation.size)
 
       loop do
         count = base_relation
           .limit(50_000)
           .update_all("full_data = REGEXP_REPLACE(full_data, '!ruby/(string|array|hash-with-ivars):Vim(Hash|String|Array)', '!ruby/\\1:\\2', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Restoring Vim Types in EmsEvents") do
+      base_relation = EventStream.in_my_region.where(:source => "VC")
+        .where("full_data LIKE ?", "%hash-with-ivars:Hash%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation
+          .limit(50_000)
+          .update_all("full_data = REGEXP_REPLACE(full_data, '!ruby/(string|array|hash-with-ivars):(Hash|String|Array)', '!ruby/\\1:Vim\\2', 'g')")
         break if count == 0
 
         say_batch_processed(count)

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -67,6 +67,7 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
 
   def const_remove(const_name)
     return unless Object.const_defined?(const_name)
+
     Object.send(:remove_const, const_name)
   end
 

--- a/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
+++ b/db/migrate/20200126203714_remove_vim_types_from_ems_events.rb
@@ -1,31 +1,4 @@
 class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
-  disable_ddl_transaction!
-  include MigrationHelper
-
-  BATCH_SIZE = 5_000
-
-  module VimType
-    def vimType
-      @vimType.nil? ? nil : @vimType.to_s
-    end
-
-    def vimType=(val)
-      @vimType = val.nil? ? nil : val.to_sym
-    end
-
-    def xsiType
-      @xsiType.nil? ? nil : @xsiType.to_s
-    end
-
-    def xsiType=(val)
-      @xsiType = val.nil? ? nil : val.to_sym
-    end
-  end
-
-  class VimHash < Hash; include VimType; end
-  class VimArray < Array; include VimType; end
-  class VimString < String; include VimType; end
-
   class EventStream < ActiveRecord::Base
     include ActiveRecord::IdRegions
 
@@ -33,72 +6,10 @@ class RemoveVimTypesFromEmsEvents < ActiveRecord::Migration[5.1]
   end
 
   def up
-    with_replaced_constants(:VimHash => VimHash, :VimString => VimString, :VimArray => VimArray) do
-      say_with_time("Removing Vim Types from EmsEvents") do
-        base_relation = EventStream.in_my_region.where(:source => "VC").where("full_data LIKE ?", "%hash-with-ivars:VimHash%")
-        say_batch_started(base_relation.size)
-
-        base_relation.find_in_batches(batch_size: BATCH_SIZE) do |events|
-          processors = ENV["RAILS_ENV"] == "test" ? 0 : nil
-
-          resources = events.collect { |event| [event.id, event.full_data] }
-
-          require 'parallel'
-          resources = Parallel.map(resources, :in_processes => processors) do |event_id, full_data|
-            ActiveRecord::Base.connection.reconnect! unless processors == 0
-
-            [event_id, vim_types_to_basic_types(YAML.load(full_data)).to_yaml]
-          end
-
-          ActiveRecord::Base.connection.reconnect! unless processors == 0
-
-          event_full_data_by_event_id = Hash[resources]
-
-          ActiveRecord::Base.transaction do
-            events.each do |event|
-              event.update!(:full_data => event_full_data_by_event_id[event.id])
-            end
-          end
-
-          say_batch_processed(events.count)
-        end
-      end
+    say_with_time("Removing Vim Types from EmsEvents") do
+      EventStream.in_my_region.where(:source => "VC")
+        .where("full_data LIKE ?", "%hash-with-ivars:VimHash%")
+        .update_all("full_data = REGEXP_REPLACE(full_data, '!ruby/(string|array|hash-with-ivars):Vim(Hash|String|Array)', '!ruby/\\1:\\2', 'g')")
     end
-  end
-
-  private
-
-  def with_replaced_constants(constants)
-    backed_up_constants = Hash[constants.map { |sym, klass| [sym, const_replace(sym, klass)] }]
-    yield
-  ensure
-    backed_up_constants.each { |sym, klass| const_replace(sym, klass) unless klass.nil? }
-  end
-
-  def const_replace(const_name, new_const)
-    old_const = const_remove(const_name)
-    Object.const_set(const_name, new_const)
-    old_const
-  end
-
-  def const_remove(const_name)
-    return unless Object.const_defined?(const_name)
-
-    Object.send(:remove_const, const_name)
-  end
-
-  def vim_types_to_basic_types(obj)
-    case obj
-    when VimString
-      obj = obj.to_s
-    when VimHash
-      obj = obj.to_h
-      obj.transform_values! { |val| vim_types_to_basic_types(val) }
-    when VimArray
-      obj = obj.to_a
-      obj.map! { |v| vim_types_to_basic_types(v) }
-    end
-
-    obj
   end
 end

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -39,7 +39,12 @@ describe RemoveVimTypesFromEmsEvents do
 
       expect(full_data.class.name).to eq("Hash")
       expect(full_data["key"].class.name).to eq("String")
+      expect(full_data["key"]).to eq("585137")
       expect(full_data["datacenter"].class.name).to eq("Hash")
+      expect(full_data["datacenter"]).to include(
+        "name"       => "dev-vc67-DC",
+        "datacenter" => "datacenter-104"
+      )
     end
   end
 

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -6,29 +6,29 @@ describe RemoveVimTypesFromEmsEvents do
   migration_context :up do
     it "converts a VimHash to a normal Hash" do
       full_data = <<~FULL_DATA
-      --- !ruby/hash-with-ivars:VimHash
-      elements:
-        key: !ruby/string:VimString
-          str: '585137'
-          xsiType: :SOAP::SOAPInt
-          vimType:
-        datacenter: !ruby/hash-with-ivars:VimHash
-          elements:
-            name: !ruby/string:VimString
-              str: dev-vc67-DC
-              xsiType: :SOAP::SOAPString
-              vimType:
-            datacenter: !ruby/string:VimString
-              str: datacenter-104
-              xsiType: :ManagedObjectReference
-              vimType: :Datacenter
-          ivars:
-            :@xsiType: :DatacenterEventArgument
-            :@vimType:
-        eventType: VmCreatedEvent
-      ivars:
-        :@xsiType: :VmCreatedEvent
-        :@vimType:
+        --- !ruby/hash-with-ivars:VimHash
+        elements:
+          key: !ruby/string:VimString
+            str: '585137'
+            xsiType: :SOAP::SOAPInt
+            vimType:
+          datacenter: !ruby/hash-with-ivars:VimHash
+            elements:
+              name: !ruby/string:VimString
+                str: dev-vc67-DC
+                xsiType: :SOAP::SOAPString
+                vimType:
+              datacenter: !ruby/string:VimString
+                str: datacenter-104
+                xsiType: :ManagedObjectReference
+                vimType: :Datacenter
+            ivars:
+              :@xsiType: :DatacenterEventArgument
+              :@vimType:
+          eventType: VmCreatedEvent
+        ivars:
+          :@xsiType: :VmCreatedEvent
+          :@vimType:
       FULL_DATA
 
       event = event_stream_stub.create!(:full_data => full_data, :source => "VC")

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -1,0 +1,48 @@
+require_migration
+
+describe RemoveVimTypesFromEmsEvents do
+  let(:event_stream_stub) { migration_stub(:EventStream) }
+
+  migration_context :up do
+    it "converts a VimHash to a normal Hash" do
+      full_data = <<~FULL_DATA
+      --- !ruby/hash-with-ivars:VimHash
+      elements:
+        key: !ruby/string:VimString
+          str: '585137'
+          xsiType: :SOAP::SOAPInt
+          vimType:
+        datacenter: !ruby/hash-with-ivars:VimHash
+          elements:
+            name: !ruby/string:VimString
+              str: dev-vc67-DC
+              xsiType: :SOAP::SOAPString
+              vimType:
+            datacenter: !ruby/string:VimString
+              str: datacenter-104
+              xsiType: :ManagedObjectReference
+              vimType: :Datacenter
+          ivars:
+            :@xsiType: :DatacenterEventArgument
+            :@vimType:
+        eventType: VmCreatedEvent
+      ivars:
+        :@xsiType: :VmCreatedEvent
+        :@vimType:
+      FULL_DATA
+
+      event = event_stream_stub.create!(:full_data => full_data, :source => "VC")
+
+      migrate
+
+      full_data = YAML.load(event.reload.full_data)
+
+      expect(full_data.class.name).to eq("Hash")
+      expect(full_data["key"].class.name).to eq("String")
+      expect(full_data["datacenter"].class.name).to eq("Hash")
+    end
+  end
+
+  migration_context :down do
+  end
+end

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -4,7 +4,7 @@ describe RemoveVimTypesFromEmsEvents do
   let(:event_stream_stub) { migration_stub(:EventStream) }
 
   migration_context :up do
-    it "converts a VimHash to a normal Hash" do
+    it "converts VimTypes to a normal types" do
       full_data = <<~FULL_DATA
         --- !ruby/hash-with-ivars:VimHash
         elements:
@@ -64,6 +64,60 @@ describe RemoveVimTypesFromEmsEvents do
       expect(full_data["arguments"].count).to eq(1)
       expect(full_data["arguments"].first.class).to eq(Hash)
       expect(full_data["arguments"].first).to include("datacenter" => "datacenter-104")
+    end
+  end
+
+  migration_context :down do
+    it "converts Hash/String/Array to Vim Types" do
+      full_data = <<~FULL_DATA
+        --- !ruby/hash-with-ivars:Hash
+        elements:
+          key: !ruby/string:String
+            str: '585137'
+            xsiType: :SOAP::SOAPInt
+            vimType:
+          datacenter: !ruby/hash-with-ivars:Hash
+            elements:
+              name: !ruby/string:String
+                str: dev-vc67-DC
+                xsiType: :SOAP::SOAPString
+                vimType:
+              datacenter: !ruby/string:String
+                str: datacenter-104
+                xsiType: :ManagedObjectReference
+                vimType: :Datacenter
+            ivars:
+              :@xsiType: :DatacenterEventArgument
+              :@vimType:
+          eventType: VmCreatedEvent
+          arguments: !ruby/array:Array
+            internal:
+            - !ruby/hash-with-ivars:Hash
+              elements:
+                datacenter: !ruby/string:String
+                  str: datacenter-104
+                  xsiType: :Datacenter
+                  vimType: :ManagedObjectReference
+              ivars:
+                :@xsiType: :DatacenterArgument
+                :@vimType:
+            ivars:
+              :@xsiType: :KeyAnyValue
+              :@vimType:
+        ivars:
+          :@xsiType: :VmCreatedEvent
+          :@vimType:
+
+      FULL_DATA
+
+      event = event_stream_stub.create!(:full_data => full_data, :source => "VC")
+
+      migrate
+
+      full_data = event.reload.full_data
+      expect(full_data).to include("ruby/hash-with-ivars:VimHash")
+      expect(full_data).to include("ruby/string:VimString")
+      expect(full_data).to include("ruby/array:VimArray")
     end
   end
 end

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -26,9 +26,24 @@ describe RemoveVimTypesFromEmsEvents do
               :@xsiType: :DatacenterEventArgument
               :@vimType:
           eventType: VmCreatedEvent
+          arguments: !ruby/array:VimArray
+            internal:
+            - !ruby/hash-with-ivars:VimHash
+              elements:
+                datacenter: !ruby/string:VimString
+                  str: datacenter-104
+                  xsiType: :Datacenter
+                  vimType: :ManagedObjectReference
+              ivars:
+                :@xsiType: :DatacenterArgument
+                :@vimType:
+            ivars:
+              :@xsiType: :KeyAnyValue
+              :@vimType:
         ivars:
           :@xsiType: :VmCreatedEvent
           :@vimType:
+
       FULL_DATA
 
       event = event_stream_stub.create!(:full_data => full_data, :source => "VC")
@@ -45,6 +60,10 @@ describe RemoveVimTypesFromEmsEvents do
         "name"       => "dev-vc67-DC",
         "datacenter" => "datacenter-104"
       )
+      expect(full_data["arguments"].class).to eq(Array)
+      expect(full_data["arguments"].count).to eq(1)
+      expect(full_data["arguments"].first.class).to eq(Hash)
+      expect(full_data["arguments"].first).to include("datacenter" => "datacenter-104")
     end
   end
 end

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -37,10 +37,10 @@ describe RemoveVimTypesFromEmsEvents do
 
       full_data = YAML.load(event.reload.full_data)
 
-      expect(full_data.class.name).to eq("Hash")
-      expect(full_data["key"].class.name).to eq("String")
+      expect(full_data.class).to eq(Hash)
+      expect(full_data["key"].class).to eq(String)
       expect(full_data["key"]).to eq("585137")
-      expect(full_data["datacenter"].class.name).to eq("Hash")
+      expect(full_data["datacenter"].class).to eq(Hash)
       expect(full_data["datacenter"]).to include(
         "name"       => "dev-vc67-DC",
         "datacenter" => "datacenter-104"

--- a/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
+++ b/spec/migrations/20200126203714_remove_vim_types_from_ems_events_spec.rb
@@ -47,7 +47,4 @@ describe RemoveVimTypesFromEmsEvents do
       )
     end
   end
-
-  migration_context :down do
-  end
 end


### PR DESCRIPTION
EmsEvents have VimTypes (e.g. VimHash/VimString) in the serialized full_data column which requires core workers to require `VMwareWebService/VimTypes` to be able to load the record.