### PR TITLE
Policy Simulation startpage url migration to set it to new path

### DIFF
--- a/db/migrate/20210106180202_update_policy_rsop_startpage_url.rb
+++ b/db/migrate/20210106180202_update_policy_rsop_startpage_url.rb
@@ -1,0 +1,25 @@
+class UpdatePolicyRsopStartpageUrl < ActiveRecord::Migration[5.2]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating start page url for users who had Policy Simulation set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_policy/rsop'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_policy_rsop'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Reverting start page url for users who had Policy Simulation pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_policy_rsop'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_policy/rsop'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20210106180202_update_policy_rsop_startpage_url_spec.rb
+++ b/spec/migrations/20210106180202_update_policy_rsop_startpage_url_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe UpdatePolicyRsopStartpageUrl do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page update' do
+      it 'update user start page if miq_policy/rsop' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_policy/rsop'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_policy_rsop')
+      end
+    end
+
+    it "user start page remains unchanged if it is set to some other url" do
+      user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+      migrate
+      user.reload
+
+      expect(user.settings[:display][:startpage]).to eq('host/show_list')
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'revert start page' do
+      it "reverts user start page to miq_policy/rsop from miq_policy_rsop" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_policy_rsop'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_policy/rsop')
+      end
+
+      it "user start page remains unchanged if it is set to some other url" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('host/show_list')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pre work for https://github.com/ManageIQ/manageiq-ui-classic/pull/7401

Core PR https://github.com/ManageIQ/manageiq/pull/20932
UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7556