### PR TITLE
set vm ancestry from relationship resource info

### DIFF
--- a/db/migrate/20200607025146_add_ancestry_to_vm.rb
+++ b/db/migrate/20200607025146_add_ancestry_to_vm.rb
@@ -9,40 +9,73 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
   class Relationship < ActiveRecord::Base
   end
 
-  #
-  # build sql that converts relationship ancestry with the id of the relationship to model-side ancestry with the id of the model
-  #
+  def up
+    add_column :vms, :ancestry, :string
+    add_index :vms, :ancestry
 
-  # def ancestry_resource_ids(relationship, model_class_name, id_range)
-  #   Relationship.where(
-  #     :relationship => relationship,
-  #     :resource_type => model_class_name,
-  #     :resource_id => id_range
-  #   ).where.not(:ancestry => nil).flat_map do |a_rels|
-  #     a_rels.ancestry.split('/').each_with_index.map { |rel_id, indx| [a_rels.resource_id, rel_id, indx] }
-  #   end
-  # end
+    say_with_time("set vm ancestry from existing genealogy relationship resource information") do
+      connection.execute(transfer_relationships_to_ancestry(VmOrTemplate, 'VmOrTemplate', 'genealogy'))
+    end
 
-  def ancestry_resource_ids(relationship, model_class_name, id_range)
+    Relationship.where(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => VmOrTemplate.all.select(:id)).delete_all
+  end
+
+  def down
+    say_with_time("create relationship records from vm ancestry") do
+      create_relationships_from_ancestry(VmOrTemplate.where(:template => false), Relationship, 'VmOrTemplate', 'genealogy')
+    end
+
+    remove_column :vms, :ancestry
+  end
+
+  # src is relationship, dest is vm
+  def transfer_relationships_to_ancestry(dest_model, resource_type, relationship)
+    ancestry_resources = ancestry_resource_ids(relationship, resource_type, dest_model.rails_sequence_range(dest_model.my_region_number))
+    ancestry_sources = ancestry_src_ids(ancestry_resources)
+    new_ancestors = ancestry_of_src_ids_for_src(ancestry_sources)
+    update_src(new_ancestors, dest_model)
+  end
+
+  # src is vm, dest is relationship
+  def create_relationships_from_ancestry(src_model, dest_model, resource_type, relationship)
+    children = src_model.select("ancestry::bigint").where("ancestry not like '%/%'")
+    rels = src_model.where.not(:ancestry => nil).or(src_model.where(:id => children)).map do |obj|
+      dest_model.create!(:relationship  => relationship,
+                         :resource_type => resource_type,
+                         :resource_id   => obj.id,
+                         :ancestry      => obj.ancestry)
+    end.index_by(&:resource_id)
+    rels.each do |_, r|
+      next if r.ancestry.nil?
+
+      ancestry = r.ancestry.split('/').map { |rel| rels[rel.to_i].id }.join('/')
+      r.update!(:ancestry => ancestry)
+    end
+  end
+
+  private
+
+  def ancestry_resource_ids(relationship, resource_type, id_range)
     <<-SQL
     SELECT a_rels.resource_id AS src_id, relationships.id AS rel_id, relationships.indx AS rel_indx
     FROM   relationships a_rels
     LEFT JOIN LATERAL UNNEST(STRING_TO_ARRAY(a_rels.ancestry, '/')::BIGINT[])
     WITH ORDINALITY AS relationships(id, indx) ON TRUE
     WHERE  a_rels.relationship = '#{relationship}'
-    AND    a_rels.resource_type = '#{model_class_name}'
+    AND    a_rels.resource_type = '#{resource_type}'
     AND    a_rels.resource_id BETWEEN #{id_range.first} AND #{id_range.last}
     SQL
-  end
 
