### PR TITLE
Fix RSpec warning on raise_error

### DIFF
--- a/spec/migrations/20200409175736_add_failed_login_attempts_to_users_spec.rb
+++ b/spec/migrations/20200409175736_add_failed_login_attempts_to_users_spec.rb
@@ -6,7 +6,7 @@ describe AddFailedLoginAttemptsToUsers do
 
   migration_context :up do
     it 'creates a new field which defaults to 0' do
-      expect { user.failed_login_attempts }.to raise_error
+      expect(user).to_not respond_to(:failed_login_attempts)
 
       migrate
       user.reload


### PR DESCRIPTION
"expect to raise_error" should not be used without a parameter as any
error, including bugs will end up passing the test. This particular
instance can just be checked with a normal respond_to, so we use that
instead.