### PR TITLE
Fix `db/schema.rb` generation

### DIFF
--- a/lib/manageiq/schema/command_recorder.rb
+++ b/lib/manageiq/schema/command_recorder.rb
@@ -8,6 +8,14 @@ module ManageIQ
       def drop_trigger(*args)
         record(:drop_trigger, args)
       end
+
+      def create_view(*args)
+        record(:create_view, args)
+      end
+
+      def drop_view(*args)
+        record(:drop_view, args)
+      end
     end
   end
 end

--- a/lib/manageiq/schema/command_recorder.rb
+++ b/lib/manageiq/schema/command_recorder.rb
@@ -1,0 +1,13 @@
+module ManageIQ
+  module Schema
+    module CommandRecorder
+      def add_trigger(*args)
+        record(:add_trigger, args)
+      end
+
+      def drop_trigger(*args)
+        record(:drop_trigger, args)
+      end
+    end
+  end
+end

--- a/lib/manageiq/schema/engine.rb
+++ b/lib/manageiq/schema/engine.rb
@@ -5,9 +5,14 @@ module ManageIQ
 
       ActiveSupport.on_load(:active_record) do
         require_relative 'migrate_with_cleared_schema_cache'
+        require_relative 'schema_statements'
+        require_relative 'command_recorder'
         require_relative 'schema_dumper'
 
         ActiveRecord::Migration.prepend(MigrateWithClearedSchemaCache)
+
+        ActiveRecord::ConnectionAdapters::AbstractAdapter.include(SchemaStatements)
+        ActiveRecord::Migration::CommandRecorder.include(CommandRecorder)
         ActiveRecord::ConnectionAdapters::SchemaDumper.prepend(SchemaDumper)
       end
 

--- a/lib/manageiq/schema/engine.rb
+++ b/lib/manageiq/schema/engine.rb
@@ -5,7 +5,10 @@ module ManageIQ
 
       ActiveSupport.on_load(:active_record) do
         require_relative 'migrate_with_cleared_schema_cache'
+        require_relative 'schema_dumper'
+
         ActiveRecord::Migration.prepend(MigrateWithClearedSchemaCache)
+        ActiveRecord::ConnectionAdapters::SchemaDumper.prepend(SchemaDumper)
       end
 
       initializer :append_migrations do |app|

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -3,6 +3,38 @@ module ManageIQ
     module SchemaDumper
       METRIC_ROLLUP_TABLE_REGEXP = /metrics?_.*\d\d$/.freeze
 
+      def tables(stream)
+        super
+        triggers(stream)
+      end
+
+      def triggers(stream)
+        @connection.triggers.each do |(direction, table, name, body)|
+          # Inverse of the case statement in add_trigger_hook
+          direction_key = direction.downcase.gsub(/\s/, "")
+
+          # Formats the SQL we get from the database to do that following:
+          #
+          # - Removes the "BEGIN" and "END;" stanzas
+          # - Chomps the new lines from the beginning (keeps existing indent)
+          # - Strips whitespace from the end (no need to worry about indent)
+          # - Indents by four spaces
+          #
+          # For formatting, we want to ensure at least some bit of an indent,
+          # regardless of how the SQL string was originally added.
+          #
+          formatted_body = body.gsub(/(BEGIN$|^END;$)/, "")
+                               .reverse.chomp.reverse.rstrip
+                               .indent(4)
+
+          stream.puts "  add_trigger #{direction_key.inspect}, "       \
+                                    "#{table.inspect}, "               \
+                                    "#{name.inspect}, "                \
+                                    "<<-SQL\n#{formatted_body}\n  SQL"
+          stream.puts
+        end
+      end
+
       private
 
       def column_spec_for_primary_key(column)

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -12,7 +12,19 @@ module ManageIQ
 
       def table(table, stream)
         super
+        add_id_column_comment(table, stream)
         track_miq_metric_table_inheritance(table)
