### PR TITLE
[SchemaDumper] Handle edge cases for metric tables

### DIFF
--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -19,7 +19,7 @@ module ManageIQ
       def add_id_column_comment(table, stream)
         pk      = @connection.primary_key(table)
         pkcol   = @connection.columns(table).detect { |c| c.name == pk }
-        comment = pkcol.comment
+        comment = pkcol.try(:comment)
 
         return unless comment
 

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -87,8 +87,8 @@ module ManageIQ
 
       def track_miq_metric_table_inheritance(table)
         return unless table.match?(METRIC_ROLLUP_TABLE_REGEXP)
+        return unless (inherit_from = determine_table_parent(table))
 
-        inherit_from              = determine_table_parent(table)
         inherited_metrics_tables << [table, inherit_from]
       end
 
@@ -97,12 +97,16 @@ module ManageIQ
       end
 
       def determine_table_parent(table_name)
-        @connection.execute(<<-SQL).first["parent_table"]
+        table = @connection.execute(<<-SQL)
           SELECT pg_class.relname AS parent_table
           FROM   pg_catalog.pg_inherits
           JOIN pg_class ON pg_class.oid = pg_inherits.inhparent
           WHERE inhrelid = '#{table_name}'::regclass
         SQL
+
+        return if table.first.nil?
+
+        table.first["parent_table"]
       end
 
       def column_spec_for_primary_key(column)


### PR DESCRIPTION
Fixes two problems described in https://github.com/ManageIQ/manageiq-schema/issues/516

### 1. "Custom" metrics tables

(AKA:  The "Martin H. Factor" commit)

So, when doing something outside of Rails to, say, backup a metrics table before testing a migration by doing something like:

> cop[y] metric_rollups_01 to xmetric_rollups_01 as a backup

Then this will get picked up by the `METRIC_ROLLUP_TABLE_REGEXP`, and work though the other methods (`determine_table_parent`) and cause the following error:

```
** Execute db:schema:dump
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
manageiq-schema/lib/manageiq/schema/schema_dumper.rb:100:in `determine_table_parent'
manageiq-schema/lib/manageiq/schema/schema_dumper.rb:91:in `track_miq_metric_table_inheritance'
manageiq-schema/lib/manageiq/schema/schema_dumper.rb:16:in `table'
```

This does another check to handle these cases.  This means said table can't be used with the Rails models, but that should be fine since this table is definitely outside of the Rails managed tables.


### 2. Tables without primary keys

(AKA:  "The Martin H. Factor: Part 2")

So this should never happen with a Rails generated table, but if you were to create a table manually like so:

    CREATE TABLE aaa (id serial);

This wouldn't have a PRIMARY KEY associated with it.  However, Rails always defines a PRIMARY KEY when generating it's tables:

https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L214-L253

So this shouldn't ever actually happen unless you execute custom table creates.... which apparently some people do...


## Testing/QA

Tested the second scenario by doing the following:

```console
$ RAILS_ENV=development rake db:environment:set evm:db:destroy db:migrate > /dev/null
NOTICE:  table "service_offerings" does not exist, skipping
NOTICE:  table "service_parameters_sets" does not exist, skipping
NOTICE:  table "service_instances" does not exist, skipping
NOTICE:  table "ems_licenses" does not exist, skipping
NOTICE:  table "ems_extensions" does not exist, skipping
$ bin/rails db
** ManageIQ master, codename: Kasparov
psql (10.13)
Type "help" for help.

vmdb_development=#  create table aaa (id serial);
CREATE TABLE
vmdb_development=# \q
$ RAILS_ENV=development rake db:migrate > /dev/null
$ grep -C 5 aaa  db/schema.rb
ActiveRecord::Schema.define(version: 2020_09_24_151045) do

  # These are extensions that must be enabled in order to support this database
  enable_extension "plpgsql"

  create_table "aaa", id: false, force: :cascade do |t|
    t.serial "id", null: false
  end

  create_table "accounts", force: :cascade do |t|
    t.string "name"
```

And tested the first after that by doing:

```console
$ bin/rails db
** ManageIQ master, codename: Kasparov
psql (10.13)
Type "help" for help.

vmdb_development=# CREATE TABLE xmetric_rollups_01 AS SELECT * FROM metric_rollups_01;
SELECT 0
vmdb_development=# SELECT * FROM xmetric_rollups_01
vmdb_development-# ;
 id | timestamp | capture_interval | resource_type | resource_id | cpu_usage_rate_average | ... 
----+-----------+------------------+---------------+-------------+------------------------+-----
(0 rows)

vmdb_development=# \q
$ RAILS_ENV=development rake db:migrate > /dev/null
$ grep -A 10 xmetric  db/schema.rb
  create_table "xmetric_rollups_01", id: false, force: :cascade do |t|
    t.bigint "id"
    t.datetime "timestamp"
    t.integer "capture_interval"
    t.string "resource_type"
    t.bigint "resource_id"
    t.float "cpu_usage_rate_average"
    t.float "cpu_usagemhz_rate_average"
    t.float "mem_usage_absolute_average"
    t.float "disk_usage_rate_average"
$
```