### PR TITLE
[wip] add ancestry to folders and resource pools

### DIFF
--- a/db/migrate/20200917212438_add_ancestry_to_ems_folder.rb
+++ b/db/migrate/20200917212438_add_ancestry_to_ems_folder.rb
@@ -1,0 +1,6 @@
+class AddAncestryToEmsFolder < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ems_folders, :ancestry, :string
+    add_index :ems_folders, :ancestry
+  end
+end

--- a/db/migrate/20200917212453_add_ancestry_to_resource_pool.rb
+++ b/db/migrate/20200917212453_add_ancestry_to_resource_pool.rb
@@ -1,0 +1,6 @@
+class AddAncestryToResourcePool < ActiveRecord::Migration[5.2]
+  def change
+    add_column :resource_pools, :ancestry, :string
+    add_index :resource_pools, :ancestry
+  end
+end


### PR DESCRIPTION
we're working on converting resource pool genealogy and folder genealogy to use ancestry and it's better to have the change that adds ancestry be separate from the migration to sort out the relationship side. 

split out from https://github.com/ManageIQ/manageiq-schema/pull/497 and https://github.com/ManageIQ/manageiq-schema/pull/510 and if those are merged as is, this can be closed. or if separation of concerns matters, i can take out the relevant lines from those PRs and leave this intact. 

## related to 
 https://github.com/ManageIQ/manageiq/pull/20392 