### PR TITLE
Remove RH domain

### DIFF
--- a/db/migrate/20200211181329_drop_red_hat_domain.rb
+++ b/db/migrate/20200211181329_drop_red_hat_domain.rb
@@ -1,0 +1,35 @@
+class DropRedHatDomain < ActiveRecord::Migration[5.1]
+  class MiqAeNamespace < ActiveRecord::Base; end
+  class MiqAeField < ActiveRecord::Base; end
+  class MiqAeMethod < ActiveRecord::Base; end
+  class MiqAeInstance < ActiveRecord::Base; end
+  class MiqAeValue < ActiveRecord::Base; end
+  class MiqAeClass < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Remove RedHat domain') do
+      domain = MiqAeNamespace.find_by(:name => 'RedHat', :parent_id => nil)
+      return unless domain
+
+      domain_ids_list = fetch_child_namespace_ids(domain.id)
+      ae_classes_id_list = MiqAeClass.where(:namespace_id => domain_ids_list).pluck(:id)
+      instances_id_list = MiqAeInstance.where(:class_id => ae_classes_id_list).pluck(:id)
+
+      MiqAeValue.where(:instance_id => instances_id_list).destroy_all
+      MiqAeField.where(:class_id => ae_classes_id_list).destroy_all
+      MiqAeMethod.where(:class_id => ae_classes_id_list).destroy_all
+      MiqAeInstance.where(:class_id => ae_classes_id_list).destroy_all
+      MiqAeClass.where(:namespace_id => domain_ids_list).destroy_all
+      MiqAeNamespace.where(:id => domain_ids_list).destroy_all
+    end
+  end
+
+  def fetch_child_namespace_ids(namespace_ids)
+    return [] if namespace_ids.blank?
+
+    ids = MiqAeNamespace.where(:parent_id => namespace_ids).pluck(:id)
+    fetch_child_namespace_ids(ids) + Array(namespace_ids)
+  end
+end

--- a/spec/migrations/20200211181329_drop_red_hat_domain_spec.rb
+++ b/spec/migrations/20200211181329_drop_red_hat_domain_spec.rb
@@ -1,0 +1,60 @@
+require_migration
+
+describe DropRedHatDomain do
+  let(:miq_ae_namespace_stub) { migration_stub(:MiqAeNamespace) }
+  let(:miq_ae_class_stub) { migration_stub(:MiqAeClass) }
+  let(:miq_ae_method_stub) { migration_stub(:MiqAeMethod) }
+  let(:miq_ae_field_stub) { migration_stub(:MiqAeField) }
+  let(:miq_ae_instance_stub) { migration_stub(:MiqAeInstance) }
+  let(:miq_ae_value_stub) { migration_stub(:MiqAeValue) }
+
+  migration_context :up do
+    it "drops domain, classes, methods, fields from RH domain" do
+      namespace = miq_ae_namespace_stub.create!(:name => 'RedHat', :parent_id => nil)
+      namespace2 = miq_ae_namespace_stub.create!(:name => 'RedHat2', :parent_id => namespace.id)
+      namespace3 = miq_ae_namespace_stub.create!(:name => 'RedHat3', :parent_id => namespace2.id)
+      ae_class = miq_ae_class_stub.create!(:namespace_id => namespace2.id)
+      ae_class2 = miq_ae_class_stub.create!(:namespace_id => namespace3.id)
+      ae_class3 = miq_ae_class_stub.create!(:namespace_id => namespace.id)
+      miq_ae_method_stub.create!(:class_id => ae_class.id)
+      miq_ae_field_stub.create!(:class_id => ae_class.id)
+      miq_ae_field_stub.create!(:class_id => ae_class2.id)
+      miq_ae_field_stub.create!(:class_id => ae_class3.id)
+      ae_instance = miq_ae_instance_stub.create!(:class_id => ae_class.id)
+      ae_instance2 = miq_ae_instance_stub.create!(:class_id => ae_class2.id)
+      ae_instance3 = miq_ae_instance_stub.create!(:class_id => ae_class3.id)
+      miq_ae_value_stub.create!(:instance_id => ae_instance.id)
+      miq_ae_value_stub.create!(:instance_id => ae_instance2.id)
+      miq_ae_value_stub.create!(:instance_id => ae_instance3.id)
+
+      migrate
+
+      expect(miq_ae_namespace_stub.find_by(:name => 'RedHat')).to eq(nil)
+      expect(miq_ae_class_stub.count).to eq(0)
+      expect(miq_ae_field_stub.count).to eq(0)
+      expect(miq_ae_method_stub.count).to eq(0)
+      expect(miq_ae_instance_stub.count).to eq(0)
+      expect(miq_ae_value_stub.count).to eq(0)
+    end
+
+    it "doesn't drop domain, classes, methods, fields from other domain" do
+      namespace = miq_ae_namespace_stub.create!(:name => 'NotRedHat', :parent_id => nil)
+      namespace2 = miq_ae_namespace_stub.create!(:name => 'RedHat2', :parent_id => namespace.id)
+      ae_class = miq_ae_class_stub.create!(:namespace_id => namespace2.id)
+      miq_ae_method_stub.create!(:class_id => ae_class.id)
+      miq_ae_field_stub.create!(:class_id => ae_class.id)
+      ae_instance = miq_ae_instance_stub.create!(:class_id => ae_class.id)
+      miq_ae_value_stub.create!(:instance_id => ae_instance.id)
+
+      migrate
+
+      expect(miq_ae_namespace_stub.find_by(:name => 'RedHat')).to eq(nil)
+      expect(miq_ae_namespace_stub.count).to eq(2)
+      expect(miq_ae_class_stub.count).to eq(1)
+      expect(miq_ae_field_stub.count).to eq(1)
+      expect(miq_ae_method_stub.count).to eq(1)
+      expect(miq_ae_instance_stub.count).to eq(1)
+      expect(miq_ae_value_stub.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
The [RedHat domain contents have been moved into the ManageIQ domain](https://github.com/ManageIQ/manageiq-content/issues/630) and the powers that be said that I could remove the domain now. It's ... what was it Jason said? Oh right, "it's admittedly weird". 

Per https://github.com/ManageIQ/manageiq-schema/issues/456