### PR TITLE
Update vms table 'format' column comment

### DIFF
--- a/db/migrate/20201012120000_update_comment_to_vms_table_format.rb
+++ b/db/migrate/20201012120000_update_comment_to_vms_table_format.rb
@@ -1,0 +1,5 @@
+class UpdateCommentToVmsTableFormat < ActiveRecord::Migration[5.2]
+  def up
+    change_column_comment :vms, :format, "The format of the VM's disk, such as vmdk, qcow2, and tier1."
+  end
+end


### PR DESCRIPTION
The vms table 'format' column is being used by manageiq-providers-ibm_cloud:
ManageIQ/manageiq-providers-ibm_cloud#82

In this PR I'm trying update the comment to remove the deprecation note. I've marked
it WIP because I'm unsure of the DB migration mechanics.