### PR TITLE
Feature identifier updates migration for Configuration Script

### DIFF
--- a/db/migrate/20210218230058_update_configuration_script_features.rb
+++ b/db/migrate/20210218230058_update_configuration_script_features.rb
@@ -1,0 +1,33 @@
+class UpdateConfigurationScriptFeatures < ActiveRecord::Migration[5.1]
+  class MiqProductFeature < ActiveRecord::Base; end
+  class MiqRolesFeature < ActiveRecord::Base; end
+
+  FEATURE_MAPPING = {
+    'automation_manager_configuration_scripts_accord'        => 'configuration_script',
+    'automation_manager_configuration_script_view'           => 'configuration_script_view',
+    'automation_manager_configuration_script_control'        => 'configuration_script_control',
+    'automation_manager_configuration_script_service_dialog' => 'configuration_script_service_dialog',
+    'automation_manager_configuration_script_tag'            => 'configuration_script_tag'
+  }.freeze
+
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjusting Configuration Script features for the non-explorer views' do
+      # Direct renaming of features
+      FEATURE_MAPPING.each do |from, to|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+
+  def down
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjust Configuration Script features to explorer views' do
+      FEATURE_MAPPING.each do |to, from|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+end

--- a/spec/migrations/20210218230058_update_configuration_script_features_spec.rb
+++ b/spec/migrations/20210218230058_update_configuration_script_features_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe UpdateConfigurationScriptFeatures do
+  let(:user_role_id) { anonymous_class_with_id_regions.id_in_region(1, anonymous_class_with_id_regions.my_region_number) }
+  let(:feature_stub) { migration_stub :MiqProductFeature }
+  let(:roles_feature_stub) { migration_stub :MiqRolesFeature }
+
+  migration_context :up do
+    describe 'product features renaming' do
+      it 'renames the features' do
+        UpdateConfigurationScriptFeatures::FEATURE_MAPPING.keys.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+          roles_feature_stub.create!(:miq_product_feature_id => feature.id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        UpdateConfigurationScriptFeatures::FEATURE_MAPPING.values.each do |identifier|
+          expect(feature_stub.find_by_identifier(identifier)).to be_truthy
+        end
+      end
+    end
+  end
+
+  migration_context :down do
+    describe 'product features revert' do
+      it 'reverts the configuration script explorer features' do
+        UpdateConfigurationScriptFeatures::FEATURE_MAPPING.values.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+          roles_feature_stub.create!(:miq_product_feature_id => feature.id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        UpdateConfigurationScriptFeatures::FEATURE_MAPPING.keys.each do |identifier|
+          expect(feature_stub.find_by_identifier(identifier)).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These changes support moving of Templates accordion out of Automation/Ansible Tower explorer to be it's own new de-explorized screen.

for https://github.com/ManageIQ/manageiq/pull/21065 & https://github.com/ManageIQ/manageiq-ui-classic/pull/7638

@miq-bot add_reviewer @gtanzillo @Fryguy 
@miq-bot add_label enhancement