### PR TITLE
MiqAeNamespace should use ancestry instead of acts_as_tree

### DIFF
--- a/db/migrate/20200221200855_add_ancestry_to_miq_ae_namespace.rb
+++ b/db/migrate/20200221200855_add_ancestry_to_miq_ae_namespace.rb
@@ -1,0 +1,31 @@
+require 'ancestry'
+
+class AddAncestryToMiqAeNamespace < ActiveRecord::Migration[5.1]
+  class MiqAeNamespace < ActiveRecord::Base
+    has_ancestry
+  end
+
+  def up
+    add_column :miq_ae_namespaces, :ancestry, :string
+    add_index :miq_ae_namespaces, :ancestry
+
+    say_with_time("Converting MiqAeNamespaces from parent_id to ancestry") do
+      MiqAeNamespace.build_ancestry_from_parent_ids!
+    end
+
+    remove_index :miq_ae_namespaces, :column => :parent_id
+    remove_column :miq_ae_namespaces, :parent_id
+  end
+
+  def down
+    add_column :miq_ae_namespaces, :parent_id, :bigint
+    add_index :miq_ae_namespaces, :parent_id
+
+    say_with_time("Converting MiqAeNamespaces from ancestry to parent_id") do
+      MiqAeNamespace.update_all("parent_id = CAST(regexp_replace(ancestry, '.*/', '') AS bigint)")
+    end
+
+    remove_index :miq_ae_namespaces, :column => :ancestry
+    remove_column :miq_ae_namespaces, :ancestry
+  end
+end

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
+  s.add_dependency "ancestry"
   s.add_dependency "activerecord-id_regions", "~> 0.3.0"
   s.add_dependency "linux_admin", "~> 2.0"
   s.add_dependency "manageiq-password", "~> 0.3"

--- a/spec/migrations/20200221200855_add_ancestry_to_miq_ae_namespace_spec.rb
+++ b/spec/migrations/20200221200855_add_ancestry_to_miq_ae_namespace_spec.rb
@@ -1,0 +1,54 @@
+require_migration
+
+describe AddAncestryToMiqAeNamespace do
+  let(:ns_stub) { Class.new(ActiveRecord::Base) { self.table_name = "miq_ae_namespaces" } }
+
+  migration_context :up do
+    # nodes:
+    # ns1
+    #   ns11
+    #     ns111
+    #     ns112
+    # ns2
+    #   ns21
+    it "updates tree" do
+      ns1   = ns_stub.create!
+      ns2   = ns_stub.create!
+      ns11  = ns_stub.create!(:parent_id => ns1.id)
+      ns111 = ns_stub.create!(:parent_id => ns11.id)
+      ns112 = ns_stub.create!(:parent_id => ns11.id)
+      ns21  = ns_stub.create!(:parent_id => ns2.id)
+
+      migrate
+
+      expect(ns1.reload.ancestry).to be_nil
+      expect(ns2.reload.ancestry).to be_nil
+
+      expect(ns11.reload.ancestry).to eq(ns1.id.to_s)
+      expect(ns111.reload.ancestry).to eq("#{ns1.id}/#{ns11.id}")
+      expect(ns112.reload.ancestry).to eq("#{ns1.id}/#{ns11.id}")
+      expect(ns21.reload.ancestry).to eq(ns2.id.to_s)
+    end
+  end
+
+  migration_context :down do
+    it "updates tree" do
+      ns1   = ns_stub.create!
+      ns2   = ns_stub.create!
+      ns11  = ns_stub.create!(:ancestry => ns1.id)
+      ns111 = ns_stub.create!(:ancestry => "#{ns1.id}/#{ns11.id}")
+      ns112 = ns_stub.create!(:ancestry => "#{ns1.id}/#{ns11.id}")
+      ns21  = ns_stub.create!(:ancestry => ns2.id)
+
+      migrate
+
+      expect(ns1.reload.parent_id).to eq(nil)
+      expect(ns2.reload.parent_id).to eq(nil)
+
+      expect(ns11.reload.parent_id).to eq(ns1.id)
+      expect(ns111.reload.parent_id).to eq(ns11.id)
+      expect(ns112.reload.parent_id).to eq(ns11.id)
+      expect(ns21.reload.parent_id).to eq(ns2.id)
+    end
+  end
+end


### PR DESCRIPTION
Cross Repo Tests: ManageIQ/manageiq-cross_repo-tests#66
Blocks https://github.com/ManageIQ/manageiq/pull/19824

https://github.com/ManageIQ/manageiq-automation_engine/issues/409

@miq-bot add_label performance

cc @tinaafitz 