### PR TITLE
Migration to update startpage entry for chargeback/explorer

### DIFF
--- a/db/migrate/20200512201614_update_chargeback_startpage.rb
+++ b/db/migrate/20200512201614_update_chargeback_startpage.rb
@@ -1,0 +1,25 @@
+class UpdateChargebackStartpage < ActiveRecord::Migration[5.2]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating starting page for users who had chargeback explorer set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'chargeback/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'chargeback_reports/explorer'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Updating starting page for users who had non-explorer ems_configuration pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'chargeback_reports/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'chargeback/explorer'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20200512201614_update_chargeback_startpage_spec.rb
+++ b/spec/migrations/20200512201614_update_chargeback_startpage_spec.rb
@@ -1,0 +1,47 @@
+require_migration
+
+describe UpdateChargebackStartpage do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page replace' do
+      it 'replaces user starting page if chargeback/explorer' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'chargeback/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('chargeback_reports/explorer')
+      end
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'starting page replace' do
+      it "replaces user starting page to chargeback if chargeback_reports" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'chargeback_reports/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('chargeback/explorer')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This migration will update startpage entry for any existing user from `chargeback/explorer` to `chargeback_reports/explorer`

This issue was caused by changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/7016

@skateman please review