### PR TITLE
Introduce Openstack cloud manager child manager migration

### DIFF
--- a/db/migrate/20201019211215_create_legacy_managers.rb
+++ b/db/migrate/20201019211215_create_legacy_managers.rb
@@ -1,0 +1,88 @@
+class CreateLegacyManagers < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  include MigrationHelper
+
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    include MigrationStubHelper
+
+    has_one  :swift_manager,
+             -> { swift_managers },
+             :foreign_key => :parent_ems_id,
+             :class_name  => "CreateLegacyManagers::ExtManagementSystem",
+             :autosave    => true
+
+    has_one  :cinder_manager,
+             -> { cinder_managers },
+             :foreign_key => :parent_ems_id,
+             :class_name  => "CreateLegacyManagers::ExtManagementSystem",
+             :autosave    => true
+
+    def self.openstack
+      where(:type => "ManageIQ::Providers::Openstack::CloudManager")
+    end
+
+    def self.swift_managers
+      where(:type => "ManageIQ::Providers::StorageManager::SwiftManager")
+    end
+
+    def self.cinder_managers
+      where(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager")
+    end
+  end
+
+  class CloudVolume < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolumeBackup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolumeSnapshot < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudObjectStoreContainer < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudObjectStoreObject < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    cloud_managers = ExtManagementSystem.openstack.pluck(:id)
+    missing_cinder_manager = cloud_managers - ExtManagementSystem.cinder_managers.pluck(:parent_ems_id)
+    missing_swift_manager = cloud_managers - ExtManagementSystem.swift_managers.pluck(:parent_ems_id)
+
+    say_with_time("Adding missing Cinder Managers") do
+      ExtManagementSystem.where(:id => missing_cinder_manager).each do |parent|
+        child = parent.create_cinder_manager(
+          :name            => "#{parent.name} Cinder Manager",
+          :zone_id         => parent.zone_id,
+          :tenant_id       => parent.tenant_id,
+          :provider_region => parent.provider_region
+        )
+
+        CloudVolume.where(:ems_id => parent.id).update(:ems_id => child.id)
+        CloudVolumeBackup.where(:ems_id => parent.id).update(:ems_id => child.id)
+        CloudVolumeSnapshot.where(:ems_id => parent.id).update(:ems_id => child.id)
+      end
+    end
+
+    say_with_time("Adding missing Swift Managers") do
+      ExtManagementSystem.where(:id => missing_swift_manager).each do |parent|
+        child = parent.create_swift_manager(
+          :name            => "#{parent.name} Swift Manager",
+          :zone_id         => parent.zone_id,
+          :tenant_id       => parent.tenant_id,
+          :provider_region => parent.provider_region
+        )
+        CloudObjectStoreContainer.where(:ems_id => parent.id).update(:ems_id => child.id)
+        CloudObjectStoreObject.where(:ems_id => parent.id).update(:ems_id => child.id)
+      end
+    end
+  end
+end

--- a/spec/migrations/20201019211215_create_legacy_managers_spec.rb
+++ b/spec/migrations/20201019211215_create_legacy_managers_spec.rb
@@ -1,0 +1,131 @@
+require_migration
+
+RSpec.describe CreateLegacyManagers do
+  let(:os_provider_class)    { "ManageIQ::Providers::Openstack::CloudManager" }
+  let(:cinder_ems_class)     { "ManageIQ::Providers::Openstack::StorageManager::CinderManager" }
+  let(:swift_ems_class)      { "ManageIQ::Providers::StorageManager::SwiftManager" }
+
+  let(:ems_stub)             { migration_stub(:ExtManagementSystem) }
+  let(:volume_stub)          { migration_stub(:CloudVolume) }
+  let(:backup_stub)          { migration_stub(:CloudVolumeBackup) }
+  let(:snapshot_stub)        { migration_stub(:CloudVolumeSnapshot) }
+  let(:store_container_stub) { migration_stub(:CloudObjectStoreContainer) }
+  let(:store_object_stub)    { migration_stub(:CloudObjectStoreObject) }
+
+  let(:provider) do
+    ems_stub.create!(
+      :type            => os_provider_class,
+      :name            => "sample",
+      :zone_id         => 99,
+      :provider_region => "ne-dc1"
+    )
+  end
+
+  # note: these are cached so if they are accessed before migrate, need to reload them
+  let(:emses)          { ems_stub.order(:type).load }
+  let(:cloud_manager)  { emses.first }
+  let(:cinder_manager) { emses.second }
+  let(:swift_manager)  { emses.last }
+
+  migration_context :up do
+    it "creates two managers for providers with no managers" do
+      provider
+
+      migrate
+
+      expect(emses.count).to eq(3)
+
+      expect(cinder_manager).to have_attributes(
+        :type            => cinder_ems_class,
+        :name            => /sample Cinder Manager/i,
+        :zone_id         => 99,
+        :parent_ems_id   => provider.id,
+        :provider_region => "ne-dc1"
+      )
+
+      expect(swift_manager).to have_attributes(
+        :type            => swift_ems_class,
+        :name            => /sample swift manager/i,
+        :zone_id         => 99,
+        :parent_ems_id   => provider.id,
+        :provider_region => "ne-dc1"
+      )
+    end
+
+    it "migrates cinder objects" do
+      provider
+      volume_stub.create(:ems_id => provider.id)
+      backup_stub.create(:ems_id => provider.id)
+      snapshot_stub.create(:ems_id => provider.id)
+
+      migrate
+
+      expect(volume_stub.all.map(&:ems_id).uniq).to eq([cinder_manager.id])
+      expect(backup_stub.all.map(&:ems_id).uniq).to eq([cinder_manager.id])
+      expect(snapshot_stub.all.map(&:ems_id).uniq).to eq([cinder_manager.id])
+    end
+
+    it "migrates swift objects" do
+      provider
+      store_container_stub.create(:ems_id => provider.id)
+      store_object_stub.create(:ems_id => provider.id)
+
+      migrate
+
+      expect(store_container_stub.all.map(&:ems_id).uniq).to eq([swift_manager.id])
+      expect(store_object_stub.all.map(&:ems_id).uniq).to eq([swift_manager.id])
+    end
+
+    it "does not create cinder manager if it exists" do
+      ems_stub.create!(
+        :type            => cinder_ems_class,
+        :name            => /sample Cinder/i,
+        :zone_id         => 99,
+        :parent_ems_id   => provider.id,
+        :provider_region => "ne-dc1"
+      )
+
+      migrate
+
+      expect(emses.count).to eq(3)
+    end
+
+    it "does not create swift manager if it exists" do
+      ems_stub.create!(
+        :type            => swift_ems_class,
+        :name            => /sample swift/i,
+        :zone_id         => 99,
+        :parent_ems_id   => provider.id,
+        :provider_region => "ne-dc1"
+      )
+
+      migrate
+
+      expect(emses.count).to eq(3)
+    end
+
+    it "creates none if swift and cinder managers exist" do
+      provider
+
+      ems_stub.create!(
+        :type            => cinder_ems_class,
+        :name            => /sample Cinder/i,
+        :zone_id         => 99,
+        :parent_ems_id   => provider.id,
+        :provider_region => "ne-dc1"
+      )
+
+      ems_stub.create!(
+        :type            => swift_ems_class,
+        :name            => /sample swift/i,
+        :zone_id         => 99,
+        :parent_ems_id   => provider.id,
+        :provider_region => "ne-dc1"
+      )
+
+      migrate
+
+      expect(emses.count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/20701

Child storage managers were introduced in E release.
When creating a cloud manager, these child managers are auto created.

For existing ems, the cloud volumes were linked to the cloud manager but
they now will point to the storage managers.

to avoid a migration, we had introduced code in the model to do this migration.
This PR moves that code to migrations where it belongs.

This is only necessary for customers transitioning from darga and have
not run a refresh (in the past 5 years...)

Since we are deleting this from the model, we need this in here for safe measure.