### PR TITLE
[wip] convert ems folder relationship data to ancestry

### DIFF
--- a/db/migrate/20200727223040_add_ancestry_to_ems_folder.rb
+++ b/db/migrate/20200727223040_add_ancestry_to_ems_folder.rb
@@ -1,0 +1,63 @@
+class AddAncestryToEmsFolder < ActiveRecord::Migration[5.2]
+  include RelationshipAncestryConverterHelper
+  class EmsFolder < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    has_many :all_relationships, :class_name => "AddAncestryToEmsFolder::Relationship", :dependent => :destroy, :as => :resource
+    include ActiveRecord::IdRegions
+  end
+
+  class ResourcePool < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    has_many :all_relationships, :class_name => "AddAncestryToEmsFolder::Relationship", :dependent => :destroy, :as => :resource
+    include ActiveRecord::IdRegions
+  end
+
+  class Relationship < ActiveRecord::Base
+    belongs_to :ems_folder, :class_name => 'AddAncestryToEmsFolder::EmsFolder'
+    belongs_to :resource_pool, :class_name => 'AddAncestryToEmsFolder::ResourcePool'
+  end
+
+  def up
+    add_column :ems_folders, :ancestry, :string
+    add_column :resource_pools, :ancestry, :string
+    add_index :ems_folders, :ancestry
+    add_index :resource_pools, :ancestry
+
+    say_with_time("set ems folder ancestry from existing ems_metadata relationship information") do
+      ancestry_resources = ancestry_resource_ids('ems_metadata', "EmsFolder", EmsFolder.rails_sequence_range(EmsFolder.my_region_number))
+      ancestry_sources = ancestry_src_ids(ancestry_resources)
+      new_ancestors = ancestry_of_src_ids_for_src(ancestry_sources)
+      connection.execute(update_src(new_ancestors, EmsFolder))
+    end
+
+    say_with_time("set resource pool ancestry from existing ems_metadata relationship information") do
+      ancestry_resources = ancestry_resource_ids('ems_metadata', "ResourcePool", ResourcePool.rails_sequence_range(ResourcePool.my_region_number))
+      ancestry_sources = ancestry_src_ids(ancestry_resources)
+      new_ancestors = ancestry_of_src_ids_for_src(ancestry_sources)
+      connection.execute(update_src(new_ancestors, ResourcePool))
+    end
+
+    Relationship.where(:relationship => 'ems_metadata', :resource_type => 'EmsFolder', :resource_id => EmsFolder.all.select(:id)).delete_all
+    Relationship.where(:relationship => 'ems_metadata', :resource_type => 'ResourcePool', :resource_id => ResourcePool.all.select(:id)).delete_all
+  end
+
+  def down
+    say_with_time("create relationship records from resource pool ancestry") do
+      rps_with_ancestry = ResourcePool.where.not(:ancestry => nil)
+      rps_with_ancestry.each do |rp|
+        Relationship.create!(:relationship => 'ems_metadata', :resource_type => 'ResourcePool', :resource_id => rp.id, :ancestry => rp.ancestry)
+      end
+
+      remove_column :resource_pools, :ancestry
+    end
+
+    say_with_time("create relationship records from ems folder ancestry") do
+      folders_with_ancestry = EmsFolder.where.not(:ancestry => nil)
+      folders_with_ancestry.each do |folder|
+        Relationship.create!(:relationship => 'ems_metadata', :resource_type => 'EmsFolder', :resource_id => folder.id, :ancestry => folder.ancestry)
+      end
+
+      remove_column :ems_folders, :ancestry
+    end
+  end
+end

