### PR TITLE
Subclass SwiftManagers under Openstack

### DIFF
--- a/db/migrate/20210105162025_subclass_swift_manager_openstack.rb
+++ b/db/migrate/20210105162025_subclass_swift_manager_openstack.rb
@@ -1,0 +1,19 @@
+class SubclassSwiftManagerOpenstack < ActiveRecord::Migration[5.2]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Subclass SwiftManager under Openstack") do
+      ExtManagementSystem.where(:type => "ManageIQ::Providers::StorageManager::SwiftManager")
+                         .update_all(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
+    end
+  end
+
+  def down
+    say_with_time("Move SwiftManager from Openstack") do
+      ExtManagementSystem.where(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
+                         .update_all(:type => "ManageIQ::Providers::StorageManager::SwiftManager")
+    end
+  end
+end

--- a/spec/migrations/20210105162025_subclass_swift_manager_openstack_spec.rb
+++ b/spec/migrations/20210105162025_subclass_swift_manager_openstack_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+RSpec.describe SubclassSwiftManagerOpenstack do
+  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it "Updates the SwiftManager :type" do
+      ems = ems_stub.create!(:type => "ManageIQ::Providers::StorageManager::SwiftManager")
+
+      migrate
+
+      expect(ems.reload.type).to eq("ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
+    end
+
+    it "Doesn't update other managers' types" do
+      ems = ems_stub.create!(:type => "ManageIQ::Providers::StorageManager::CinderManager")
+
+      migrate
+
+      expect(ems.reload.type).to eq("ManageIQ::Providers::StorageManager::CinderManager")
+    end
+  end
+
+  migration_context :down do
+    it "Updates the SwiftManager :type" do
+      ems = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
+
+      migrate
+
+      expect(ems.reload.type).to eq("ManageIQ::Providers::StorageManager::SwiftManager")
+    end
+
+    it "Doesn't update other managers' types" do
+      ems = ems_stub.create!(:type => "ManageIQ::Providers::StorageManager::CinderManager")
+
+      migrate
+
+      expect(ems.reload.type).to eq("ManageIQ::Providers::StorageManager::CinderManager")
+    end
+  end
+end


### PR DESCRIPTION
SwiftManagers depend on an Openstack::CloudManager to be able to do ems_refresh and thus should be in the openstack plugin.  This doesn't preclude the ability of adding swift managers as standalone without an associated CloudManager in the future, simply declares that the operational bits belong to openstack.

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/673

Dependent:
- [ ] https://github.com/ManageIQ/manageiq/pull/20927