### PR TITLE
Data migration to cover edge conditions after control explorer split

### DIFF
--- a/db/migrate/20201202164337_control_explorer_split_feature_mapping.rb
+++ b/db/migrate/20201202164337_control_explorer_split_feature_mapping.rb
@@ -1,0 +1,64 @@
+class ControlExplorerSplitFeatureMapping < ActiveRecord::Migration[5.2]
+  class MiqProductFeature < ActiveRecord::Base; end
+  class MiqRolesFeature < ActiveRecord::Base; end
+
+  FEATURE_MAPPING = {
+    "control_explorer"       => "control",
+    "policy_profile"         => "miq_policy_set",
+    "policy_profile_view"    => "miq_policy_set_view",
+    "policy_profile_admin"   => "miq_policy_set_admin",
+    "profile_new"            => "miq_policy_set_new",
+    "profile_delete"         => "miq_policy_set_delete",
+    "profile_edit"           => "miq_policy_set_edit",
+    "policy"                 => "miq_policy",
+    "policy_view"            => "miq_policy_view",
+    "policy_admin"           => "miq_policy_admin",
+    "policy_new"             => "miq_policy_new",
+    "policy_copy"            => "miq_policy_copy",
+    "policy_edit"            => "miq_policy_edit",
+    "policy_edit_conditions" => "miq_policy_conditions_assignment",
+    "policy_edit_events"     => "miq_policy_events_assignment",
+    "policy_delete"          => "miq_policy_delete",
+    "event"                  => "miq_event",
+    "action"                 => "miq_action",
+    "action_admin"           => "miq_action_admin",
+    "action_show_list"       => "miq_action_show_list",
+    "action_show"            => "miq_action_show",
+    "action_new"             => "miq_action_new",
+    "action_edit"            => "miq_action_edit",
+    "action_delete"          => "miq_action_delete",
+    "alert_profile"          => "miq_alert_set",
+    "alert_profile_admin"    => "miq_alert_set_admin",
+    "alert_profile_new"      => "miq_alert_set_new",
+    "alert_profile_edit"     => "miq_alert_set_edit",
+    "alert_profile_assign"   => "miq_alert_set_assign",
+    "alert_profile_delete"   => "miq_alert_set_delete",
+    "alert"                  => "miq_alert",
+    "alert_admin"            => "miq_alert_admin",
+    "alert_new"              => "miq_alert_new",
+    "alert_copy"             => "miq_alert_copy",
+    "alert_edit"             => "miq_alert_edit",
+    "alert_delete"           => "miq_alert_delete",
+  }.freeze
+
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time 'Renaming old hidden features under control explorer after the split' do
+      # Direct renaming of features
+      FEATURE_MAPPING.each do |from, to|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+
+  def down
+    return if MiqProductFeature.none?
+
+    say_with_time 'Naming features back to match old features before the explorer split' do
+      FEATURE_MAPPING.each do |to, from|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+end

--- a/spec/migrations/20201202164337_control_explorer_split_feature_mapping_spec.rb
+++ b/spec/migrations/20201202164337_control_explorer_split_feature_mapping_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe ControlExplorerSplitFeatureMapping do
+  let(:user_role_id) { anonymous_class_with_id_regions.id_in_region(1, anonymous_class_with_id_regions.my_region_number) }
+  let(:feature_stub) { migration_stub :MiqProductFeature }
+  let(:roles_feature_stub) { migration_stub :MiqRolesFeature }
+
+  migration_context :up do
+    describe 'product features renaming' do
+      it 'renames the features' do
+        ControlExplorerSplitFeatureMapping::FEATURE_MAPPING.keys.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+          roles_feature_stub.create!(:miq_product_feature_id => feature.id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        ControlExplorerSplitFeatureMapping::FEATURE_MAPPING.values.each do |identifier|
+          expect(feature_stub.find_by_identifier(identifier)).to be_truthy
+        end
+      end
+    end
+  end
+
+  migration_context :down do
+    describe 'product features revert' do
+      it 'reverts the control explorer features' do
+        ControlExplorerSplitFeatureMapping::FEATURE_MAPPING.values.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+          roles_feature_stub.create!(:miq_product_feature_id => feature.id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        ControlExplorerSplitFeatureMapping::FEATURE_MAPPING.keys.each do |identifier|
+          expect(feature_stub.find_by_identifier(identifier)).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There could be some edge conditions where user's might have old hidden features explicitly mentioned in their user role record, more details/discussions are in https://github.com/ManageIQ/manageiq-api/pull/966#pullrequestreview-542927153

@NickLaMuro @skateman @gtanzillo @Fryguy We only needed to rename the old features in this migration. After looking at changes made in original split PR, it appears that `control_explorer_view` was not directly being used at all and did not have any children under that node so even if user had an access to that feature somehow, it did not do anything. 
Few of features that were deleted in original PR, that were not in use are listed below.
`control_explorer_view`,  `event_admin`, `event_edit`, `policy_profile_assign`

Condition related features remain the same as before.

Original [PR](https://github.com/ManageIQ/manageiq/pull/20438) with control feature split changes