### PR TITLE
Add a JSONB Capabilities to EMS and Providers

### DIFF
--- a/db/migrate/20210217201401_add_capabilities_to_ext_management_system.rb
+++ b/db/migrate/20210217201401_add_capabilities_to_ext_management_system.rb
@@ -1,0 +1,5 @@
+class AddCapabilitiesToExtManagementSystem < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ext_management_systems, :capabilities, :jsonb, :default => {}
+  end
+end

--- a/db/migrate/20210217201406_add_capabilities_to_provider.rb
+++ b/db/migrate/20210217201406_add_capabilities_to_provider.rb
@@ -1,0 +1,5 @@
+class AddCapabilitiesToProvider < ActiveRecord::Migration[6.0]
+  def change
+    add_column :providers, :capabilities, :jsonb, :default => {}
+  end
+end


### PR DESCRIPTION
Allow storing provider and manager capabilities in VMDB to assist in deciding what is possible to do on a particular provider instance without having to do an API call out to the provider.

This is commonly done to decide if we can e.g. start an event catcher or collect metrics.

https://github.com/ManageIQ/manageiq/issues/21061