### PR TITLE
Add target platform to the configuration profiles

### DIFF
--- a/db/migrate/20200914005000_add_target_platform_to_configuration_profiles.rb
+++ b/db/migrate/20200914005000_add_target_platform_to_configuration_profiles.rb
@@ -1,0 +1,5 @@
+class AddTargetPlatformToConfigurationProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :configuration_profiles, :target_platform, :string
+  end
+end


### PR DESCRIPTION
As part of the [IBM Terraform provider](https://github.com/ManageIQ/manageiq-providers-ibm_terraform) implementation, we discover the terraform templates from CAM and currently we represent them as configuration profiles. 

Template contains metadata (name, description, cloud provider) and they can have multiple template versions. 
Each version has a unique name (i.e. "v1.0.0") and it either has the template source reference such as git repo, branch, token, etc or contains the template code source if the template version is stored locally. A template can have only one default version.

This PR is to enhance the configuration_profiles table and add the cloud provider information. 