### PR TITLE
[WIP] Add and populate Tenant#ems_ref

### DIFF
--- a/db/migrate/20200128180604_add_ems_ref_to_tenants.rb
+++ b/db/migrate/20200128180604_add_ems_ref_to_tenants.rb
@@ -1,0 +1,5 @@
+class AddEmsRefToTenants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tenants, :ems_ref, :string
+  end
+end

--- a/db/migrate/20200129122439_copy_cloud_tenants_ems_ref_to_tenants.rb
+++ b/db/migrate/20200129122439_copy_cloud_tenants_ems_ref_to_tenants.rb
@@ -1,0 +1,36 @@
+class CopyCloudTenantsEmsRefToTenants < ActiveRecord::Migration[5.1]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Tenant < ActiveRecord::Base; end
+
+  class CloudTenant < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Copying CloudTenant#ems_ref or ExtManagementSystem#guid to Tenant#ems_ref") do
+      Tenant.where.not(:source_id => nil).each do |tenant|
+        case tenant.source_type
+        when "CloudTenant"
+          source_scope = CloudTenant.where(:id => tenant.source_id)
+          if source_scope.exists?
+            tenant.update_attributes(:ems_ref => source_scope.first.ems_ref)
+          end
+        when "ExtManagementSystem"
+          source_scope = ExtManagementSystem.where(:id => tenant.source_id)
+          if source_scope.exists?
+            tenant.update_attributes(:ems_ref => source_scope.first.guid)
+          end
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time("Nullifying Tenant#ems_ref") do
+      Tenant.where.not(:source_id => nil).where(:source_type => %w[CloudTenant ExtManagementSystem]).update_all(:ems_ref => nil)
+    end
+  end
+end

--- a/spec/migrations/20200129122439_copy_cloud_tenants_ems_ref_to_tenants_spec.rb
+++ b/spec/migrations/20200129122439_copy_cloud_tenants_ems_ref_to_tenants_spec.rb
@@ -1,0 +1,42 @@
+require_migration
+
+describe CopyCloudTenantsEmsRefToTenants do
+  let(:cloud_tenant_model) { migration_stub(:CloudTenant) }
+  let(:tenant_model)       { migration_stub(:Tenant) }
+  let(:ems_model)          { migration_stub(:ExtManagementSystem) }
+  let(:ems_guid)           { "XXXX" }
+  let(:ems_ref)            { "YYYY" }
+
+  migration_context :up do
+    it "copies CloudTenant#ems_ref or ExtManagementSystem#guid to Tenant#ems_ref" do
+      expect(ems_model.count).to eq(0)
+      expect(cloud_tenant_model.count).to eq(0)
+
+      ems = ems_model.create(:name => 'name', :guid => ems_guid)
+      tenant_for_ems = tenant_model.create(:source_id => ems.id, :source_type => 'ExtManagementSystem')
+
+      ct = cloud_tenant_model.create(:name => 'name', :ems_ref => ems_ref)
+      tenant_for_cloud_tenant = tenant_model.create(:source_id => ct.id, :source_type => 'CloudTenant')
+
+      migrate
+
+      expect(tenant_for_ems.reload.ems_ref).to eq(ems_guid)
+      expect(tenant_for_cloud_tenant.reload.ems_ref).to eq(ems_ref)
+    end
+  end
+
+  migration_context :down do
+    it "removes Tenant#ems_ref from Tenants with source" do
+      ems = ems_model.create(:name => 'name', :guid => ems_guid)
+      tenant_for_ems = tenant_model.create(:source_id => ems.id, :source_type => 'ExtManagementSystem', :ems_ref => ems_guid)
+
+      ct = cloud_tenant_model.create(:name => 'name', :ems_ref => ems_ref)
+      tenant_for_cloud_tenant = tenant_model.create(:source_id => ct.id, :source_type => 'CloudTenant', :ems_ref => ems_ref)
+
+      migrate
+
+      expect(tenant_for_ems.reload.ems_ref).to be_nil
+      expect(tenant_for_cloud_tenant.reload.ems_ref).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
We had issue when openstack provider was removed and then re-added with same name with openstack mapping(OM). OM creates tenant structure according to cloud tenants. When those tenants are tied with some group, then removal of openstack provider will leave tenants(tied with groups. ) in system (we cannot remove tenant with group)  and then OM fails when provider was re-added and provider was not able to create tenant structure.
In this case, we need to rejoin existing tenants with new OM but we don't have unique identification how to do it. We have just name(this name is reflected in mapped tenant) of provider  and it can be so we cannot rely on it.

to achieve this we need to add  nique identification  to the mapped tenant from provider.

in mapped tenants of CloudTenant we are using `CloudTenant#ems_ref` in 
in mapped root tenant of Provider we are using  `ExtManagement#guid`.

This PR adds ems_ref to Tenant and populates Tenant#ems_ref  according to ^


After this PR we can update OM sync process.

 @aufi can you review please.  ? can you take look whether I am using proper identification ( ExtManagement#guid., CloudTenant#ems_ref) for mapped tenants ? thanks! 

cc @gtanzillo 





@miq-bot add_label bug


 


