### PR TITLE
Remove VimString objects from Notification.options

### DIFF
--- a/db/migrate/20200427122455_remove_vim_strings_from_notifications.rb
+++ b/db/migrate/20200427122455_remove_vim_strings_from_notifications.rb
@@ -1,0 +1,36 @@
+class RemoveVimStringsFromNotifications < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  include MigrationHelper
+
+  class Notification < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    say_with_time("Removing VimStrings from Notifications") do
+      base_relation = Notification.in_my_region.where("options LIKE ?", "%ruby/string:VimString%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("options = REGEXP_REPLACE(options, '!ruby/string:VimString', '!ruby/string:String', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Restoring VimStrings in Notifications") do
+      base_relation = Notification.in_my_region.where("options LIKE ?", "%ruby/string:String%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("options = REGEXP_REPLACE(options, '!ruby/string:String', '!ruby/string:VimString', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+end

--- a/spec/migrations/20200427122455_remove_vim_strings_from_notifications_spec.rb
+++ b/spec/migrations/20200427122455_remove_vim_strings_from_notifications_spec.rb
@@ -1,0 +1,61 @@
+require_migration
+
+class RemoveVimStringsFromNotifications
+  class NotificationType < ActiveRecord::Base
+  end
+end
+
+describe RemoveVimStringsFromNotifications do
+  let(:notification_stub)      { migration_stub(:Notification) }
+  let(:notification_type_stub) { migration_stub(:NotificationType) }
+
+  migration_context :up do
+    it "converts VimStrings to Strings" do
+      options = <<~OPTIONS
+        ---
+        :error: !ruby/string:VimString
+        str: Another task is already in progress.
+        xsiType: :SOAP::SOAPString
+        vimType:
+        :snapshot_op: remove
+        :subject: sapm-db2a
+      OPTIONS
+
+      notification_type = notification_type_stub.find_or_create_by!(:name => "vm_snapshot_failure")
+      notification = notification_stub.create!(
+        :notification_type_id => notification_type.id,
+        :options           => options
+      )
+
+      migrate
+
+      options = YAML.load(notification.reload.options)
+      expect(options[:error].class).to eq(String)
+    end
+  end
+
+  migration_context :down do
+    it "restores String to VimString" do
+      options = <<~OPTIONS
+        ---
+        :error: !ruby/string:String
+        str: Another task is already in progress.
+        xsiType: :SOAP::SOAPString
+        vimType:
+        :snapshot_op: remove
+        :subject: sapm-db2a
+      OPTIONS
+
+      notification_type = notification_type_stub.find_or_create_by!(:name => "vm_snapshot_failure")
+      notification = notification_stub.create!(
+        :notification_type_id => notification_type.id,
+        :options           => options
+      )
+
+      migrate
+
+      options = notification.reload.options
+      expect(options).to include("ruby/string:VimString")
+    end
+  end
+end


### PR DESCRIPTION
There are some `VimStrings` that made their way into `Notification.options[:error]` which are now failing to load without having `'VMwareWebService/VimTypes'` required.

This is similar to the issue that https://github.com/ManageIQ/manageiq-schema/pull/451 addressed

https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb#L29