### PR TITLE
Convert OvirtSDK4 objects to Hash in EventStream full_data

### DIFF
--- a/db/migrate/20200212171537_remove_ovirt_sdk4_from_event_stream.rb
+++ b/db/migrate/20200212171537_remove_ovirt_sdk4_from_event_stream.rb
@@ -1,0 +1,27 @@
+class RemoveOvirtSdk4FromEventStream < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  include MigrationHelper
+
+  class EventStream < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Removing OvirtSDK4 types from EmsEvents") do
+      base_relation = EventStream.in_my_region.where(:source => "RHEVM")
+        .where("full_data LIKE ?", "%object:OvirtSDK4::Event%")
+
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000)
+          .update_all("full_data = REGEXP_REPLACE(full_data, '!ruby/object:OvirtSDK4::\\w+', '!ruby/object:Hash', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+end

--- a/spec/migrations/20200212171537_remove_ovirt_sdk4_from_event_stream_spec.rb
+++ b/spec/migrations/20200212171537_remove_ovirt_sdk4_from_event_stream_spec.rb
@@ -1,0 +1,48 @@
+require_migration
+
+describe RemoveOvirtSdk4FromEventStream do
+  let(:event_stream_stub) { migration_stub(:EventStream) }
+
+  migration_context :up do
+    it "converts OvirtSDK4 Objects to a hash" do
+      full_data = <<~FULL_DATA
+        --- !ruby/object:OvirtSDK4::Event
+        href: "/ovirt-engine/api/events/616040"
+        name: USER_STARTED_VM
+        cluster: !ruby/object:OvirtSDK4::Cluster
+          href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000024b"
+          id: 00000002-0002-0002-0002-00000000024b
+          name: Default
+        data_center: !ruby/object:OvirtSDK4::DataCenter
+          href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000123"
+          id: 00000001-0001-0001-0001-000000000123
+          name: Default
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/f92aa108-3e37-4c76-ae81-5a5c6fc3e24d"
+          id: f92aa108-3e37-4c76-ae81-5a5c6fc3e24d
+        origin: oVirt
+        severity: normal
+        template: !ruby/object:OvirtSDK4::Template
+          href: "/ovirt-engine/api/templates/e286b99b-bc49-4b7d-b265-3d82bfb5eac7"
+          id: e286b99b-bc49-4b7d-b265-3d82bfb5eac7
+          name: RHEL76_Base
+        time: !ruby/object:DateTime 2019-02-20 05:15:48.290000000 -05:00
+        user: !ruby/object:OvirtSDK4::User
+          href: "/ovirt-engine/api/users/0000001a-001a-001a-001a-000000000392"
+          id: 0000001a-001a-001a-001a-000000000392
+          name: admin@internal-authz
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: "/ovirt-engine/api/vms/b6c5d8ca-7db5-4372-bfd2-26d3c8116227"
+          id: b6c5d8ca-7db5-4372-bfd2-26d3c8116227
+          name: ocp311-master1
+      FULL_DATA
+
+      event = event_stream_stub.create!(:full_data => full_data, :source => "RHEVM")
+
+      migrate
+
+      full_data = YAML.load(event.reload.full_data)
+      expect(full_data.class).to eq(Hash)
+    end
+  end
+end


### PR DESCRIPTION
The `Ovirt` event catcher was populating the `event_streams` `:full_data` column with `OvirtSDK4` objects like `OvirtSDK4::Event`.  This was causing the event handler to throw an exception because it does not load the `OvirtSDK4` gem.

Similar to: https://github.com/ManageIQ/manageiq-schema/pull/451