### PR TITLE
Fix CloudVolume* STI types on older CinderManagers

### DIFF
--- a/db/migrate/20201202172818_fix_cinder_manager_cloud_volumes.rb
+++ b/db/migrate/20201202172818_fix_cinder_manager_cloud_volumes.rb
@@ -1,0 +1,57 @@
+class FixCinderManagerCloudVolumes < ActiveRecord::Migration[5.2]
+  class CloudVolume < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolumeBackup < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolumeSnapshot < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudVolumeType < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    [CloudVolume, CloudVolumeBackup, CloudVolumeSnapshot, CloudVolumeType].each do |klass|
+      klass_name = klass.name.sub("FixCinderManagerCloudVolumes::", "")
+
+      old_type = "#{openstack_klass}::#{klass_name}"
+      new_type = "#{cinder_klass}::#{klass_name}"
+
+      say_with_time("Fixing OpenStack #{klass_name} STI class") do
+        klass.in_my_region.where(:type => old_type).update_all(:type => new_type)
+      end
+    end
+  end
+
+  def down
+    [CloudVolume, CloudVolumeBackup, CloudVolumeSnapshot, CloudVolumeType].each do |klass|
+      klass_name = klass.name.sub("FixCinderManagerCloudVolumes::", "")
+
+      old_type = "#{cinder_klass}::#{klass_name}"
+      new_type = "#{openstack_klass}::#{klass_name}"
+
+      say_with_time("Resetting OpenStack #{klass_name} STI class") do
+        klass.in_my_region.where(:type => old_type).update_all(:type => new_type)
+      end
+    end
+  end
+
+  private
+
+  def cinder_klass
+    "ManageIQ::Providers::Openstack::StorageManager::CinderManager".freeze
+  end
+
+  def openstack_klass
+    "ManageIQ::Providers::Openstack::CloudManager".freeze
+  end
+end

--- a/spec/migrations/20201202172818_fix_cinder_manager_cloud_volumes_spec.rb
+++ b/spec/migrations/20201202172818_fix_cinder_manager_cloud_volumes_spec.rb
@@ -1,0 +1,56 @@
+require_migration
+
+RSpec.describe FixCinderManagerCloudVolumes do
+  let(:cloud_volume_stub)          { migration_stub(:CloudVolume) }
+  let(:cloud_volume_snapshot_stub) { migration_stub(:CloudVolumeSnapshot) }
+  let(:cloud_volume_backup_stub)   { migration_stub(:CloudVolumeBackup) }
+  let(:cloud_volume_type_stub)     { migration_stub(:CloudVolumeType) }
+
+  migration_context :up do
+    it "Fixes the STI class of OpenStack Cloud Volumes, Backups, Snapshots, and Types" do
+      cloud_volume = cloud_volume_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+      )
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot"
+      )
+      cloud_volume_backup = cloud_volume_backup_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
+      )
+      cloud_volume_type = cloud_volume_type_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType"
+      )
+
+      migrate
+
+      expect(cloud_volume.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume")
+      expect(cloud_volume_snapshot.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot")
+      expect(cloud_volume_backup.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup")
+      expect(cloud_volume_type.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType")
+    end
+  end
+
+  migration_context :down do
+    it "Resets the STI class of OpenStack Cloud Volumes, Backups, Snapshots, and Types" do
+      cloud_volume = cloud_volume_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume"
+      )
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot"
+      )
+      cloud_volume_backup = cloud_volume_backup_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup"
+      )
+      cloud_volume_type = cloud_volume_type_stub.create!(
+        :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType"
+      )
+
+      migrate
+
+      expect(cloud_volume.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolume")
+      expect(cloud_volume_snapshot.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot")
+      expect(cloud_volume_backup.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup")
+      expect(cloud_volume_type.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType")
+    end
+  end
+end


### PR DESCRIPTION
Older `Openstack` `CinderManagers` didn't use the subclassed `ManageIQ::Providers::Openstack::StorageManager::CinderManager` but rather the base `ManageIQ::Providers::StorageManager::CinderManager`.  This caused the previous data migration to miss these records because it was querying on active `Openstack` `CinderManagers`.

This led to:
`[ActiveRecord::SubclassNotFound] The single-table inheritance mechanism failed to locate the subclass: 'ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot'. This error is raised because the column 'type' is reserved for storing the class in case of inheritance. Please rename this column if you didn't intend it to be used for storing the inheritance class or overwrite CloudVolumeSnapshot.inheritance_column to use another column for that information.`

Follow-up to https://github.com/ManageIQ/manageiq-schema/pull/532