### PR TITLE
Update the GCE CloudVolume STI class

### DIFF
--- a/db/migrate/20201103143405_fix_google_cloud_volume_sti.rb
+++ b/db/migrate/20201103143405_fix_google_cloud_volume_sti.rb
@@ -1,0 +1,30 @@
+class FixGoogleCloudVolumeSti < ActiveRecord::Migration[5.2]
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolume < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system,
+               :foreign_key => :ems_id,
+               :class_name  => "FixGoogleCloudVolumeSti::ExtManagementSystem"
+  end
+
+  GOOGLE_CLOUD_KLASS        = "ManageIQ::Providers::Google::CloudManager".freeze
+  GOOGLE_CLOUD_VOLUME_KLASS = "ManageIQ::Providers::Google::CloudManager::CloudVolume".freeze
+
+  def up
+    gce_relation = ExtManagementSystem.in_my_region.where(:type => GOOGLE_CLOUD_KLASS)
+    CloudVolume.in_my_region.where(:type => nil, :ext_management_system => gce_relation)
+               .update_all(:type => GOOGLE_CLOUD_VOLUME_KLASS)
+  end
+
+  def down
+    gce_relation = ExtManagementSystem.in_my_region.where(:type => GOOGLE_CLOUD_KLASS)
+    CloudVolume.in_my_region.where(:type => GOOGLE_CLOUD_VOLUME_KLASS, :ext_management_system => gce_relation)
+               .update_all(:type => nil)
+  end
+end

--- a/spec/migrations/20201103143405_fix_google_cloud_volume_sti_spec.rb
+++ b/spec/migrations/20201103143405_fix_google_cloud_volume_sti_spec.rb
@@ -1,0 +1,55 @@
+require_migration
+
+RSpec.describe FixGoogleCloudVolumeSti do
+  let(:ems_stub)    { migration_stub(:ExtManagementSystem) }
+  let(:volume_stub) { migration_stub(:CloudVolume) }
+
+  migration_context :up do
+    it "Fixes the STI class of Google Cloud Volumes" do
+      gce = ems_stub.create!(:type => "ManageIQ::Providers::Google::CloudManager")
+      volume = volume_stub.create!(:ext_management_system => gce, :type => nil)
+
+      migrate
+
+      expect(volume.reload.type).to eq("ManageIQ::Providers::Google::CloudManager::CloudVolume")
+    end
+
+    it "Doesn't impact non-Google Cloud volumes" do
+      osp = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
+      volume = volume_stub.create!(
+        :ext_management_system => osp,
+        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+      )
+
+      migrate
+
+      expect(volume.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolume")
+    end
+  end
+
+  migration_context :down do
+    it "Fixes the STI class of Google Cloud Volumes" do
+      gce = ems_stub.create!(:type => "ManageIQ::Providers::Google::CloudManager")
+      volume = volume_stub.create!(
+        :ext_management_system => gce,
+        :type                  => "ManageIQ::Providers::Google::CloudManager::CloudVolume"
+      )
+
+      migrate
+
+      expect(volume.reload.type).to be_nil
+    end
+
+    it "Doesn't impact non-Google Cloud volumes" do
+      osp = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
+      volume = volume_stub.create!(
+        :ext_management_system => osp,
+        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+      )
+
+      migrate
+
+      expect(volume.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolume")
+    end
+  end
+end


### PR DESCRIPTION
Google Cloud never had a CloudVolume subclass and these volumes are of the base class type.

Provider PR: https://github.com/ManageIQ/manageiq-providers-google/pull/167
Noticed from: https://github.com/ManageIQ/manageiq/pull/20761