### PR TITLE
Added schema changes for Autosde provider

### DIFF
--- a/db/migrate/20200519141015_create_storage_resources.rb
+++ b/db/migrate/20200519141015_create_storage_resources.rb
@@ -1,0 +1,14 @@
+class CreateStorageResources < ActiveRecord::Migration[5.2]
+  def change
+    create_table :storage_resources do |t|
+      t.string :name
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.string :ems_ref
+      t.string :uuid
+      t.bigint :logical_free
+      t.bigint :logical_total
+      t.references :physical_storage, :type => :bigint, :index => true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200519141015_create_storage_resources.rb
+++ b/db/migrate/20200519141015_create_storage_resources.rb
@@ -4,10 +4,12 @@ class CreateStorageResources < ActiveRecord::Migration[5.2]
       t.string :name
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
       t.string :ems_ref
-      t.string :uuid
+      t.string :uid_ems
       t.bigint :logical_free
       t.bigint :logical_total
       t.references :physical_storage, :type => :bigint, :index => true
+      t.string :type
+
       t.timestamps
     end
   end

--- a/db/migrate/20200521150213_create_storage_services.rb
+++ b/db/migrate/20200521150213_create_storage_services.rb
@@ -1,0 +1,14 @@
+class CreateStorageServices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :storage_services do |t|
+      t.string :name
+      t.string :description
+      t.string :uuid
+      t.bigint :version
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.string :ems_ref
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200521150213_create_storage_services.rb
+++ b/db/migrate/20200521150213_create_storage_services.rb
@@ -3,10 +3,11 @@ class CreateStorageServices < ActiveRecord::Migration[5.2]
     create_table :storage_services do |t|
       t.string :name
       t.string :description
-      t.string :uuid
       t.bigint :version
       t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
       t.string :ems_ref
+      t.string :uid_ems
+      t.string :type
 
       t.timestamps
     end

--- a/db/migrate/20200524074928_create_storage_service_resource_attachments.rb
+++ b/db/migrate/20200524074928_create_storage_service_resource_attachments.rb
@@ -1,0 +1,12 @@
+class CreateStorageServiceResourceAttachments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :storage_service_resource_attachments do |t|
+      t.references :storage_service, :type => :bigint, :index => {:name => "index_storage_svc_resource_attachments_on_storage_service_id"}
+      t.references :storage_resource, :type => :bigint, :index => {:name => "index_storage_svc_resource_attachments_on_storage_resource_id"}
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.string :ems_ref
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200608163713_create_physical_storage_families.rb
+++ b/db/migrate/20200608163713_create_physical_storage_families.rb
@@ -1,0 +1,11 @@
+class CreatePhysicalStorageFamilies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :physical_storage_families do |t|
+      t.string :name
+      t.string :version
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.string :ems_ref
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200806112501_expand_cloud_volume.rb
+++ b/db/migrate/20200806112501_expand_cloud_volume.rb
@@ -1,0 +1,6 @@
+class ExpandCloudVolume < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :cloud_volumes, :storage_resource, :type => :bigint, :index => true
+    add_reference :cloud_volumes, :storage_service, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20200922180455_add_family_to_physical_storages.rb
+++ b/db/migrate/20200922180455_add_family_to_physical_storages.rb
@@ -1,0 +1,5 @@
+class AddFamilyToPhysicalStorages < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :physical_storages, :physical_storage_family, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20200922180455_add_uuid_and_family_to_physical_storages.rb
+++ b/db/migrate/20200922180455_add_uuid_and_family_to_physical_storages.rb
@@ -1,0 +1,6 @@
+class AddUuidAndFamilyToPhysicalStorages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :physical_storages, :uuid, :string
+    add_reference :physical_storages, :physical_storage_family, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20200922180455_add_uuid_and_family_to_physical_storages.rb
+++ b/db/migrate/20200922180455_add_uuid_and_family_to_physical_storages.rb
@@ -1,6 +1,0 @@
-class AddUuidAndFamilyToPhysicalStorages < ActiveRecord::Migration[5.2]
-  def change
-    add_column :physical_storages, :uuid, :string
-    add_reference :physical_storages, :physical_storage_family, :type => :bigint, :index => true
-  end
-end


### PR DESCRIPTION
# Added StorageResource and related tables

New tables

### Storage Resource (Pool)
Represents an entity that can provide block volumes. Most often a pool, a pool-replication-group, or an io-group.
Holds general information about the pool such as name, free space, etc..

Example
```ruby
<StorageResource id: 1
  name: "9.151.159.178:AutoSDE_Pool_CI"
  ems_id: 2
  ems_ref: "fad8a091-38c5-4320-a575-099e3125a9bd"
  uuid: "fad8a091-38c5-4320-a575-099e3125a9bd"
  logical_free: 1095216660480
  logical_total: 1099511627776
  pool_name: "AutoSDE_Pool_CI"
  storage_system_id: 1
  created_at: "2020-09-09 12:47:43"
  updated_at: "2020-09-09 12:47:43">
```


### Physical Storage Family
Represents a type system which the provider supports.
EMSs that want to allow users to attach a storage system to MIQ will need to build a list of storage systems supported by their provider. 
The storage_system_families are supposed to be scanned from the provider. It's up to the EMS and the provider to determine what to put in these records based on how they want to differentiate different storage systems.
So one provider could have a list like ["SVC", "V7000", "Netapp"], and that could be enough for them. So they would have 3 StorageSystemFamily DB records.
Another provider could need to use advanced functions of SVC which would require to differentiate between different SVC versions, their storage_system_families could look like ["svc_version_lte_x", "svc_version_gt_x", "V8K"]. So they would have 4 StorageSystemFamily DB records. 
Note that the lists don't adhere to a unified naming convention because they use conventions from the EMS's respective providers.

Storage families are used when creating a PhysicalStorage. The user needs to pick one from a drop-down, since the provider needs to know what kind of a system it is in order to connect to it.
In the future we want to use them to determine what features the system supports, and perhaps add uniformity across EMSs.

Example
```ruby
<PhysicalStorageFamily id: 1
  name: "svc"
  version: "1.1"
  ems_id: 2
  ems_ref: "06fd344c-64a1-4b31-a502-a7c5aa01b8ab"
  created_at: "2020-09-09 12:47:43"
  updated_at: "2020-09-09 12:47:43">
```

### Storage Service
This is an abstraction layer for volume creation and allocation.

A storage service represents a type of volume that end-user will consume.
Each storage service is connected to a set of suitable storage resources which fulfill the service criteria.

Storage services will be displayed in the self-service catalog for users requesting new volumes.
Provider may adjust volumes based on changes to their service.

Different storage services can be defined for different user needs.
For example DB storage service. Real-time storage service, etc..
A volume is then created on one of the pools attached to the service.

Example
```ruby
<StorageService id: 1
  name: "9.151.159.178:AutoSDE_Pool_CI"
  description: "auto_created_service"
  uuid: "6c14b03e-572e-4528-a19f-f92e6d91df12"
  ems_id: 2
  ems_ref: "6c14b03e-572e-4528-a19f-f92e6d91df12"
  created_at: "2020-09-09 12:47:43"
  updated_at: "2020-09-09 12:47:43">
```

### Service Resource Attachment
This is the M2M table that attaches storage-services to storage-resources.

### Rough Diagram

![image](https://user-images.githubusercontent.com/68283004/93761721-f64ddf00-fc16-11ea-9331-ddf883a5a7b2.png)