--- a/spec/migrations/20200727223040_add_ancestry_to_ems_folder_spec.rb
+++ b/spec/migrations/20200727223040_add_ancestry_to_ems_folder_spec.rb
@@ -1,0 +1,90 @@
+require_migration
+
+describe AddAncestryToEmsFolder do
+  let(:rel_stub) { migration_stub(:Relationship) }
+  let(:ems_folder_stub) { migration_stub :EmsFolder }
+  let(:resource_pool_stub) { migration_stub :ResourcePool }
+  let(:ems_folder) { ems_folder_stub.create! }
+  let(:rp) { resource_pool_stub.create! }
+
+  migration_context :up do
+    context "complicated tree" do
+      it 'updates ancestry' do
+        #           a
+        #      b         c
+        #      d         g
+        #    e   f
+        a = ems_folder_stub.create!
+        b = resource_pool_stub.create!
+        c = ems_folder_stub.create!
+        d = resource_pool_stub.create!
+        e = resource_pool_stub.create!
+        f = ems_folder_stub.create!
+        g = resource_pool_stub.create!
+
+        a_rel = create_rel(a, 'ems_metadata', 'EmsFolder')
+        b_rel = create_rel(b, 'ems_metadata', 'ResourcePool', ancestry_for(a_rel))
+        c_rel = create_rel(c, 'ems_metadata', 'EmsFolder', ancestry_for(a_rel))
+        d_rel = create_rel(d, 'ems_metadata', 'ResourcePool', ancestry_for(b_rel, a_rel))
+        create_rel(e, 'ems_metadata', 'ResourcePool', ancestry_for(d_rel, b_rel, a_rel))    # e_rel
+        create_rel(f, 'ems_metadata', 'EmsFolder', ancestry_for(d_rel, b_rel, a_rel))       # f_rel
+        create_rel(g, 'ems_metadata', 'ResourcePool', ancestry_for(c_rel, a_rel))           # g_rel
+
+        migrate
+
+        expect(a.reload.ancestry).to eq(nil)
+        expect(b.reload.ancestry).to eq(ancestry_for(a))
+        expect(c.reload.ancestry).to eq(ancestry_for(a))
+        expect(g.reload.ancestry).to eq(ancestry_for(c, a))
+        expect(e.reload.ancestry).to eq(ancestry_for(d, b, a))
+        expect(f.reload.ancestry).to eq(ancestry_for(d, b, a))
+        expect(rel_stub.count).to eq(0)
+      end
+    end
+
+    context "vm without rels" do
+      it 'nil ancestry' do
+        migrate
+
+        expect(resource_pool_stub.find(rp.id).ancestry).to eq(nil)
+        expect(ems_folder_stub.find(ems_folder.id).ancestry).to eq(nil)
+      end
+    end
+  end
+
+  migration_context :down do
+    context "multiple rels" do
+      let!(:rp) { resource_pool_stub.create(:ancestry => '6/5/4') }
+      it 'creates rel and removes ancestry' do
+        migrate
+
+        rel = rel_stub.first
+        expect(rel.relationship).to eq('ems_metadata')
+        expect(rel.ancestry).to eq('6/5/4')
+        expect(rel.resource_type).to eq('ResourcePool')
+        expect(rel.resource_id).to eq(rp.id)
+      end
+    end
+
+    context "single rel" do
+      let!(:folder) { ems_folder_stub.create(:ancestry => '645') }
+      it 'creates rel and removes ancestry' do
+        migrate
+
+        rel = rel_stub.first
+        expect(rel.relationship).to eq('ems_metadata')
+        expect(rel.ancestry).to eq('645')
+        expect(rel.resource_type).to eq('EmsFolder')
+        expect(rel.resource_id).to eq(folder.id)
+      end
+    end
+  end
+
+  def ancestry_for(*nodes)
+    nodes.map(&:id).join("/").presence
+  end
+
+  def create_rel(resource, relationship, resource_type, ancestors = nil)
+    rel_stub.create!(:relationship => relationship, :ancestry => ancestors.nil? ? nil : ancestors, :resource_type => resource_type, :resource_id => resource.id)
+  end
+end


### PR DESCRIPTION
we're working on converting folder ems_metadata rels to use ancestry. In order to do this, we need to use the existing relationship resource information on all folders with ems_metadata rels of type EmsFolder and convert those resource ids into folder ids. 

This PR, just like the equivalent https://github.com/ManageIQ/manageiq-schema/pull/492 , 1) adds the necessary index and 2) gets the ancestry information from the relationships, splitting on slashes, then maps those back to the folder ancestry records. 

## needs concurrent merge with:
core prs:  
https://github.com/ManageIQ/manageiq/pull/20392 
https://github.com/ManageIQ/manageiq/pull/20564


## relies on 
https://github.com/ManageIQ/manageiq-schema/pull/492
(for the shared helper that contains the sql)

#### WIP because requires 492 first and 492 isn't quite there yet