### PR TITLE
Remove VimStrings from MiqProvision#phase_context

### DIFF
--- a/db/migrate/20200629194033_remove_vim_strings_from_miq_provision.rb
+++ b/db/migrate/20200629194033_remove_vim_strings_from_miq_provision.rb
@@ -1,0 +1,38 @@
+class RemoveVimStringsFromMiqProvision < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  include MigrationHelper
+
+  class MiqRequestTask < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Removing VimStrings from MiqRequestTask") do
+      base_relation = MiqRequestTask.in_my_region.where("phase_context LIKE ?", "%ruby/string:VimString%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("phase_context = REGEXP_REPLACE(phase_context, '!ruby/string:VimString', '!ruby/string:String', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Restoring VimStrings in MiqRequestTask") do
+      base_relation = MiqRequestTask.in_my_region.where("phase_context LIKE ?", "%ruby/string:String%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("phase_context = REGEXP_REPLACE(phase_context, '!ruby/string:String', '!ruby/string:VimString', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+end

--- a/spec/migrations/20200629194033_remove_vim_strings_from_miq_provision_spec.rb
+++ b/spec/migrations/20200629194033_remove_vim_strings_from_miq_provision_spec.rb
@@ -1,0 +1,47 @@
+require_migration
+
+describe RemoveVimStringsFromMiqProvision do
+  let(:miq_request_task_stub) { migration_stub(:MiqRequestTask) }
+
+  migration_context :up do
+    it "converts VimStrings to Strings" do
+      phase_context = <<~CONTEXT
+        ---
+        :new_vm_ems_ref: !ruby/string:VimString
+        str: vm-123
+        xsiType: :SOAP::SOAPString
+        vimType: :VirtualMachine
+      CONTEXT
+
+      miq_request_task = miq_request_task_stub.create!(
+        :phase_context => phase_context
+      )
+
+      migrate
+
+      options = YAML.load(miq_request_task.reload.phase_context)
+      expect(options[:new_vm_ems_ref].class).to eq(String)
+    end
+  end
+
+  migration_context :down do
+    it "restores String to VimString" do
+      phase_context = <<~OPTIONS
+        ---
+        :error: !ruby/string:String
+        str: vm-123
+        xsiType: :SOAP::SOAPString
+        vimType: :VirtualMachine
+      OPTIONS
+
+      miq_request_task = miq_request_task_stub.create!(
+        :phase_context => phase_context
+      )
+
+      migrate
+
+      phase_context = miq_request_task.reload.phase_context
+      expect(phase_context).to include("ruby/string:VimString")
+    end
+  end
+end


### PR DESCRIPTION
The MiqProvision phase_context is a serialized hash that in the case of VMware provision requests contains a new_vm_ems_ref and a clone_vm_task_completion_time that both come from the VMware "Task" and thus are VimStrings.

https://github.com/ManageIQ/manageiq-providers-vmware/pull/597