### PR TITLE
Policy Log startpage url migration to set it to new path

### DIFF
--- a/db/migrate/20210106201124_update_policy_log_startpage_url.rb
+++ b/db/migrate/20210106201124_update_policy_log_startpage_url.rb
@@ -1,0 +1,25 @@
+class UpdatePolicyLogStartpageUrl < ActiveRecord::Migration[5.2]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating start page url for users who had Policy Log set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_policy/log'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_policy_log'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Reverting start page url for users who had Policy Log pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_policy_log'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_policy/log'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20210106201124_update_policy_log_startpage_url_spec.rb
+++ b/spec/migrations/20210106201124_update_policy_log_startpage_url_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe UpdatePolicyLogStartpageUrl do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page update' do
+      it 'update user start page if miq_policy/log' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_policy/log'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_policy_log')
+      end
+    end
+
+    it "user start page remains unchanged if it is set to some other url" do
+      user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+      migrate
+      user.reload
+
+      expect(user.settings[:display][:startpage]).to eq('host/show_list')
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'revert start page' do
+      it "reverts user start page to miq_policy/log from miq_policy_log/log" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_policy_log'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_policy/log')
+      end
+
+      it "user start page remains unchanged if it is set to some other url" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('host/show_list')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pre work for https://github.com/ManageIQ/manageiq-ui-classic/pull/7401

Data migration to update startpage url form Control/Log entries to new url

UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7557
Core PR https://github.com/ManageIQ/manageiq/pull/20934

@skateman please review