+      end
+
+      def add_id_column_comment(table, stream)
+        pk      = @connection.primary_key(table)
+        pkcol   = @connection.columns(table).detect { |c| c.name == pk }
+        comment = pkcol.comment
+
+        return unless comment
+
+        stream.puts "  change_column_comment #{remove_prefix_and_suffix(table).inspect}, #{pk.inspect}, #{comment.inspect}"
+        stream.puts
       end
 
       # Must be done after all of the table definitions since `metrics_01` is

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -1,12 +1,40 @@
 module ManageIQ
   module Schema
     module SchemaDumper
-      METRIC_ROLLUP_TABLE_REGEXP = /metrics?_.*\d\d$/.freeze
+      METRIC_ROLLUP_TABLE_REGEXP = /(?<METRIC_TYPE>metrics?_?.*)_(?<CHILD_TABLE_NUM>\d\d)$/.freeze
 
       def tables(stream)
         super
+        miq_metric_table_contraints(stream)
         miq_metric_views(stream)
         triggers(stream)
+      end
+
+      def table(table, stream)
+        super
+        track_miq_metric_table_inheritance(table)
+      end
+
+      # Must be done after all of the table definitions since `metrics_01` is
+      # dumpped prior to `metrics_base`, etc.
+      #
+      def miq_metric_table_contraints(stream)
+        inherited_metrics_tables.each do |(table, inherit_from)|
+          match             = table.match(METRIC_ROLLUP_TABLE_REGEXP)
+          child_table       = remove_prefix_and_suffix(table).inspect
+          primary_condition = if inherit_from.include?("rollup")
+                                "capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?"
+                              else
+                                "capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?"
+                              end
+          conditions        = [primary_condition, "realtime", match[:CHILD_TABLE_NUM]]
+
+          stream.puts "  add_miq_metric_table_inheritance #{child_table}, " \
+                          "#{inherit_from.inspect}, "                       \
+                          ":conditions => #{conditions.inspect}"
+        end
+
+        stream.puts
       end
 
       def miq_metric_views(stream)
@@ -44,6 +72,26 @@ module ManageIQ
       end
 
       private
+
+      def track_miq_metric_table_inheritance(table)
+        return unless table.match?(METRIC_ROLLUP_TABLE_REGEXP)
+
+        inherit_from              = determine_table_parent(table)
+        inherited_metrics_tables << [table, inherit_from]
+      end
+
+      def inherited_metrics_tables
+        @inherited_metrics_tables ||= []
+      end
+
+      def determine_table_parent(table_name)
+        @connection.execute(<<-SQL).first["parent_table"]
+          SELECT pg_class.relname AS parent_table
+          FROM   pg_catalog.pg_inherits
+          JOIN pg_class ON pg_class.oid = pg_inherits.inhparent
+          WHERE inhrelid = '#{table_name}'::regclass
+        SQL
+      end
 
       def column_spec_for_primary_key(column)
         result = super

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -1,0 +1,15 @@
+module ManageIQ
+  module Schema
+    module SchemaDumper
+      METRIC_ROLLUP_TABLE_REGEXP = /metrics?_.*\d\d$/.freeze
+
+      private
+
+      def column_spec_for_primary_key(column)
+        result = super
+        result.delete(:default) if column.table_name.match?(METRIC_ROLLUP_TABLE_REGEXP)
+        result
+      end
+    end
+  end
+end

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -5,7 +5,15 @@ module ManageIQ
 
       def tables(stream)
         super
+        miq_metric_views(stream)
         triggers(stream)
+      end
+
+      def miq_metric_views(stream)
+        @connection.views.each do |view|
+          stream.puts "  create_miq_metric_view #{view["name"].inspect}"
+          stream.puts
+        end
       end
 
       def triggers(stream)

