### PR TITLE
[wip] convert resource pool relationship data to ancestry

### DIFF
--- a/db/migrate/20200912032913_add_ancestry_to_resource_pool.rb
+++ b/db/migrate/20200912032913_add_ancestry_to_resource_pool.rb
@@ -1,0 +1,61 @@
+class AddAncestryToResourcePool < ActiveRecord::Migration[5.2]
+  class ResourcePool < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+    has_many :all_relationships, :class_name => "AddAncestryToResourcePool::Relationship", :dependent => :destroy, :as => :resource
+    include ActiveRecord::IdRegions
+  end
+
+  class Relationship < ActiveRecord::Base
+    belongs_to :resource_pool, :class_name => 'AddAncestryToResourcePool::ResourcePool', :foreign_key => :resource_pool_id
+  end
+
+  def up
+    add_column :resource_pools, :ancestry, :string
+    add_index :resource_pools, :ancestry
+
+    id_range = ResourcePool.rails_sequence_range(ResourcePool.my_region_number)
+
+    say_with_time("set resource pool ancestry from existing genealogy relationship resource information") do
+      connection.execute(<<-SQL)
+      UPDATE resource_pools
+      SET ancestry = new_ancestry
+      FROM (
+        -- join to resources to convert rel.id to resource_pool.id (it is in resource_id column)
+        -- ARRAY_AGG takes multiple rows and converts to an array
+        SELECT ancestor_resources_for_resource_pools.resource_pool_id AS resource_pool_id,
+        ARRAY_TO_STRING(ARRAY_AGG(res_rels.resource_id)::VARCHAR[], '/') AS new_ancestry
+        FROM (
+          -- get resource pool and associated ancestor rel_id
+          -- unnest converts an array to multiple rows, 1 ancestor per row
+          -- with ordinality, and order by relationships.indx make sure ancestors stay in the same order
+          SELECT resource_pools.id AS resource_pool_id, relationships.id AS rel_id
+          FROM resource_pools
+          JOIN relationships a_rels ON a_rels.resource_id = resource_pools.id
+          AND a_rels.relationship = 'genealogy'
+          AND a_rels.resource_type = 'ResourcePool'
+          LEFT JOIN LATERAL UNNEST(STRING_TO_ARRAY(a_rels.ancestry, '/')::BIGINT[])
+          WITH ORDINALITY AS relationships(id, indx) ON TRUE
+          WHERE resource_pools.id BETWEEN #{id_range.first} AND #{id_range.last}
+          ORDER BY resource_pools.id, relationships.indx
+        ) AS ancestor_resources_for_resource_pools
+        JOIN relationships res_rels ON res_rels.id = ancestor_resources_for_resource_pools.rel_id AND res_rels.relationship = 'genealogy'
+        GROUP BY ancestor_resources_for_resource_pools.resource_pool_id
+      ) AS new_ancestors_for_resource_pools
+      WHERE new_ancestors_for_resource_pools.resource_pool_id = resource_pools.id
+      SQL
+    end
+
+    Relationship.where(:relationship => 'genealogy', :resource_type => 'ResourcePool', :resource_id => ResourcePool.all.select(:id)).delete_all
+  end
+
+  def down
+    say_with_time("create relationship records from resource pool ancestry") do
+      rps_with_ancestry = ResourcePool.where.not(:ancestry => nil)
+      rps_with_ancestry.each do |rp|
+        Relationship.create!(:relationship => 'genealogy', :resource_type => 'ResourcePool', :resource_id => rp.id, :ancestry => rp.ancestry)
+      end
+
+      remove_column :resource_pools, :ancestry
+    end
+  end
+end

