### PR TITLE
Remove most of VmdbDatabase and friends

### DIFF
--- a/db/migrate/20200508150740_remove_vmdb_database_tables.rb
+++ b/db/migrate/20200508150740_remove_vmdb_database_tables.rb
@@ -1,0 +1,78 @@
+class RemoveVmdbDatabaseTables < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :vmdb_database_metrics
+    drop_table :vmdb_databases
+    drop_table :vmdb_indexes
+    drop_table :vmdb_metrics
+    drop_table :vmdb_tables
+  end
+
+  def down
+    create_table "vmdb_database_metrics", force: :cascade do |t|
+      t.bigint "vmdb_database_id"
+      t.integer "running_processes"
+      t.integer "active_connections"
+      t.datetime "timestamp"
+      t.string "capture_interval_name"
+      t.bigint "disk_total_bytes"
+      t.bigint "disk_free_bytes"
+      t.bigint "disk_used_bytes"
+      t.bigint "disk_total_inodes"
+      t.bigint "disk_used_inodes"
+      t.bigint "disk_free_inodes"
+    end
+
+    create_table "vmdb_databases", force: :cascade do |t|
+      t.string "name"
+      t.string "ipaddress"
+      t.string "vendor"
+      t.string "version"
+      t.string "data_directory"
+      t.datetime "last_start_time"
+      t.string "data_disk"
+    end
+
+    create_table "vmdb_indexes", force: :cascade do |t|
+      t.bigint "vmdb_table_id"
+      t.string "name"
+      t.text "prior_raw_metrics"
+    end
+
+    create_table "vmdb_metrics", force: :cascade do |t|
+      t.bigint "resource_id"
+      t.string "resource_type"
+      t.bigint "size"
+      t.bigint "rows"
+      t.bigint "pages"
+      t.float "percent_bloat"
+      t.float "wasted_bytes"
+      t.integer "otta"
+      t.bigint "table_scans"
+      t.bigint "sequential_rows_read"
+      t.bigint "index_scans"
+      t.bigint "index_rows_fetched"
+      t.bigint "rows_inserted"
+      t.bigint "rows_updated"
+      t.bigint "rows_deleted"
+      t.bigint "rows_hot_updated"
+      t.bigint "rows_live"
+      t.bigint "rows_dead"
+      t.datetime "last_vacuum_date"
+      t.datetime "last_autovacuum_date"
+      t.datetime "last_analyze_date"
+      t.datetime "last_autoanalyze_date"
+      t.datetime "timestamp"
+      t.string "capture_interval_name"
+      t.index ["resource_id", "resource_type", "timestamp"], name: "index_vmdb_metrics_on_resource_and_timestamp"
+    end
+
+    create_table "vmdb_tables", force: :cascade do |t|
+      t.bigint "vmdb_database_id"
+      t.string "name"
+      t.string "type"
+      t.bigint "parent_id"
+      t.text "prior_raw_metrics"
+      t.index ["type"], name: "index_vmdb_tables_on_type"
+    end
+  end
+end

--- a/db/migrate/20200512161742_remove_vmdb_database_settings.rb
+++ b/db/migrate/20200512161742_remove_vmdb_database_settings.rb
@@ -1,0 +1,18 @@
+class RemoveVmdbDatabaseSettings < ActiveRecord::Migration[5.2]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time('Removing RemoveVmdbDatabaseSettings') do
+      SettingsChange.where(:key => '/database/metrics_collection/collection_schedule').destroy_all
+      SettingsChange.where(:key => '/database/metrics_collection/daily_rollup_schedule').destroy_all
+      SettingsChange.where(:key => '/database/metrics_history/keep_daily_metrics').destroy_all
+      SettingsChange.where(:key => '/database/metrics_history/keep_hourly_metrics').destroy_all
+      SettingsChange.where(:key => '/database/metrics_history/purge_schedule').destroy_all
+      SettingsChange.where(:key => '/database/metrics_history/purge_window_size').destroy_all
+      SettingsChange.where(:key => '/database/metrics_history/queue_timeout').destroy_all
+      SettingsChange.where(:key => '/ui/display_ops_database').destroy_all
+      SettingsChange.where(:key => '/workers/worker_base/schedule_worker/log_database_statistics_interval').destroy_all
+    end
+  end
+end

--- a/spec/migrations/20200512161742_remove_vmdb_database_settings_spec.rb
+++ b/spec/migrations/20200512161742_remove_vmdb_database_settings_spec.rb
@@ -1,0 +1,29 @@
+require_migration
+
+describe RemoveVmdbDatabaseSettings do
+  let(:settings_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it 'Remove VmdbDatabase Settings' do
+      settings_stub.create!(:key => '/database/metrics_collection/collection_schedule', :value => "1 * * * *")
+      settings_stub.create!(:key => '/database/metrics_collection/daily_rollup_schedule', :value => "23 0 * * *")
+      settings_stub.create!(:key => '/database/metrics_history/keep_daily_metrics', :value => 6.months)
+      settings_stub.create!(:key => '/database/metrics_history/keep_hourly_metrics', :value => 6.months)
+      settings_stub.create!(:key => '/database/metrics_history/purge_schedule', :value => "50 * * * *")
+      settings_stub.create!(:key => '/database/metrics_history/purge_window_size', :value => 10000)
+      settings_stub.create!(:key => '/database/metrics_history/queue_timeout', :value => 20.minutes)
+      settings_stub.create!(:key => '/ui/display_ops_database', :value => false)
+      settings_stub.create!(:key => '/workers/worker_base/schedule_worker/log_database_statistics_interval', :value => 1.days)
+
+      # one setting that should not be touched
+      settings_stub.create!(:key => '/ui/mark_translated_strings', :value => true)
+
+      migrate
+
+      expect(settings_stub.count).to eql(1)
+      expect(settings_stub.where(:key => '/ui/mark_translated_strings').count).to eql(1)
+    end
+  end
+end
+
+


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/20103 (backend issue)
Related to https://github.com/ManageIQ/manageiq-ui-classic/issues/6995 (frontend
issue)
- [x] Goes together with the frontend PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/6998 [MERGED]
- [ ] Goes together with the core PR: https://github.com/ManageIQ/manageiq/pull/20148
- [x] [cross repo tests](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/119)

We're leaving VmdbDatabaseConnection and VmdbDatabaseLock models because there is
application code using the connection information, etc., so we'll need
replacements for those before we can remove them.