### PR TITLE
set dialog system flag

### DIFF
--- a/db/migrate/20200427175819_set_read_only_flag.rb
+++ b/db/migrate/20200427175819_set_read_only_flag.rb
@@ -1,0 +1,13 @@
+class SetReadOnlyFlag < ActiveRecord::Migration[5.1]
+  class Dialog < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    say_with_time("Updating Dialogs") do
+      Dialog.in_my_region.where(:label => 'Transform VM').update_all(:system => true)
+      Dialog.in_my_region.where.not(:label => 'Transform VM').update_all(:system => false)
+    end
+  end
+end

--- a/spec/migrations/20200427175819_set_read_only_flag_spec.rb
+++ b/spec/migrations/20200427175819_set_read_only_flag_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe SetReadOnlyFlag do
+  let(:dialog) { migration_stub(:Dialog) }
+
+  migration_context :up do
+    it "sets the flag" do
+      dialog1 = dialog.create(:label => "anything else")
+      dialog2 = dialog.create(:label => 'Transform VM')
+
+      migrate
+
+      expect(dialog1.reload.system).to be(false)
+      expect(dialog2.reload.system).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
we have one built-in dialog, we could use something like this to differentiate them
really i just want to see what people have to say about it

requires data migration for it: 
`Dialog.find_by(:label => 'Transform VM')`

that issue mentions the azure one, `manageiq-providers-azure/content/service_dialogs/azure-single-vm-from-user-image.yml` but I think we got rid of that dialog in https://github.com/ManageIQ/manageiq-providers-azure/pull/107

see https://github.com/ManageIQ/manageiq/issues/15144

where.not doesn't work with nils but we've the name/label can't be nil anyway

## depends on 
data migration required for https://github.com/ManageIQ/manageiq-schema/pull/468