### PR TITLE
Fix the dummy app's database.yml user/password

### DIFF
--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -2,6 +2,8 @@
 base: &base
   adapter: postgresql
   encoding: utf8
+  username: root
+  password: smartvm
   pool: 5
   wait_timeout: 5
   min_messages: warning


### PR DESCRIPTION
The default username and password was removed from the
spec/dummy/config/database.yml file causing errors setting up the dummy
test database.