### PR TITLE
Append the alert_status feature to all roles having the alert feature

### DIFF
--- a/db/migrate/20201208092011_append_alert_statuses_feature.rb
+++ b/db/migrate/20201208092011_append_alert_statuses_feature.rb
@@ -1,0 +1,19 @@
+class AppendAlertStatusesFeature < ActiveRecord::Migration[5.2]
+  class MiqProductFeature < ActiveRecord::Base; end
+  class MiqRolesFeature < ActiveRecord::Base; end
+
+  def up
+    return if MiqProductFeature.none?
+
+    alert = MiqProductFeature.find_or_create_by!(:identifier => 'alert')
+    alert_status = MiqProductFeature.find_or_create_by!(:identifier => 'alert_status')
+
+    MiqRolesFeature.where(:miq_product_feature_id => alert.id).each do |feature|
+      MiqRolesFeature.create!(:miq_product_feature_id => alert_status.id, :miq_user_role_id => feature.miq_user_role_id)
+    end
+  end
+
+  def down
+    # not reversible
+  end
+end

--- a/spec/migrations/20201208092011_append_alert_statuses_feature_spec.rb
+++ b/spec/migrations/20201208092011_append_alert_statuses_feature_spec.rb
@@ -1,0 +1,22 @@
+require_migration
+
+describe AppendAlertStatusesFeature do
+  let(:user_role_id) { anonymous_class_with_id_regions.id_in_region(1, anonymous_class_with_id_regions.my_region_number) }
+  let(:feature_stub) { migration_stub :MiqProductFeature }
+  let(:roles_feature_stub) { migration_stub :MiqRolesFeature }
+
+  migration_context :up do
+    it "appends the 'alert_status' feature to all roles with an 'alert' role" do
+      alert = feature_stub.create!(:identifier => 'alert')
+
+      roles_feature_stub.create!(:miq_product_feature_id => alert.id, :miq_user_role_id => user_role_id)
+
+      migrate
+
+      alert_status = feature_stub.find_by!(:identifier => 'alert_status')
+      assigned = roles_feature_stub.where(:miq_product_feature_id => alert_status.id, :miq_user_role_id => user_role_id)
+
+      expect(assigned.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
The API was referring to the wrong top-level RBAC feature for the `/api/alerts` endpoint. Even though this was not exposed in the UI, I'm creating this migration to prevent any possible inconsistencies in existing setups.

The less scary twin of https://github.com/ManageIQ/manageiq-schema/pull/539
Required because of https://github.com/ManageIQ/manageiq-api/pull/966#pullrequestreview-542927153

@miq-bot assign @gtanzillo 