### PR TITLE
add system flag to dialogs

### DIFF
--- a/db/migrate/20200424183342_add_read_only_to_dialogs.rb
+++ b/db/migrate/20200424183342_add_read_only_to_dialogs.rb
@@ -1,0 +1,5 @@
+class AddReadOnlyToDialogs < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dialogs, :system, :boolean
+  end
+end


### PR DESCRIPTION
we have one built-in dialog, we could use something like this to differentiate it
really i just want to see what people have to say about it

requires data migration for it: 
`Dialog.find_by(:label => 'Transform VM')`

that issue mentions the azure one, `manageiq-providers-azure/content/service_dialogs/azure-single-vm-from-user-image.yml` but I think we got rid of that dialog in https://github.com/ManageIQ/manageiq-providers-azure/pull/107

see https://github.com/ManageIQ/manageiq/issues/15144