### PR TITLE
Drop unused / typo timestamp column (fix for Rails 6)

### DIFF
--- a/db/migrate/20151104115400_create_chargeback_tiers.rb
+++ b/db/migrate/20151104115400_create_chargeback_tiers.rb
@@ -6,8 +6,6 @@ class CreateChargebackTiers < ActiveRecord::Migration[4.2]
       t.float :finish
       t.float :fixed_rate
       t.float :variable_rate
-
-      t.timestamp :null => false
     end
   end
 end


### PR DESCRIPTION
It was meant to be t.timestamps :null => false to magically
add created_at and updated_at columns but without the 's', it
expects a column name.

In rails 4.2, 5.0, 5.1, and 5.2, this line is ignored without a column name.
In rails 6.0, it raises: Missing column name(s) for timestamp.

It's been 5 years, we didn't need timestamps up until now, so we'll just drop it.