### PR TITLE
change hardware mem usage to bigint

### DIFF
--- a/db/migrate/20200519213913_change_hardware_mem_types.rb
+++ b/db/migrate/20200519213913_change_hardware_mem_types.rb
@@ -1,0 +1,16 @@
+class ChangeHardwareMemTypes < ActiveRecord::Migration[5.2]
+  class Hardware < ActiveRecord::Base
+  end
+
+  def up
+    change_column :hardwares, :memory_mb, :bigint
+  end
+
+  def down
+    say_with_time "clamp oversized memory_mb values" do
+      Hardware.where("memory_mb > 2147483647").update_all(:memory_mb => 2_147_483_647)
+    end
+
+    change_column :hardwares, :memory_mb, :integer
+  end
+end

--- a/spec/migrations/20200519213913_change_hardware_mem_types_spec.rb
+++ b/spec/migrations/20200519213913_change_hardware_mem_types_spec.rb
@@ -1,0 +1,16 @@
+require_migration
+
+describe ChangeHardwareMemTypes do
+  migration_context :down do
+    let(:hardware) { migration_stub(:Hardware).create(:memory_mb => 2_147_483_648) }
+
+    it "caps > 2147483647" do
+      expect(hardware.memory_mb).to eq(2_147_483_648)
+
+      migrate
+      hardware.reload
+
+      expect(hardware).to have_attributes(:memory_mb => 2_147_483_647)
+    end
+  end
+end


### PR DESCRIPTION
At least memory_mb ought to not be an int cause we convert this as Keenan said into bytes and multiply by 1024*1024 which with aggregation will overflow and instead of a model cast we should be doing something ... something else. 

this changes the type, and has a size check on the down 

@miq-bot assign @kbrock 
or um, no bot after all