### PR TITLE
Add type column to service_order table

### DIFF
--- a/db/migrate/20200128122000_add_type_column_to_service_order.rb
+++ b/db/migrate/20200128122000_add_type_column_to_service_order.rb
@@ -1,0 +1,23 @@
+class AddTypeColumnToServiceOrder < ActiveRecord::Migration[5.0]
+  class ServiceOrder < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+  class MiqRequest < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    add_column :service_orders, :type, :string
+
+    say_with_time("Set service_orders type") do
+      v2v_order_ids = MiqRequest.where(:type => 'ServiceTemplateTransformationPlanRequest').pluck(:service_order_id)
+      ServiceOrder.where(:id => v2v_order_ids).update_all(:type => 'ServiceOrderV2V')
+
+      ServiceOrder.where(:type => nil).update_all(:type => 'ServiceOrderCart')
+    end
+  end
+
+  def down
+    remove_column :service_orders, :type
+  end
+end

--- a/db/migrate/20200128122000_add_type_column_to_service_order.rb
+++ b/db/migrate/20200128122000_add_type_column_to_service_order.rb
@@ -1,8 +1,12 @@
 class AddTypeColumnToServiceOrder < ActiveRecord::Migration[5.0]
   class ServiceOrder < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
     self.inheritance_column = :_type_disabled # disable STI
   end
   class MiqRequest < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
     self.inheritance_column = :_type_disabled # disable STI
   end
 
@@ -10,10 +14,10 @@ class AddTypeColumnToServiceOrder < ActiveRecord::Migration[5.0]
     add_column :service_orders, :type, :string
 
     say_with_time("Set service_orders type") do
-      v2v_order_ids = MiqRequest.where(:type => 'ServiceTemplateTransformationPlanRequest').pluck(:service_order_id)
+      v2v_order_ids = MiqRequest.in_my_region.where(:type => 'ServiceTemplateTransformationPlanRequest').pluck(:service_order_id)
       ServiceOrder.where(:id => v2v_order_ids).update_all(:type => 'ServiceOrderV2V')
 
-      ServiceOrder.where(:type => nil).update_all(:type => 'ServiceOrderCart')
+      ServiceOrder.in_my_region.where(:type => nil).update_all(:type => 'ServiceOrderCart')
     end
   end
 

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -2,8 +2,6 @@
 base: &base
   adapter: postgresql
   encoding: utf8
-  username: root
-  password: smartvm
   pool: 5
   wait_timeout: 5
   min_messages: warning

--- a/spec/migrations/20200128122000_add_type_column_to_service_order_spec.rb
+++ b/spec/migrations/20200128122000_add_type_column_to_service_order_spec.rb
@@ -1,0 +1,23 @@
+require_migration
+
+describe AddTypeColumnToServiceOrder do
+  let(:service_order) { migration_stub(:ServiceOrder) }
+  let(:miq_request)   { migration_stub(:MiqRequest) }
+
+  migration_context :up do
+    it "Updates service orders to v2v or cart" do
+      v2v_service_order = service_order.create!
+      miq_request.create!(:type             => 'ServiceTemplateTransformationPlanRequest',
+                          :service_order_id => v2v_service_order.id)
+      plain_service_order = service_order.create!
+
+      migrate
+
+      v2v_service_order.reload
+      expect(v2v_service_order.type).to eq "ServiceOrderV2V"
+
+      plain_service_order.reload
+      expect(plain_service_order.type).to eq "ServiceOrderCart"
+    end
+  end
+end


### PR DESCRIPTION
NEEDS TO BE MERGED ALONG WITH https://github.com/ManageIQ/manageiq/pull/19766

This adds a type column to the service_order table. The associated type would be plucked from its associated requests e.g. ServiceTemplateProvisionRequest or ServiceTemplateTransformationPlanRequest.

**Still need to update ServiceOrder with type on creation so new `ServiceOrder` instances use STI.**
Needs to be merged along with  https://github.com/ManageIQ/manageiq/pull/19795

Attempts to solve ManageIQ/manageiq-ui-service#1463

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1565049