### PR TITLE
Rename TagMapping resource_type for Amazon Vms and Images

### DIFF
--- a/db/migrate/20201022201901_update_amazon_tag_mapper_resource_type.rb
+++ b/db/migrate/20201022201901_update_amazon_tag_mapper_resource_type.rb
@@ -1,0 +1,22 @@
+class UpdateAmazonTagMapperResourceType < ActiveRecord::Migration[5.2]
+  class ProviderTagMapping < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Update ProviderTagMapping Vm label") do
+      ProviderTagMapping.where(:labeled_resource_type => "Vm").update_all(:labeled_resource_type => "VmAmazon")
+    end
+    say_with_time("Update ProviderTagMapping Image label") do
+      ProviderTagMapping.where(:labeled_resource_type => "Image").update_all(:labeled_resource_type => "ImageAmazon")
+    end
+  end
+
+  def down
+    say_with_time("Update ProviderTagMapping VmAmazon label") do
+      ProviderTagMapping.where(:labeled_resource_type => "VmAmazon").update_all(:labeled_resource_type => "Vm")
+    end
+    say_with_time("Update ProviderTagMapping ImageAmazon label") do
+      ProviderTagMapping.where(:labeled_resource_type => "ImageAmazon").update_all(:labeled_resource_type => "Image")
+    end
+  end
+end

--- a/spec/migrations/20201022201901_update_amazon_tag_mapper_resource_type_spec.rb
+++ b/spec/migrations/20201022201901_update_amazon_tag_mapper_resource_type_spec.rb
@@ -1,0 +1,45 @@
+require_migration
+
+describe UpdateAmazonTagMapperResourceType do
+  let(:provider_tag_mapping_stub) { migration_stub(:ProviderTagMapping) }
+
+  migration_context :up do
+    it "Converts Vm and Image to VmAmazon and ImageAmazon" do
+      vm_mapping    = provider_tag_mapping_stub.create!(:labeled_resource_type => "Vm")
+      image_mapping = provider_tag_mapping_stub.create!(:labeled_resource_type => "Image")
+
+      migrate
+
+      expect(vm_mapping.reload.labeled_resource_type).to eq("VmAmazon")
+      expect(image_mapping.reload.labeled_resource_type).to eq("ImageAmazon")
+    end
+
+    it "Doesn't update other tag mappings" do
+      vm_mapping = provider_tag_mapping_stub.create!(:labeled_resource_type => "VmOpenstack")
+
+      migrate
+
+      expect(vm_mapping.reload.labeled_resource_type).to eq("VmOpenstack")
+    end
+  end
+
+  migration_context :down do
+    it "Converts VmAmazon and ImageAmazon to Vm and Image" do
+      vm_mapping    = provider_tag_mapping_stub.create!(:labeled_resource_type => "VmAmazon")
+      image_mapping = provider_tag_mapping_stub.create!(:labeled_resource_type => "ImageAmazon")
+
+      migrate
+
+      expect(vm_mapping.reload.labeled_resource_type).to eq("Vm")
+      expect(image_mapping.reload.labeled_resource_type).to eq("Image")
+    end
+
+    it "Doesn't update other tag mappings" do
+      vm_mapping = provider_tag_mapping_stub.create!(:labeled_resource_type => "VmOpenstack")
+
+      migrate
+
+      expect(vm_mapping.reload.labeled_resource_type).to eq("VmOpenstack")
+    end
+  end
+end


### PR DESCRIPTION
The Amazon provider was the first cloud provider to participate in the (originally) ContainerLabelTagMapping class.  It has since been expanded to include many providers including Openstack, Azure, and VMware vSphere.

This means that the original labeled_resource_type of "Vm" and "Image" meaning Amazon VMs and Templates is quite confusing.

Follow-up to: https://github.com/ManageIQ/manageiq-providers-vmware/pull/658#issuecomment-714732041
Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/7438 https://github.com/ManageIQ/manageiq-providers-amazon/pull/671