### PR TITLE
Add orchestration stacks reference to configured systems

### DIFF
--- a/db/migrate/20201008185329_add_orchestration_stacks_to_configured_systems.rb
+++ b/db/migrate/20201008185329_add_orchestration_stacks_to_configured_systems.rb
@@ -1,0 +1,5 @@
+class AddOrchestrationStacksToConfiguredSystems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :configured_systems, :orchestration_stack
+  end
+end


### PR DESCRIPTION
As discussed in https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/36, we need to add a reference to `orchestration_stacks` in the `configured_systems`