### PR TITLE
Fix Openstack Storage STI Types

### DIFF
--- a/db/migrate/20201105124938_fix_openstack_cloud_volume_sti_types.rb
+++ b/db/migrate/20201105124938_fix_openstack_cloud_volume_sti_types.rb
@@ -1,0 +1,86 @@
+class FixOpenstackCloudVolumeStiTypes < ActiveRecord::Migration[5.2]
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolume < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system,
+               :foreign_key => :ems_id,
+               :class_name  => "FixOpenstackCloudVolumeStiTypes::ExtManagementSystem"
+  end
+
+  class CloudVolumeBackup < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system,
+               :foreign_key => :ems_id,
+               :class_name  => "FixOpenstackCloudVolumeStiTypes::ExtManagementSystem"
+  end
+
+  class CloudVolumeSnapshot < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system,
+               :foreign_key => :ems_id,
+               :class_name  => "FixOpenstackCloudVolumeStiTypes::ExtManagementSystem"
+  end
+
+  class CloudVolumeType < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system,
+               :foreign_key => :ems_id,
+               :class_name  => "FixOpenstackCloudVolumeStiTypes::ExtManagementSystem"
+  end
+
+  def up
+    [CloudVolume, CloudVolumeBackup, CloudVolumeSnapshot, CloudVolumeType].each do |klass|
+      klass_name = klass.name.sub("FixOpenstackCloudVolumeStiTypes::", "")
+
+      old_type = "#{openstack_klass}::#{klass_name}"
+      new_type = "#{cinder_klass}::#{klass_name}"
+
+      say_with_time("Fixing OpenStack #{klass_name} STI class") do
+        klass.in_my_region
+             .where(:ext_management_system => cinder_managers, :type => old_type)
+             .update_all(:type => new_type)
+      end
+    end
+  end
+
+  def down
+    [CloudVolume, CloudVolumeBackup, CloudVolumeSnapshot, CloudVolumeType].each do |klass|
+      klass_name = klass.name.sub("FixOpenstackCloudVolumeStiTypes::", "")
+
+      old_type = "#{cinder_klass}::#{klass_name}"
+      new_type = "#{openstack_klass}::#{klass_name}"
+
+      say_with_time("Resetting OpenStack #{klass_name} STI class") do
+        klass.in_my_region
+             .where(:ext_management_system => cinder_managers, :type => old_type)
+             .update_all(:type => new_type)
+      end
+    end
+  end
+
+  private
+
+  def cinder_managers
+    ExtManagementSystem.in_my_region.where(:type => cinder_klass)
+  end
+
+  def cinder_klass
+    "ManageIQ::Providers::Openstack::StorageManager::CinderManager".freeze
+  end
+
+  def openstack_klass
+    "ManageIQ::Providers::Openstack::CloudManager".freeze
+  end
+end

--- a/spec/migrations/20201105124938_fix_openstack_cloud_volume_sti_types_spec.rb
+++ b/spec/migrations/20201105124938_fix_openstack_cloud_volume_sti_types_spec.rb
@@ -1,0 +1,71 @@
+require_migration
+
+RSpec.describe FixOpenstackCloudVolumeStiTypes do
+  let(:ems_stub)                   { migration_stub(:ExtManagementSystem) }
+  let(:cloud_volume_stub)          { migration_stub(:CloudVolume) }
+  let(:cloud_volume_snapshot_stub) { migration_stub(:CloudVolumeSnapshot) }
+  let(:cloud_volume_backup_stub)   { migration_stub(:CloudVolumeBackup) }
+  let(:cloud_volume_type_stub)     { migration_stub(:CloudVolumeType) }
+
+  migration_context :up do
+    it "Fixes the STI class of OpenStack Cloud Volumes, Backups, Snapshots, and Types" do
+      osp    = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
+      cinder = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager", :parent_ems_id => osp.id)
+
+      cloud_volume = cloud_volume_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+      )
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot"
+      )
+      cloud_volume_backup = cloud_volume_backup_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
+      )
+      cloud_volume_type = cloud_volume_type_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType"
+      )
+
+      migrate
+
+      expect(cloud_volume.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume")
+      expect(cloud_volume_snapshot.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot")
+      expect(cloud_volume_backup.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup")
+      expect(cloud_volume_type.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType")
+    end
+  end
+
+  migration_context :down do
+    it "Resets the STI class of OpenStack Cloud Volumes, Backups, Snapshots, and Types" do
+      osp    = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
+      cinder = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager", :parent_ems_id => osp.id)
+
+      cloud_volume = cloud_volume_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume"
+      )
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot"
+      )
+      cloud_volume_backup = cloud_volume_backup_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup"
+      )
+      cloud_volume_type = cloud_volume_type_stub.create!(
+        :ext_management_system => cinder,
+        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType"
+      )
+
+      migrate
+
+      expect(cloud_volume.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolume")
+      expect(cloud_volume_snapshot.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot")
+      expect(cloud_volume_backup.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup")
+      expect(cloud_volume_type.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType")
+    end
+  end
+end


### PR DESCRIPTION
A number of openstack storage types (`CloudVolume`, `CloudVolumeBackup`, `CloudVolumeSnapshot`, and `CloudVolumeType`) belong to the `Openstack::StorageManager::CinderManager` but their STI class indicates that they belong to the `Openstack::CloudManager`.