### PR TITLE
Data migration for control explorer split

### DIFF
--- a/db/migrate/20200910163614_adjust_control_explorer_features.rb
+++ b/db/migrate/20200910163614_adjust_control_explorer_features.rb
@@ -1,0 +1,26 @@
+class AdjustControlExplorerFeatures < ActiveRecord::Migration[5.2]
+  class MiqProductFeature < ActiveRecord::Base; end
+
+  FEATURE_MAPPING = {
+    'control_explorer'  => 'control'
+  }.freeze
+
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjusting control_explorer features for the split explorers' do
+      # Direct renaming of features
+      FEATURE_MAPPING.each do |from, to|
+        MiqProductFeature.find_or_create_by!(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Adjusting split explorer features back to control explorer' do
+      FEATURE_MAPPING.each do |to, from|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+end

--- a/db/migrate/20200910163718_adjust_control_explorer_startpage_entries.rb
+++ b/db/migrate/20200910163718_adjust_control_explorer_startpage_entries.rb
@@ -1,0 +1,25 @@
+class AdjustControlExplorerStartpageEntries < ActiveRecord::Migration[5.2]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating starting page for users who had control explorer set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'control/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_policy_set/explorer'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Updating starting page for users who had miq_policy_set back to unified control explorer' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_policy_set/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'control/explorer'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20200910163614_adjust_control_explorer_features_spec.rb
+++ b/spec/migrations/20200910163614_adjust_control_explorer_features_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe AdjustControlExplorerFeatures do
+  let(:user_role_id) { anonymous_class_with_id_regions.id_in_region(1, anonymous_class_with_id_regions.my_region_number) }
+  let(:feature_stub) { migration_stub :MiqProductFeature }
+
+  migration_context :up do
+    describe 'product features update' do
+      it 'updates the control feature' do
+        AdjustControlExplorerFeatures::FEATURE_MAPPING.keys.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+        end
+
+        migrate
+
+        feature = feature_stub.find_by(:identifier => 'control')
+        expect(feature.identifier).to eq('control')
+      end
+
+      it 'renames the features' do
+        view_feature = feature_stub.create!(:identifier => 'control_explorer')
+
+        migrate
+
+        expect(view_feature.reload.identifier).to eq('control')
+      end
+    end
+  end
+
+  migration_context :down do
+    let!(:view_feature) { feature_stub.create!(:identifier => 'control') }
+
+    describe 'product features update' do
+      it 'sets the control feature back to unified control_explorer feature' do
+        migrate
+
+        expect(view_feature.reload.identifier).to eq('control_explorer')
+      end
+    end
+  end
+end

--- a/spec/migrations/20200910163718_adjust_control_explorer_startpage_entries_spec.rb
+++ b/spec/migrations/20200910163718_adjust_control_explorer_startpage_entries_spec.rb
@@ -1,0 +1,47 @@
+require_migration
+
+describe AdjustControlExplorerStartpageEntries do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page replace' do
+      it 'replaces user starting page if control/explorer' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'control/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_policy_set/explorer')
+      end
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'starting page replace' do
+      it "replaces user starting page to control/explorer if miq_policy_set/explorer" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_policy_set/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('control/explorer')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Migration changes are to go with changes in https://github.com/ManageIQ/manageiq/pull/20438.
- startpage url changed to `miq_policy_set`(Policy Profiles explorer) as start page instead of `control explorer`(unified version of Control explorer)
- parent feature identifier was changed from `control_explorer` to `control`, we do not need to worry about other child features in migration because those were hidden features previously. If a user could access control explorer they were allowed to perform all actions in that area. Now to be consistent with other screens, made all features visible so RBAC can be applied on the actions individually.

https://github.com/ManageIQ/manageiq-ui-classic/issues/6996

This PR goes with changes in core [PR](https://github.com/ManageIQ/manageiq/pull/20438)
UI changes in [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7259)