--- a/lib/manageiq/schema/schema_statements.rb
+++ b/lib/manageiq/schema/schema_statements.rb
@@ -1,0 +1,61 @@
+module ManageIQ
+  module Schema
+    module SchemaStatements
+      def add_trigger(direction, table, name, body)
+        add_trigger_function(name, body)
+        add_trigger_hook(direction, name, table, name)
+      end
+
+      def drop_trigger(table, name)
+        quoted_name  = quote_column_name(name)
+        quoted_table = quote_table_name(table)
+
+        execute("DROP TRIGGER IF EXISTS #{quoted_name} ON #{quoted_table};", 'Drop trigger')
+        execute("DROP FUNCTION IF EXISTS #{quoted_name}();", 'Drop trigger function')
+      end
+
+      # Fetch the direction, table, name, and body for all of the MIQ INSERT
+      # database triggers
+      #
+      def triggers
+        select_rows(<<~TRIGGER_SQL.prepend("\n"))
+          SELECT information_schema.triggers.action_timing AS direction,
+                 pg_class.relname                          AS table,
+                 pg_trigger.tgname                         AS name,
+                 pg_proc.prosrc                            AS body
+          FROM pg_trigger
+          JOIN pg_class                    ON pg_trigger.tgrelid = pg_class.oid
+          JOIN pg_proc                     ON pg_trigger.tgname  = pg_proc.proname
+          JOIN information_schema.triggers ON pg_trigger.tgname  = information_schema.triggers.trigger_name
+        TRIGGER_SQL
+      end
+
+      private
+
+      def add_trigger_function(name, body)
+        execute(<<-EOSQL, 'Create trigger function')
+          CREATE OR REPLACE FUNCTION #{quote_table_name(name)}()
+          RETURNS TRIGGER AS #{quote("BEGIN\n#{body}\nEND;\n")}
+          LANGUAGE plpgsql;
+        EOSQL
+      end
+
+      def add_trigger_hook(direction, name, table, function)
+        safe_direction = case(direction.downcase)
+                         when 'before'
+                           'BEFORE'
+                         when 'after'
+                           'AFTER'
+                         when 'insteadof'
+                           'INSTEAD OF'
+                         end
+
+        execute(<<-EOSQL, 'Create trigger')
+          CREATE TRIGGER #{quote_column_name(name)}
+          #{safe_direction} INSERT ON #{quote_table_name(table)}
+          FOR EACH ROW EXECUTE PROCEDURE #{quote_table_name(function)}();
+        EOSQL
+      end
+    end
+  end
+end

--- a/lib/migration_helper.rb
+++ b/lib/migration_helper.rb
@@ -54,51 +54,10 @@ module MigrationHelper
   # Triggers
   #
 
+  # Keeping this helper to suppress the SQL body from the `say_with_time` output
   def add_trigger(direction, table, name, body)
     say_with_time("add_trigger(:#{direction}, :#{table}, :#{name})") do
-      add_trigger_function(name, body)
-      add_trigger_hook(direction, name, table, name)
-    end
-  end
-
-  def add_trigger_function(name, body)
-    quoted_name = connection.quote_table_name(name)
-    quoted_body = connection.quote("BEGIN\n#{body}\nEND;\n")
-
-    connection.execute <<-EOSQL, 'Create trigger function'
-      CREATE OR REPLACE FUNCTION #{quoted_name}()
-      RETURNS TRIGGER AS #{quoted_body}
-      LANGUAGE plpgsql;
-    EOSQL
-  end
-
-  def add_trigger_hook(direction, name, table, function)
-    quoted_name = connection.quote_column_name(name)
-    quoted_table = connection.quote_table_name(table)
-    quoted_function = connection.quote_table_name(function)
-    safe_direction = case(direction.downcase)
-                     when 'before'
-                       'BEFORE'
-                     when 'after'
-                       'AFTER'
-                     when 'insteadof'
-                       'INSTEAD OF'
-                     end
-
-    connection.execute <<-EOSQL, 'Create trigger'
-      CREATE TRIGGER #{quoted_name}
-      #{safe_direction} INSERT ON #{quoted_table}
-      FOR EACH ROW EXECUTE PROCEDURE #{quoted_function}();
-    EOSQL
-  end
-
-  def drop_trigger(table, name)
-    quoted_name = connection.quote_column_name(name)
-    quoted_table = connection.quote_table_name(table)
-
-    say_with_time("drop_trigger(:#{table}, :#{name})") do
-      connection.execute("DROP TRIGGER IF EXISTS #{quoted_name} ON #{quoted_table};", 'Drop trigger')
-      connection.execute("DROP FUNCTION IF EXISTS #{quoted_name}();", 'Drop trigger function')
+      connection.add_trigger(direction, table, name, body)
     end
   end
 

