### PR TITLE
Delete any worker records that have a JSON queue_name

### DIFF
--- a/db/migrate/20200717181436_delete_workers_with_json_queue_names.rb
+++ b/db/migrate/20200717181436_delete_workers_with_json_queue_names.rb
@@ -1,0 +1,11 @@
+class DeleteWorkersWithJsonQueueNames < ActiveRecord::Migration[5.2]
+  class MiqWorker < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    MiqWorker.in_my_region.where("queue_name LIKE ?", "\[%\]").delete_all
+  end
+end

--- a/spec/migrations/20200717181436_delete_workers_with_json_queue_names_spec.rb
+++ b/spec/migrations/20200717181436_delete_workers_with_json_queue_names_spec.rb
@@ -1,0 +1,23 @@
+require_migration
+
+describe DeleteWorkersWithJsonQueueNames do
+  let(:miq_worker_stub) { migration_stub(:MiqWorker) }
+
+  migration_context :up do
+    it "deletes workers with a JSON type queue name" do
+      worker = miq_worker_stub.create!(:queue_name => "[\"ems_4\", \"ems_5\", \"ems_6\"]")
+
+      migrate
+
+      expect(miq_worker_stub.find_by(:id => worker.id)).to be_nil
+    end
+
+    it "doesn't touch workers without JSON queue names" do
+      worker = miq_worker_stub.create!(:queue_name => "ems_1")
+
+      migrate
+
+      expect(worker.reload.queue_name).to eq("ems_1")
+    end
+  end
+end


### PR DESCRIPTION
Allowing miq_workers with a compound queue_name is a way to allow a
worker to dequeue for multiple ext_management_systems at once, aka
allowing an Amazon RefreshWorker to refresh the CloudManager and
NetworkManager in the same worker.

This has other side effects however including making it more difficult
to find a worker by an EMS (e.g. when destroying the EMS) and requires
that the base MiqWorker class do `JSON.parse(self[:queue_name]) rescue
self[:queue_name]`

Another option is to have the child managers report their queue_name for
the refresh operation as the parent manager's queue_name.

https://github.com/ManageIQ/manageiq/pull/20345