### PR TITLE
Update schema to match manageiq rails version

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "more_core_extensions", "~> 3.5"
   s.add_dependency "pg"
   s.add_dependency "pg-pglogical", "~> 2.1.1"
-  s.add_dependency "rails", "~>5.2.4"
+  s.add_dependency "rails", "~>5.2.4", ">=5.2.4.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Note, schema can't run without manageiq but we're updating it to be consistent.

From:
https://github.com/ManageIQ/manageiq/pull/20188

[CVE-2020-8162] Circumvention of file size limits in ActiveStorage
[CVE-2020-8164] Possible Strong Parameters Bypass in ActionPack
[CVE-2020-8165] Potentially unintended unmarshalling of user-provided objects in MemCacheStore and RedisCacheStore
[CVE-2020-8166] Ability to forge per-form CSRF tokens given a global CSRF token
[CVE-2020-8167] CSRF Vulnerability in rails-ujs

https://weblog.rubyonrails.org/2020/5/18/Rails-5-2-4-3-and-6-0-3-1-have-been-released/