### PR TITLE
Rename the ContainerLabelTagMapping table to ProviderTagMapping

### DIFF
--- a/db/migrate/20200921142257_rename_container_label_tag_mapping.rb
+++ b/db/migrate/20200921142257_rename_container_label_tag_mapping.rb
@@ -1,0 +1,5 @@
+class RenameContainerLabelTagMapping < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :container_label_tag_mappings, :provider_tag_mappings
+  end
+end


### PR DESCRIPTION
This mapping table is used by more than just container providers now so it should be renamed accordingly

Core issue: https://github.com/ManageIQ/manageiq/pull/20577