### PR TITLE
Data Migration for Events Startpage url update

### DIFF
--- a/db/migrate/20210112003720_update_events_startpage_url_after_de_explorization.rb
+++ b/db/migrate/20210112003720_update_events_startpage_url_after_de_explorization.rb
@@ -1,0 +1,25 @@
+class UpdateEventsStartpageUrlAfterDeExplorization < ActiveRecord::Migration[6.0]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating start page for users who had Policy Events explorer set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_event/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_event_definition/show_list'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Reverting start page for users who had non-explorer Policy Events pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'miq_event_definition/show_list'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'miq_event/explorer'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20210112003720_update_events_startpage_url_after_de_explorization_spec.rb
+++ b/spec/migrations/20210112003720_update_events_startpage_url_after_de_explorization_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe UpdateEventsStartpageUrlAfterDeExplorization do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page update' do
+      it 'update user start page if miq_event/explorer' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_event/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_event_definition/show_list')
+      end
+    end
+
+    it "user start page remains unchanged if it is set to some other url" do
+      user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+      migrate
+      user.reload
+
+      expect(user.settings[:display][:startpage]).to eq('host/show_list')
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'revert start page' do
+      it "reverts user start page to miq_event/explorer from miq_event_definition/show_list" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'miq_event_definition/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('miq_event/explorer')
+      end
+
+      it "user start page remains unchanged if it is set to some other url" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('host/show_list')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If any of the users had their startpage set to Policy Events explorer screen, this migration sets it to non-explorer version screen of Policy Events list view.

UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7569
Core PR https://github.com/ManageIQ/manageiq/pull/20947