### PR TITLE
Add vendor to configured_systems

### DIFF
--- a/db/migrate/20200924151045_add_vendor_to_configured_systems.rb
+++ b/db/migrate/20200924151045_add_vendor_to_configured_systems.rb
@@ -1,0 +1,5 @@
+class AddVendorToConfiguredSystems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :configured_systems, :vendor, :string
+  end
+end


### PR DESCRIPTION
As part of the [IBM Terraform provider](https://github.com/ManageIQ/manageiq-providers-ibm_terraform) implementation, we discover the virtual machines from CAM and represent them as configured systems. 

The terraform resources contain a resource type (i.e. aws_instance) and we would like to capture this information in the configured systems.

Parent user story: https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/28