### PR TITLE
Data Migration for Conditions Startpage url update

### DIFF
--- a/db/migrate/20210112004301_update_conditions_startpage_url_after_de_explorization.rb
+++ b/db/migrate/20210112004301_update_conditions_startpage_url_after_de_explorization.rb
@@ -1,0 +1,25 @@
+class UpdateConditionsStartpageUrlAfterDeExplorization < ActiveRecord::Migration[6.0]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating start page for users who had Policy Conditions explorer set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'condition/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'condition/show_list'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Reverting start page for users who had non-explorer Policy Conditions pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'condition/show_list'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'condition/explorer'}))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20210112004301_update_conditions_startpage_url_after_de_explorization_spec.rb
+++ b/spec/migrations/20210112004301_update_conditions_startpage_url_after_de_explorization_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe UpdateConditionsStartpageUrlAfterDeExplorization do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page update' do
+      it 'update user start page if condition/explorer' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'condition/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('condition/show_list')
+      end
+    end
+
+    it "user start page remains unchanged if it is set to some other url" do
+      user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+      migrate
+      user.reload
+
+      expect(user.settings[:display][:startpage]).to eq('host/show_list')
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'revert start page' do
+      it "reverts user start page to condition/explorer from condition/show_list" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'condition/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('condition/explorer')
+      end
+
+      it "user start page remains unchanged if it is set to some other url" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('host/show_list')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If any of the users had their startpage set to Policy Conditions explorer screen, this migration sets it to non-explorer version screen of Policy Conditions list view.

UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7570
Core PR https://github.com/ManageIQ/manageiq/pull/20948