--- a/spec/migrations/20200912032913_add_ancestry_to_resource_pool_spec.rb
+++ b/spec/migrations/20200912032913_add_ancestry_to_resource_pool_spec.rb
@@ -1,0 +1,181 @@
+require_migration
+
+describe AddAncestryToResourcePool do
+  let(:rel_stub) { migration_stub(:Relationship) }
+  let(:resource_pool_stub) { migration_stub :ResourcePool }
+  let(:resource_pool) { resource_pool_stub.create! }
+  let(:resource_pool2) { resource_pool_stub.create! }
+  let(:resource_pool3) { resource_pool_stub.create! }
+  let(:resource_pool4) { resource_pool_stub.create! }
+  let(:resource_pool5) { resource_pool_stub.create! }
+  let(:resource_pool6) { resource_pool_stub.create! }
+  let(:resource_pool7) { resource_pool_stub.create! }
+  let(:resource_pool8) { resource_pool_stub.create! }
+  let(:root) { resource_pool_stub.create! }
+
+  migration_context :up do
+    context "single parent/child rel" do
+      it 'updates ancestry' do
+        parent_rel = rel_stub.create!(:relationship => 'genealogy', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => parent_rel.id, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+
+        migrate
+
+        expect(resource_pool.reload.ancestry).to eq(root.id.to_s)
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(0)
+      end
+    end
+
+    context "slightly more complicated tree" do
+      it 'updates ancestry' do
+        parent_rel = rel_stub.create!(:relationship => 'genealogy', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        child_rel = rel_stub.create!(:relationship => 'genealogy', :ancestry => parent_rel.id, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => child_rel.id.to_s + '/' + parent_rel.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool2.id)
+
+        migrate
+
+        expect(resource_pool.reload.ancestry).to eq(root.id.to_s)
+        expect(resource_pool2.reload.ancestry).to eq("#{resource_pool.id}/#{root.id}")
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(0)
+      end
+    end
+
+    context "complicated tree" do
+      #           a
+      #      b         c
+      #      d         g
+      #    e   f
+      it 'updates ancestry' do
+        rel_a = rel_stub.create!(:relationship => 'genealogy', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        rel_c = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_a.id, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_c.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool2.id)
+        rel_b = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool3.id)
+        rel_d = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool4.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool5.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool6.id)
+
+        migrate
+
+        expect(resource_pool5.reload.ancestry).to eq("#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(resource_pool6.reload.ancestry).to eq("#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(resource_pool3.reload.ancestry).to eq(root.id.to_s)
+        expect(resource_pool.reload.ancestry).to eq(root.id.to_s)
+        expect(resource_pool2.reload.ancestry).to eq("#{resource_pool.id}/#{root.id}")
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(0)
+      end
+    end
+
+    context "order is preserved" do
+      #      rel resource_pool
+      #      a   root
+      #      b   3
+      #      d   4
+      #      e   6
+      #      c   resource_pool
+      #      f   2
+      #      g   7
+      #      h   8
+      it 'updates ancestry' do
+        rel_a = rel_stub.create!(:relationship => 'genealogy', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        rel_b = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool3.id)
+        rel_d = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool4.id)
+        rel_e = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool6.id)
+        rel_c = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_e.id.to_s + '/' + rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+        rel_f = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_c.id.to_s + '/' + rel_e.id.to_s + '/' + rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool2.id)
+        rel_g = rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_f.id.to_s + '/' + rel_c.id.to_s + '/' + rel_e.id.to_s + '/' + rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool7.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => rel_g.id.to_s + '/' + rel_f.id.to_s + '/' + rel_c.id.to_s + '/' + rel_e.id.to_s + '/' + rel_d.id.to_s + '/' + rel_b.id.to_s + '/' + rel_a.id.to_s, :resource_type => 'ResourcePool', :resource_id => resource_pool8.id)
+
+        migrate
+
+        expect(resource_pool2.reload.ancestry).to eq("#{resource_pool.id}/#{resource_pool6.id}/#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(resource_pool6.reload.ancestry).to eq("#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(resource_pool3.reload.ancestry).to eq(root.id.to_s)
+        expect(resource_pool.reload.ancestry).to eq("#{resource_pool6.id}/#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(resource_pool7.reload.ancestry).to eq("#{resource_pool2.id}/#{resource_pool.id}/#{resource_pool6.id}/#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(resource_pool8.reload.ancestry).to eq("#{resource_pool7.id}/#{resource_pool2.id}/#{resource_pool.id}/#{resource_pool6.id}/#{resource_pool4.id}/#{resource_pool3.id}/#{root.id}")
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(0)
+      end
+    end
+
+    context "resource_pool without rels" do
+      it 'nil ancestry' do
+        migrate
+
+        expect(resource_pool_stub.find(resource_pool.id).ancestry).to eq(nil)
+      end
+    end
+
+    context "with only ems_metadata relationship tree" do
+      it 'sets nothing' do
+        parent_rel = rel_stub.create!(:relationship => 'ems_metadata', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        rel_stub.create!(:relationship => 'ems_metadata', :ancestry => parent_rel.id, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+
+        migrate
+
+        expect(resource_pool.reload.ancestry).to eq(nil)
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(2)
+      end
+    end
+
+    context "with rel type that isn't resource_pool_or_template" do
+      it 'sets nothing' do
+        parent_rel = rel_stub.create!(:relationship => 'ems_metadata', :ancestry => nil, :resource_type => 'Host', :resource_id => root.id)
+        rel_stub.create!(:relationship => 'ems_metadata', :ancestry => parent_rel.id, :resource_type => 'Host', :resource_id => resource_pool.id)
+
+        migrate
+
+        expect(resource_pool.reload.ancestry).to eq(nil)
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(2)
+      end
+    end
+
+    context "with both genealogy and ems_metadata rels" do
+      it 'only sets ancestry from genealogy rels' do
+        invalid_parent_rel = rel_stub.create!(:relationship => 'ems_metadata', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        rel_stub.create!(:relationship => 'ems_metadata', :ancestry => invalid_parent_rel.id, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+        parent_rel = rel_stub.create!(:relationship => 'genealogy', :ancestry => nil, :resource_type => 'ResourcePool', :resource_id => root.id)
+        rel_stub.create!(:relationship => 'genealogy', :ancestry => parent_rel.id, :resource_type => 'ResourcePool', :resource_id => resource_pool.id)
+
+        migrate
+
+        expect(resource_pool.reload.ancestry).to eq(root.id.to_s)
+        expect(root.reload.ancestry).to eq(nil)
+        expect(rel_stub.count).to eq(2)
+      end
+    end
+  end
+
+  migration_context :down do
+    context "multiple rels" do
+      let!(:resource_pool) { resource_pool_stub.create!(:ancestry => '6/5/4') }
+      it 'creates rel and removes ancestry' do
+        migrate
+
+        rel = rel_stub.first
+        expect(rel.relationship).to eq('genealogy')
+        expect(rel.ancestry).to eq('6/5/4')
+        expect(rel.resource_type).to eq('ResourcePool')
+        expect(rel.resource_id).to eq(resource_pool.id)
+      end
+    end
+
+    context "single rel" do
+      let!(:resource_pool) { resource_pool_stub.create!(:ancestry => '645') }
+      it 'creates rel and removes ancestry' do
+        migrate
+
+        rel = rel_stub.first
+        expect(rel.relationship).to eq('genealogy')
+        expect(rel.ancestry).to eq('645')
+        expect(rel.resource_type).to eq('ResourcePool')
+        expect(rel.resource_id).to eq(resource_pool.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
we're working on converting resource pool genealogy to use ancestry. In order to do this, we need to use the existing relationship resource information on all resource pool  with genealogy rels of type ResourcePool and convert those resource ids into resource pool  ids. 

This PR, just like the equivalent https://github.com/ManageIQ/manageiq-schema/pull/492 , 1) adds the necessary index and 2) gets the ancestry information from the relationships, splitting on slashes, then maps those back to the resource pool  ancestry records. 

https://github.com/ManageIQ/manageiq-schema/pull/513 was opened merely for testing and just adds the two lines in this code necessary for ancestry. I can take those two lines out if needed, or this can be merged and 513 closed. 

## needs concurrent merge with:
the core pr https://github.com/ManageIQ/manageiq/pull/20392 
