### PR TITLE
Data Migration for Alert Profiles Startpage url update

### DIFF
--- a/db/migrate/20210112001749_update_alert_profiles_startpage_url_after_de_explorization.rb
+++ b/db/migrate/20210112001749_update_alert_profiles_startpage_url_after_de_explorization.rb
@@ -1,0 +1,25 @@
+class UpdateAlertProfilesStartpageUrlAfterDeExplorization < ActiveRecord::Migration[6.0]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating start page for users who had Alert Profile explorer set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_alert_set/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_alert_set/show_list'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Reverting start page for users who had non-explorer Alert Profile pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_alert_set/show_list'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_alert_set/explorer'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20210112001749_update_alert_profiles_startpage_url_after_de_explorization_spec.rb
+++ b/spec/migrations/20210112001749_update_alert_profiles_startpage_url_after_de_explorization_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe UpdateAlertProfilesStartpageUrlAfterDeExplorization do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page update' do
+      it 'update user start page if miq_alert_set/explorer' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_alert_set/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_alert_set/show_list')
+      end
+    end
+
+    it "user start page remains unchanged if it is set to some other url" do
+      user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+      migrate
+      user.reload
+
+      expect(user.settings[:display][:startpage]).to eq('host/show_list')
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'revert start page' do
+      it "reverts user start page to miq_alert_set/explorer from miq_alert_set/show_list" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_alert_set/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_alert_set/explorer')
+      end
+
+      it "user start page remains unchanged if it is set to some other url" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('host/show_list')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If any of the users had their startpage set to Alert Profiles explorer screen, this migration sets it to non-explorer version screen of Alert Profiles list view.

UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7568
Core PR https://github.com/ManageIQ/manageiq/pull/20945