--- a/lib/migration_helper.rb
+++ b/lib/migration_helper.rb
@@ -64,6 +64,10 @@ module MigrationHelper
   #
   # Table inheritance
   #
+  # (note:  Can't remove because it is used in CollapsedInitialMigration and
+  # this method was renamed in MiqSchemaStatements.  Renaming might have been a
+  # poor choice...)
+  #
 
   def add_table_inheritance(table, inherit_from, options = {})
     quoted_table = connection.quote_table_name(table)


### PR DESCRIPTION
This is a first pass at the "Fix `rake db:schema:load`" option for https://github.com/ManageIQ/manageiq-schema/issues/502

What this does
--------------

The first part of the changes in this PR are a refactoring that takes much of what is coded into individual migrations and the `lib/migration_helper.rb`, and applies them to the `ActiveRecord::Base.connection`.

The other part of the changes is creating introspection for the `db/schema.rb` generation via the MiqSchemaDumper, which is a collection of additions for everything that was refactored into the `.connection` to generate the `schema.rb` with our custom functions/contrainst/views/etc.

The functions that were created on (moved to) the `.connection`:

- `.add_trigger`
- `.create_miq_metric_view`
- `.add_miq_metric_table_inheritance`

(and the `drop_*` equivalent functions for each of those)

The in addtion, there were a few introspection methods added there as well:

- `.connection.triggers`
- `.connection.views`

Which can be used to query the database to determine what exist for the `triggers` and `views`.

In addtion there is a additional introspection method in the `MiqSchemaDumper` called `determine_table_parent`, which is used to determine the table parent for a given metrics partition table.


Things for Reviewers to consider
---------------------------------

* Do we just want to leverage gems for things (like `scenic` for VIEWS) instead, or are the `MIQ` specifics enough to warrant me rolling it ourselves?
* Could some of my introspection queries be done better in a more "PostgreSQL DB Admin Approved" fashion?
* I used two different naming conventions for methods (with/without the miq_ prefix). Should we standardize?
* Are things like the `METRIC_ROLLUP_TABLE_REGEXP` too specific and do we want to make them more generic, or is it fine to specifically target tables for these additions to be more "surgical" about these changes?



Testing
-------

I have been testing by just running the following two commands:

```console
$ RAILS_ENV=development rake db:environment:set evm:db:destroy db:migrate > /dev/null
$ RAILS_ENV=development rake db:environment:set evm:db:destroy db:schema:load db:seed > /dev/null
```

And also inspected the contents of the `db/schema.rb`, which should now include entries for the above functions.  It should look something like this at the bottom:

```ruby
  add_miq_metric_table_inheritance "metric_rollups_01", "metric_rollups_base", :conditions => ["capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?", "realtime", "01"]
  add_miq_metric_table_inheritance "metric_rollups_02", "metric_rollups_base", :conditions => ["capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?", "realtime", "02"]
  add_miq_metric_table_inheritance "metric_rollups_03", "metric_rollups_base", :conditions => ["capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?", "realtime", "03"]
  # ...
  add_miq_metric_table_inheritance "metrics_00", "metrics_base", :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", "00"]
  add_miq_metric_table_inheritance "metrics_01", "metrics_base", :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", "01"]
  add_miq_metric_table_inheritance "metrics_02", "metrics_base", :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", "02"]
  add_miq_metric_table_inheritance "metrics_03", "metrics_base", :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", "03"]
  add_miq_metric_table_inheritance "metrics_04", "metrics_base", :conditions => ["capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?", "realtime", "04"]
  # ...

  create_miq_metric_view "metrics"

  create_miq_metric_view "metric_rollups"

  add_trigger "insteadof", "metrics", "metrics_partition", <<-SQL
          CASE EXTRACT(HOUR FROM NEW.timestamp)
            WHEN 0 THEN
              INSERT INTO metrics_00 VALUES (NEW.*);
           ...
  SQL

  add_trigger "insteadof", "metric_rollups", "metric_rollups_partition", <<-SQL
          CASE EXTRACT(MONTH FROM NEW.timestamp)
            WHEN 1 THEN
              INSERT INTO metric_rollups_01 VALUES (NEW.*);
          ....
  SQL
```