### PR TITLE
Added :type to volume_mapping and host_initiator

### DIFF
--- a/db/migrate/20210211174438_add_type_to_volume_mappings_and_host_initiators.rb
+++ b/db/migrate/20210211174438_add_type_to_volume_mappings_and_host_initiators.rb
@@ -1,0 +1,6 @@
+class AddTypeToVolumeMappingsAndHostInitiators < ActiveRecord::Migration[6.0]
+  def change
+    add_column :volume_mappings, :type, :string
+    add_column :host_initiators, :type, :string
+  end
+end


### PR DESCRIPTION
As explained in the PR below, type is required for these records since the providers are expected to subclass them using STI.
https://github.com/ManageIQ/manageiq-providers-autosde/pull/57