-  # def ancestry_src_ids(ancestry_resources)
-  #   ancestry_resources.map do |rec|
-  #     {
-  #       src_id: rec.src_id,
-  #       ancestry_src_id: Relationship.find(rec[1]).resource_id
-  #     }
-  #   end
-  # end
+    # The above is a pure-SQL version of this similar Ruby code:
+    #
+    #   Relationship.where(
+    #     :relationship => relationship,
+    #     :resource_type => resource_type,
+    #     :resource_id => id_range
+    #   ).where.not(:ancestry => nil).flat_map do |a_rels|
+    #     a_rels.ancestry.split('/').each_with_index.map { |rel_id, indx| [a_rels.resource_id, rel_id, indx] }
+    #   end
+  end
 
   def ancestry_src_ids(ancestry_resources)
     <<-SQL
@@ -52,16 +85,16 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
     ON res_rels.id = ancestry_resources.rel_id
     ORDER BY ancestry_resources.src_id, ancestry_resources.rel_indx
     SQL
-  end
 
-  # def ancestry_of_src_ids_for_src(ancestry_sources)
-  #   ancestry_sources.group_by { |rec| rec.src_id }.map do |src_id, recs|
-  #     {
-  #       src_id: src_id,
-  #       new_ancestry: recs.map { |rec| rec.ancestry_src_id }.join('/')
-  #     }
-  #   end
-  # end
+    # The above is a pure-SQL version of this similar Ruby code:
+    #
+    #   ancestry_resources.map do |rec|
+    #     {
+    #       src_id: rec.src_id,
+    #       ancestry_src_id: Relationship.find(rec[1]).resource_id
+    #     }
+    #   end
+  end
 
   def ancestry_of_src_ids_for_src(ancestry_sources)
     <<-SQL
