### PR TITLE
Schema dumper fixes

### DIFF
--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -5,6 +5,7 @@ module ManageIQ
 
       def tables(stream)
         super
+        miq_metric_table_sequences(stream)
         miq_metric_table_constraints(stream)
         miq_metric_views(stream)
         triggers(stream)
@@ -24,6 +25,15 @@ module ManageIQ
         return unless comment
 
         stream.puts "  change_column_comment #{remove_prefix_and_suffix(table).inspect}, #{pk.inspect}, #{comment.inspect}"
+        stream.puts
+      end
+
+      def miq_metric_table_sequences(stream)
+        inherited_metrics_tables.each do |(table, inherit_from)|
+          stream.puts "  change_miq_metric_sequence #{table.inspect}, " \
+                          "#{inherit_from.inspect}"
+        end
+
         stream.puts
       end
 

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -66,14 +66,12 @@ module ManageIQ
           # - Removes the "BEGIN" and "END;" stanzas
           # - Chomps the new lines from the beginning (keeps existing indent)
           # - Strips whitespace from the end (no need to worry about indent)
-          # - Indents by four spaces
           #
           # For formatting, we want to ensure at least some bit of an indent,
           # regardless of how the SQL string was originally added.
           #
           formatted_body = body.gsub(/(BEGIN$|^END;$)/, "")
                                .reverse.chomp.reverse.rstrip
-                               .indent(4)
 
           stream.puts "  add_trigger #{direction_key.inspect}, "       \
                                     "#{table.inspect}, "               \

--- a/lib/manageiq/schema/schema_dumper.rb
+++ b/lib/manageiq/schema/schema_dumper.rb
@@ -5,7 +5,7 @@ module ManageIQ
 
       def tables(stream)
         super
-        miq_metric_table_contraints(stream)
+        miq_metric_table_constraints(stream)
         miq_metric_views(stream)
         triggers(stream)
       end
@@ -28,18 +28,18 @@ module ManageIQ
       end
 
       # Must be done after all of the table definitions since `metrics_01` is
-      # dumpped prior to `metrics_base`, etc.
+      # dumped prior to `metrics_base`, etc.
       #
-      def miq_metric_table_contraints(stream)
+      def miq_metric_table_constraints(stream)
         inherited_metrics_tables.each do |(table, inherit_from)|
-          match             = table.match(METRIC_ROLLUP_TABLE_REGEXP)
+          child_table_num   = table.match(METRIC_ROLLUP_TABLE_REGEXP)[:CHILD_TABLE_NUM].to_i
           child_table       = remove_prefix_and_suffix(table).inspect
           primary_condition = if inherit_from.include?("rollup")
                                 "capture_interval_name != ? AND EXTRACT(MONTH FROM timestamp) = ?"
                               else
                                 "capture_interval_name = ? AND EXTRACT(HOUR FROM timestamp) = ?"
                               end
-          conditions        = [primary_condition, "realtime", match[:CHILD_TABLE_NUM]]
+          conditions        = [primary_condition, "realtime", child_table_num]
 
           stream.puts "  add_miq_metric_table_inheritance #{child_table}, " \
                           "#{inherit_from.inspect}, "                       \

--- a/lib/manageiq/schema/schema_statements.rb
+++ b/lib/manageiq/schema/schema_statements.rb
@@ -14,6 +14,10 @@ module ManageIQ
         execute("DROP FUNCTION IF EXISTS #{quoted_name}();", 'Drop trigger function')
       end
 
+      def drop_sequence(table)
+        execute("DROP SEQUENCE #{table}_id_seq CASCADE", 'Drop sequence')
+      end
+
       def create_miq_metric_view(name)
         execute("CREATE VIEW #{name} AS SELECT * FROM #{name}_base")
         execute("ALTER VIEW #{name} ALTER COLUMN id SET DEFAULT nextval('#{name}_base_id_seq')")
@@ -40,6 +44,11 @@ module ManageIQ
 
         execute("ALTER TABLE #{quoted_table} DROP CONSTRAINT #{quoted_constraint}", 'Drop inheritance check constraint')
         execute("ALTER TABLE #{quoted_table} NO INHERIT #{quoted_inherit}", 'Drop table inheritance')
+      end
+
+      def change_miq_metric_sequence(table, inherit_from)
+        drop_sequence(table)
+        change_column_default(table, :id, -> { "nextval('#{inherit_from}_id_seq')" })
       end
 
       # Fetch the direction, table, name, and body for all of the MIQ INSERT


### PR DESCRIPTION
@NickLaMuro Please review.  Each commit is a separate fix

- Fix issue where table number was dumped as a string
- Fix issue where indent of the trigger did not match original indent
- Fix sequences on metrics subtables 

These were determined by using the Schema Diff tool that is a part of pgadmin4.  After these changes there are no differences found (aside from the schema_migrations_ran_id_seq start value, which I'm not sure we can do anything about, but I will look into tackling in a follow-up PR).