### PR TITLE
Add a column to store the external service UID for miq_workers

### DIFF
--- a/db/migrate/20201105151502_add_system_uid_to_miq_workers.rb
+++ b/db/migrate/20201105151502_add_system_uid_to_miq_workers.rb
@@ -1,0 +1,5 @@
+class AddSystemUidToMiqWorkers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :miq_workers, :system_uid, :string
+  end
+end


### PR DESCRIPTION
Store the external service manager UID on the miq_workers table.  This is the pod hostname/uid on kubnernetes, unit name on systemd, and PID on process based.

This allows us to link up a k8s pod to a specific worker row which wasn't possible before.