@@ -70,43 +103,28 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
     FROM (#{ancestry_sources}) AS ancestry_sources
     GROUP BY ancestry_sources.src_id
     SQL
+
+    # The above is a pure-SQL version of this similar Ruby code:
+    #
+    #   ancestry_sources.group_by { |rec| rec.src_id }.map do |src_id, recs|
+    #     {
+    #       src_id: src_id,
+    #       new_ancestry: recs.map { |rec| rec.ancestry_src_id }.join('/')
+    #     }
+    #   end
   end
 
-  # def update_src(model, new_ancestors)
-  #   new_ancestors.each { |a| model.find(a[:src_id]).update(:ancestry => a[:new_ancestry]) }
-  # end
-
-  def update_src(new_ancestors)
+  def update_src(new_ancestors, model)
+    table_name = model.table_name
     <<-SQL
-    UPDATE vms
+    UPDATE #{table_name}
     SET ancestry = new_ancestry
     FROM (#{new_ancestors}) AS new_ancestors
-    WHERE new_ancestors.src_id = vms.id
+    WHERE new_ancestors.src_id = #{table_name}.id
     SQL
-  end
 
-  def up
-    add_column :vms, :ancestry, :string
-    add_index :vms, :ancestry
-
-    say_with_time("set vm ancestry from existing genealogy relationship resource information") do
-      ancestry_resources = ancestry_resource_ids('genealogy', "VmOrTemplate", VmOrTemplate.rails_sequence_range(VmOrTemplate.my_region_number))
-      ancestry_sources = ancestry_src_ids(ancestry_resources)
-      new_ancestors = ancestry_of_src_ids_for_src(ancestry_sources)
-      connection.execute(update_src(new_ancestors))
-    end
-
-    Relationship.where(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => VmOrTemplate.all.select(:id)).delete_all
-  end
-
-  def down
-    say_with_time("create relationship records from vm ancestry") do
-      vms_with_ancestry = VmOrTemplate.where.not(:ancestry => nil)
-      vms_with_ancestry.each do |vm|
-        Relationship.create!(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => vm.id, :ancestry => vm.ancestry)
-      end
-
-      remove_column :vms, :ancestry
-    end
+    # The above is a(n almost) pure-SQL version of this similar Ruby code:
+    #
+    #   new_ancestors.each { |a| model.find(a[:src_id]).update(:ancestry => a[:new_ancestry]) }
   end
 end

--- a/db/migrate/20200607025146_add_ancestry_to_vm.rb
+++ b/db/migrate/20200607025146_add_ancestry_to_vm.rb
@@ -3,58 +3,105 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
     self.inheritance_column = :_type_disabled
     self.table_name = 'vms'
     has_many :all_relationships, :class_name => "AddAncestryToVm::Relationship", :dependent => :destroy, :as => :resource
-  end
-
-  class Vm < VmOrTemplate
     include ActiveRecord::IdRegions
   end
 
   class Relationship < ActiveRecord::Base
-    belongs_to :vm, :class_name => 'AddAncestryToVm::VmOrTemplate', :foreign_key => :vm_id
+  end
+
+  #
+  # build sql that converts relationship ancestry with the id of the relationship to model-side ancestry with the id of the model
+  #
+
+  # def ancestry_resource_ids(relationship, model_class_name, id_range)
+  #   Relationship.where(
+  #     :relationship => relationship,
+  #     :resource_type => model_class_name,
+  #     :resource_id => id_range
+  #   ).where.not(:ancestry => nil).flat_map do |a_rels|
+  #     a_rels.ancestry.split('/').each_with_index.map { |rel_id, indx| [a_rels.resource_id, rel_id, indx] }
+  #   end
+  # end
+
+  def ancestry_resource_ids(relationship, model_class_name, id_range)
+    <<-SQL
+    SELECT a_rels.resource_id AS src_id, relationships.id AS rel_id, relationships.indx AS rel_indx
+    FROM   relationships a_rels
+    LEFT JOIN LATERAL UNNEST(STRING_TO_ARRAY(a_rels.ancestry, '/')::BIGINT[])
+    WITH ORDINALITY AS relationships(id, indx) ON TRUE
+    WHERE  a_rels.relationship = '#{relationship}'
+    AND    a_rels.resource_type = '#{model_class_name}'
+    AND    a_rels.resource_id BETWEEN #{id_range.first} AND #{id_range.last}
+    SQL
+  end
+
+  # def ancestry_src_ids(ancestry_resources)
+  #   ancestry_resources.map do |rec|
+  #     {
+  #       src_id: rec.src_id,
+  #       ancestry_src_id: Relationship.find(rec[1]).resource_id
+  #     }
+  #   end
+  # end
+
+  def ancestry_src_ids(ancestry_resources)
+    <<-SQL
+    SELECT ancestry_resources.src_id AS src_id, res_rels.resource_id AS ancestry_src_id
+    FROM (#{ancestry_resources}) AS ancestry_resources
+    JOIN relationships res_rels
+    ON res_rels.id = ancestry_resources.rel_id
+    ORDER BY ancestry_resources.src_id, ancestry_resources.rel_indx
+    SQL
+  end
+
+  # def ancestry_of_src_ids_for_src(ancestry_sources)
+  #   ancestry_sources.group_by { |rec| rec.src_id }.map do |src_id, recs|
+  #     {
+  #       src_id: src_id,
+  #       new_ancestry: recs.map { |rec| rec.ancestry_src_id }.join('/')
+  #     }
+  #   end
+  # end
+
+  def ancestry_of_src_ids_for_src(ancestry_sources)
+    <<-SQL
+    SELECT ancestry_sources.src_id AS src_id,
+           ARRAY_TO_STRING(ARRAY_AGG(ancestry_sources.ancestry_src_id)::VARCHAR[], '/') AS new_ancestry
+    FROM (#{ancestry_sources}) AS ancestry_sources
+    GROUP BY ancestry_sources.src_id
+    SQL
+  end
+
+  # def update_src(model, new_ancestors)
+  #   new_ancestors.each { |a| model.find(a[:src_id]).update(:ancestry => a[:new_ancestry]) }
+  # end
+
+  def update_src(new_ancestors)
+    <<-SQL
+    UPDATE vms
+    SET ancestry = new_ancestry
+    FROM (#{new_ancestors}) AS new_ancestors
+    WHERE new_ancestors.src_id = vms.id
+    SQL
   end
 
   def up
     add_column :vms, :ancestry, :string
     add_index :vms, :ancestry
 
-    id_range = Vm.rails_sequence_range(Vm.my_region_number)
-
     say_with_time("set vm ancestry from existing genealogy relationship resource information") do
-      connection.execute(<<-SQL)
-      UPDATE vms
-      SET ancestry = new_ancestry
-      FROM (
-        -- join to resources to convert rel.id to vm.id (it is in resource_id column)
-        -- ARRAY_AGG takes multiple rows and converts to an array
-        SELECT ancestor_resources_for_vms.vm_id AS vm_id,
-        ARRAY_TO_STRING(ARRAY_AGG(res_rels.resource_id)::VARCHAR[], '/') AS new_ancestry
-        FROM (
-          -- get vm and associated ancestor rel_id
-          -- unnest converts an array to multiple rows, 1 ancestor per row
-          -- with ordinality, and order by relationships.indx make sure ancestors stay in the same order
-          SELECT vms.id AS vm_id, relationships.id AS rel_id
-          FROM vms
-          JOIN relationships a_rels ON a_rels.resource_id = vms.id
-          AND a_rels.relationship = 'genealogy'
-          AND a_rels.resource_type = 'VmOrTemplate'
-          LEFT JOIN LATERAL UNNEST(STRING_TO_ARRAY(a_rels.ancestry, '/')::BIGINT[])
-          WITH ORDINALITY AS relationships(id, indx) ON TRUE
-          WHERE vms.id BETWEEN #{id_range.first} AND #{id_range.last}
-          ORDER BY vms.id, relationships.indx
-        ) AS ancestor_resources_for_vms
-        JOIN relationships res_rels ON res_rels.id = ancestor_resources_for_vms.rel_id AND res_rels.relationship = 'genealogy'
-        GROUP BY ancestor_resources_for_vms.vm_id
-      ) AS new_ancestors_for_vms
-      WHERE new_ancestors_for_vms.vm_id = vms.id
-      SQL
+      ancestry_resources = ancestry_resource_ids('genealogy', "VmOrTemplate", VmOrTemplate.rails_sequence_range(VmOrTemplate.my_region_number))
+      ancestry_sources = ancestry_src_ids(ancestry_resources)
+      new_ancestors = ancestry_of_src_ids_for_src(ancestry_sources)
+      connection.execute(update_src(new_ancestors))
     end
 
-    Relationship.where(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => Vm.all.select(:id)).delete_all
+    Relationship.where(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => VmOrTemplate.all.select(:id)).delete_all
   end
 
   def down
     say_with_time("create relationship records from vm ancestry") do
-      vms_with_ancestry = Vm.where.not(:ancestry => nil)
+      vms_with_ancestry = VmOrTemplate.where.not(:ancestry => nil)
       vms_with_ancestry.each do |vm|
         Relationship.create!(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => vm.id, :ancestry => vm.ancestry)
       end

--- a/db/migrate/20200607025146_add_ancestry_to_vm.rb
+++ b/db/migrate/20200607025146_add_ancestry_to_vm.rb
@@ -1,0 +1,65 @@
+class AddAncestryToVm < ActiveRecord::Migration[5.2]
+  class VmOrTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    self.table_name = 'vms'
+    has_many :all_relationships, :class_name => "AddAncestryToVm::Relationship", :dependent => :destroy, :as => :resource
+  end
+
+  class Vm < VmOrTemplate
+    include ActiveRecord::IdRegions
+  end
+
+  class Relationship < ActiveRecord::Base
+    belongs_to :vm, :class_name => 'AddAncestryToVm::VmOrTemplate', :foreign_key => :vm_id
+  end
+
+  def up
+    add_column :vms, :ancestry, :string
+    add_index :vms, :ancestry
+
+    id_range = Vm.rails_sequence_range(Vm.my_region_number)
+
+    say_with_time("set vm ancestry from existing genealogy relationship resource information") do
+      connection.execute(<<-SQL)
+      UPDATE vms
+      SET ancestry = new_ancestry
+      FROM (
+        -- join to resources to convert rel.id to vm.id (it is in resource_id column)
+        -- ARRAY_AGG takes multiple rows and converts to an array
+        SELECT ancestor_resources_for_vms.vm_id AS vm_id,
+        ARRAY_TO_STRING(ARRAY_AGG(res_rels.resource_id)::VARCHAR[], '/') AS new_ancestry
+        FROM (
+          -- get vm and associated ancestor rel_id
+          -- unnest converts an array to multiple rows, 1 ancestor per row
+          -- with ordinality, and order by relationships.indx make sure ancestors stay in the same order
+          SELECT vms.id AS vm_id, relationships.id AS rel_id
+          FROM vms
+          JOIN relationships a_rels ON a_rels.resource_id = vms.id
+          AND a_rels.relationship = 'genealogy'
+          AND a_rels.resource_type = 'VmOrTemplate'
+          LEFT JOIN LATERAL UNNEST(STRING_TO_ARRAY(a_rels.ancestry, '/')::BIGINT[])
+          WITH ORDINALITY AS relationships(id, indx) ON TRUE
+          WHERE vms.id BETWEEN #{id_range.first} AND #{id_range.last}
+          ORDER BY vms.id, relationships.indx
+        ) AS ancestor_resources_for_vms
+        JOIN relationships res_rels ON res_rels.id = ancestor_resources_for_vms.rel_id AND res_rels.relationship = 'genealogy'
+        GROUP BY ancestor_resources_for_vms.vm_id
+      ) AS new_ancestors_for_vms
+      WHERE new_ancestors_for_vms.vm_id = vms.id
+      SQL
+    end
+
+    Relationship.where(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => Vm.all.select(:id)).delete_all
+  end
+
+  def down
+    say_with_time("create relationship records from vm ancestry") do
+      vms_with_ancestry = Vm.where.not(:ancestry => nil)
+      vms_with_ancestry.each do |vm|
+        Relationship.create!(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => vm.id, :ancestry => vm.ancestry)
+      end
+
+      remove_column :vms, :ancestry
+    end
+  end
+end

--- a/db/migrate/20200607025146_add_ancestry_to_vm.rb
+++ b/db/migrate/20200607025146_add_ancestry_to_vm.rb
@@ -14,7 +14,7 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
     add_index :vms, :ancestry
 
     say_with_time("set vm ancestry from existing genealogy relationship resource information") do
-      connection.execute(transfer_relationships_to_ancestry(VmOrTemplate, 'VmOrTemplate', 'genealogy'))
+      transfer_relationships_to_ancestry(VmOrTemplate, 'VmOrTemplate', 'genealogy')
     end
 
     Relationship.where(:relationship => 'genealogy', :resource_type => 'VmOrTemplate', :resource_id => VmOrTemplate.all.select(:id)).delete_all
@@ -33,7 +33,7 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
     ancestry_resources = ancestry_resource_ids(relationship, resource_type, dest_model.rails_sequence_range(dest_model.my_region_number))
     ancestry_sources = ancestry_src_ids(ancestry_resources)
     new_ancestors = ancestry_of_src_ids_for_src(ancestry_sources)
-    update_src(new_ancestors, dest_model)
+    connection.execute(update_src(new_ancestors, dest_model))
   end
 
   # src is vm, dest is relationship

--- a/db/migrate/20200607025146_add_ancestry_to_vm.rb
+++ b/db/migrate/20200607025146_add_ancestry_to_vm.rb
@@ -38,7 +38,7 @@ class AddAncestryToVm < ActiveRecord::Migration[5.2]
 
   # src is vm, dest is relationship
   def create_relationships_from_ancestry(src_model, dest_model, resource_type, relationship)
-    children = src_model.select("ancestry::bigint").where("ancestry not like '%/%'")
+    children = src_model.select("ancestry::bigint").where("ancestry NOT LIKE '%/%'")
     rels = src_model.where.not(:ancestry => nil).or(src_model.where(:id => children)).map do |obj|
       dest_model.create!(:relationship  => relationship,
                          :resource_type => resource_type,

--- a/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
+++ b/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
@@ -1,0 +1,186 @@
+require_migration
+
+describe AddAncestryToVm do
+  let(:rel_stub) { migration_stub(:Relationship) }
+  let(:vm_stub) { migration_stub :VmOrTemplate }
+  let(:vm) { vm_stub.create! }
+  let(:default_rel_type) { 'genealogy' }
+
+  migration_context :up do
+    context "single parent/child rel" do
+      it 'updates ancestry' do
+        tree = create_tree(:parent => {:child => :grandchild})
+        parent, child, grandchild = tree[:parent], tree[:child], tree[:grandchild]
+
+        migrate
+
+        expect(child.reload.ancestry).to eq(ancestry_for(parent))
+        expect(grandchild.reload.ancestry).to eq(ancestry_for(child, parent))
+        expect(parent.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(0)
+      end
+    end
+
+    context "complicated tree" do
+      #           a
+      #      b         c
+      #      d         g
+      #    e   f
+      it 'updates ancestry' do
+        tree = create_tree(:a => [{:c => :g}, {:b => {:d => [:e, :f]}}])
+        a, b, c, d, e, f, g = tree[:a], tree[:b], tree[:c], tree[:d], tree[:e], tree[:f], tree[:g]
+
+        migrate
+
+        expect(a.reload.ancestry).to eq(nil)
+        expect(b.reload.ancestry).to eq(ancestry_for(a))
+        expect(c.reload.ancestry).to eq(ancestry_for(a))
+        expect(g.reload.ancestry).to eq(ancestry_for(c, a))
+        expect(e.reload.ancestry).to eq(ancestry_for(d, b, a))
+        expect(f.reload.ancestry).to eq(ancestry_for(d, b, a))
+        expect(rel_stub.count).to eq(0)
+      end
+
+      it 'does not change ems_metadata tree' do
+        tree = create_tree(:a => [{:c => :g}, {:b => {:d => [:e, :f]}}])
+        a, b, c, d, e, f, g = tree[:a], tree[:b], tree[:c], tree[:d], tree[:e], tree[:f], tree[:g]
+        create_non_genealogy_rel(ancestry_for(a), c)
+        create_non_genealogy_rel(ancestry_for(a, c), g)
+        create_non_genealogy_rel(ancestry_for(a), b)
+        create_non_genealogy_rel(ancestry_for(b, a), d)
+        create_non_genealogy_rel(ancestry_for(d, b, a), e)
+        create_non_genealogy_rel(ancestry_for(d, b, a), f)
+        create_non_genealogy_rel(nil, a)
+
+        migrate
+
+        expect(a.reload.ancestry).to eq(nil)
+        expect(b.reload.ancestry).to eq(ancestry_for(a))
+        expect(c.reload.ancestry).to eq(ancestry_for(a))
+        expect(g.reload.ancestry).to eq(ancestry_for(c, a))
+        expect(e.reload.ancestry).to eq(ancestry_for(d, b, a))
+        expect(f.reload.ancestry).to eq(ancestry_for(d, b, a))
+        expect(rel_stub.count).to eq(7)
+        expect(rel_stub.all.pluck(:relationship).uniq).to eq(['ems_metadata'])
+      end
+    end
+
+    context "trivial cases" do
+      it 'vm without rel record has nil ancestry' do
+        migrate
+
+        expect(vm_stub.find(vm.id).ancestry).to eq(nil)
+      end
+
+      it 'vm without ancestry' do
+        tree = create_tree(:a => nil)
+        a = tree[:a]
+
+        migrate
+
+        expect(vm_stub.find(vm.id).ancestry).to eq(nil)
+      end
+    end
+
+    context "with only ems_metadata relationship tree" do
+      let(:default_rel_type) { 'ems_metadata' }
+      it 'does not set vm ancestry' do
+        tree = create_tree(:parent => :child)
+        parent, child = tree[:parent], tree[:child]
+
+        migrate
+
+        expect(child.reload.ancestry).to eq(nil)
+        expect(parent.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(2)
+      end
+    end
+  end
+
+  migration_context :down do
+    context "complicated tree" do
+      #           a
+      #      b         c
+      #      d         g
+      #    e   f
+      it 'updates ancestry' do
+        tree = create_tree(:a => [{:c => :g}, {:b => {:d => [:e, :f]}}])
+        a, b, c, d, e, f, g = tree[:a], tree[:b], tree[:c], tree[:d], tree[:e], tree[:f], tree[:g]
+
+        migrate
+
+        expect(find_rel(a).ancestry).to eq(nil)
+        expect(find_rel(b).ancestry).to eq(ancestry_for(find_rel(a)))
+        expect(find_rel(c).ancestry).to eq(ancestry_for(find_rel(a)))
+        expect(find_rel(g).ancestry).to eq(ancestry_for(find_rel(c), find_rel(a)))
+        expect(find_rel(e).ancestry).to eq(ancestry_for(find_rel(d), find_rel(b), find_rel(a)))
+        expect(find_rel(f).ancestry).to eq(ancestry_for(find_rel(d), find_rel(b), find_rel(a)))
+      end
+
+      it 'does not change ems_metadata tree' do
+        tree = create_tree(:a => [{:c => :g}, {:b => {:d => [:e, :f]}}])
+        a, b, c, d, e, f, g = tree[:a], tree[:b], tree[:c], tree[:d], tree[:e], tree[:f], tree[:g]
+        create_non_genealogy_rel(ancestry_for(a), c)
+        create_non_genealogy_rel(ancestry_for(a, c), g)
+        create_non_genealogy_rel(ancestry_for(a), b)
+        create_non_genealogy_rel(ancestry_for(b, a), d)
+        create_non_genealogy_rel(ancestry_for(d, b, a), e)
+        create_non_genealogy_rel(ancestry_for(d, b, a), f)
+        create_non_genealogy_rel(nil, a)
+
+        migrate
+
+        expect(find_rel(a).ancestry).to eq(nil)
+        expect(find_rel(b).ancestry).to eq(ancestry_for(find_rel(a)))
+        expect(find_rel(c).ancestry).to eq(ancestry_for(find_rel(a)))
+        expect(find_rel(g).ancestry).to eq(ancestry_for(find_rel(c), find_rel(a)))
+        expect(find_rel(e).ancestry).to eq(ancestry_for(find_rel(d), find_rel(b), find_rel(a)))
+        expect(find_rel(f).ancestry).to eq(ancestry_for(find_rel(d), find_rel(b), find_rel(a)))
+        expect(rel_stub.count).to eq(14)
+        expect(rel_stub.all.pluck(:relationship).uniq).to contain_exactly("genealogy", "ems_metadata")
+      end
+    end
+  end
+
+  private
+
+  def ancestry_for(*nodes)
+    nodes.map(&:id).join("/").presence
+  end
+
+  def find_rel(obj)
+    rel_stub.all.detect { |r| r.resource_id == obj.id }
+  end
+
+  def create_tree(tree, relationship = default_rel_type)
+    resources = {}
+    traverse(tree, []) { |_, id| resources.merge!(id => vm_stub.create!) }
+
+    traverse(tree, []) do |parents, id|
+      ancestry = parents.reverse.map { |s| rel_stub.find_by(:resource_id => resources[s].id).id }.compact.join('/') if parents.present?
+      rel_stub.create!(:ancestry => ancestry, :resource_id => resources[id].id, :resource_type => 'VmOrTemplate', :relationship => relationship)
+    end
+
+    resources
+  end
+
+  def traverse(tree, parent, &block)
+    case tree
+    when Symbol || String
+      yield(parent, tree)
+    when Array
+      tree.each { |node| traverse(node, parent, &block) }
+    when Hash
+      tree.each do |key, children|
+        yield(parent, key)
+        traverse(children, parent + [key], &block)
+      end
+    else
+      puts "curious type: #{tree.class.name}"
+    end
+  end
+
+  def create_non_genealogy_rel(ancestors, resource, relationship = 'ems_metadata')
+    rel_stub.create!(:relationship => relationship, :ancestry => ancestors, :resource_type => 'VmOrTemplate', :resource_id => resource.id)
+  end
+end

--- a/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
+++ b/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
@@ -7,7 +7,7 @@ describe AddAncestryToVm do
   let(:default_rel_type) { 'genealogy' }
 
   migration_context :up do
-    context "single parent/child rel" do
+    context "parent/child/grandchild rel" do
       it 'updates ancestry' do
         tree = create_tree(:parent => {:child => :grandchild})
         parent, child, grandchild = tree[:parent], tree[:child], tree[:grandchild]
@@ -22,10 +22,6 @@ describe AddAncestryToVm do
     end
 
     context "complicated tree" do
-      #           a
-      #      b         c
-      #      d         g
-      #    e   f
       it 'updates ancestry' do
         tree = create_tree(:a => [{:c => :g}, {:b => {:d => [:e, :f]}}])
         a, b, c, d, e, f, g = tree[:a], tree[:b], tree[:c], tree[:d], tree[:e], tree[:f], tree[:g]
@@ -144,10 +140,6 @@ describe AddAncestryToVm do
 
   private
 
-  def ancestry_for(*nodes)
-    nodes.map(&:id).join("/").presence
-  end
-
   def find_rel(obj)
     rel_stub.all.detect { |r| r.resource_id == obj.id }
   end
@@ -182,5 +174,9 @@ describe AddAncestryToVm do
 
   def create_non_genealogy_rel(ancestors, resource, relationship = 'ems_metadata')
     rel_stub.create!(:relationship => relationship, :ancestry => ancestors, :resource_type => 'VmOrTemplate', :resource_id => resource.id)
+  end
+
+  def ancestry_for(*nodes)
+    nodes.map(&:id).join("/").presence
   end
 end

--- a/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
+++ b/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
@@ -69,8 +69,7 @@ describe AddAncestryToVm do
       end
 
       it 'vm without ancestry' do
-        tree = create_tree(:a => nil)
-        a = tree[:a]
+        create_tree(:a => nil)
 
         migrate
 
@@ -86,6 +85,7 @@ describe AddAncestryToVm do
 
         migrate
 
+        expect(vm.reload.ancestry).to eq(nil)
         expect(child.reload.ancestry).to eq(nil)
         expect(parent.reload.ancestry).to eq(nil)
         expect(rel_stub.count).to eq(2)

--- a/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
+++ b/spec/migrations/20200607025146_add_ancestry_to_vm_spec.rb
@@ -167,8 +167,9 @@ describe AddAncestryToVm do
         yield(parent, key)
         traverse(children, parent + [key], &block)
       end
+    when nil
     else
-      puts "curious type: #{tree.class.name}"
+      raise StandardError, "curious type: #{tree.class.name}"
     end
   end
 


### PR DESCRIPTION
we are working on converting vm genealogy to use ancestry. In order to do this, we need to use the existing relationship resource information on all vms with genealogy rels of type VmOrTemplate to convert those resource ids into vm ids. 

This PR 1) adds the necessary index and 2) gets the ancestry information from the relationships, splitting on slashes, then maps those back to the vm ancestry records. 

the first commit's the original sql which joined to vms
the second commit removes that join so we no longer have a potential issue with the ordering 


needs https://github.com/ManageIQ/manageiq/pull/20788, tests are green: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/225
