### PR TITLE
Data migrations for Ansible Tower De-explorization

### DIFF
--- a/db/migrate/20210315161215_update_automation_provider_features.rb
+++ b/db/migrate/20210315161215_update_automation_provider_features.rb
@@ -1,0 +1,38 @@
+class UpdateAutomationProviderFeatures < ActiveRecord::Migration[6.0]
+  class MiqProductFeature < ActiveRecord::Base; end
+  class MiqRolesFeature < ActiveRecord::Base; end
+
+  FEATURE_MAPPING = {
+    'automation_manager'                   => 'ems_automation',
+    'automation_manager_admin'             => 'ems_automation_admin',
+    'automation_manager_resume'            => 'ems_automation_resume',
+    'automation_manager_providers_view'    => 'ems_automation_view',
+    'automation_manager_delete_provider'   => 'ems_automation_delete_provider',
+    'automation_manager_edit_provider'     => 'ems_automation_edit_provider',
+    'automation_manager_pause'             => 'ems_automation_pause',
+    'automation_manager_providers_control' => 'ems_automation_control',
+    'automation_manager_refresh_provider'  => 'ems_automation_refresh_provider',
+    'automation_manager_provider_tag'      => 'ems_automation_tag'
+  }.freeze
+
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjusting Automation Provider features for the non-explorer views' do
+      # Direct renaming of features
+      FEATURE_MAPPING.each do |from, to|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+
+  def down
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjust Automation Provider features to explorer views' do
+      FEATURE_MAPPING.each do |to, from|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+end

--- a/db/migrate/20210315161230_update_automation_provider_startpage.rb
+++ b/db/migrate/20210315161230_update_automation_provider_startpage.rb
@@ -1,0 +1,25 @@
+class UpdateAutomationProviderStartpage < ActiveRecord::Migration[6.0]
+  class User < ActiveRecord::Base
+    serialize :settings, Hash
+  end
+
+  def up
+    say_with_time 'Updating start page for users who had Ansible Tower explorer set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'automation_manager/explorer'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'ems_automation/show_list'}))
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Reverting start page for users who had non-explorer Ansible Tower pages set' do
+      User.select(:id, :settings).each do |user|
+        if user.settings&.dig(:display, :startpage) == 'ems_automation/show_list'
+          user.update!(:settings => user.settings.deep_merge(:display => {:startpage => 'automation_manager/explorer'}))
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210315161241_update_automation_provider_user_roles.rb
+++ b/db/migrate/20210315161241_update_automation_provider_user_roles.rb
@@ -1,0 +1,58 @@
+class UpdateAutomationProviderUserRoles < ActiveRecord::Migration[6.0]
+  class MiqUserRole < ActiveRecord::Base
+    has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features, :class_name => "UpdateAutomationProviderUserRoles::MiqProductFeature"
+  end
+
+  class MiqProductFeature < ActiveRecord::Base; end
+
+  def up
+    say_with_time "Correcting user created role feature sets" do
+      automation_manager                   = MiqProductFeature.find_by(:identifier => "automation_manager")
+      ems_automation                       = MiqProductFeature.find_by(:identifier => "ems_automation")
+      automation_manager_configured_system = MiqProductFeature.find_by(:identifier => "automation_manager_configured_system")
+      configuration_script                 = MiqProductFeature.find_by(:identifier => "configuration_script")
+
+      affected_user_roles.each do |user_role|
+        if user_role.miq_product_features.include?(automation_manager)
+          user_role.miq_product_features << ems_automation
+          user_role.miq_product_features << automation_manager_configured_system
+          user_role.miq_product_features << configuration_script
+          user_role.miq_product_features.delete(automation_manager)
+        end
+
+        user_role.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time "Reverting user created role feature sets" do
+      automation_manager                   = MiqProductFeature.find_by(:identifier => "automation_manager")
+      ems_automation                       = MiqProductFeature.find_by(:identifier => "ems_automation")
+      automation_manager_configured_system = MiqProductFeature.find_by(:identifier => "automation_manager_configured_system")
+      configuration_script                 = MiqProductFeature.find_by(:identifier => "configuration_script")
+
+      %w(ems_automation automation_manager_configured_system configuration_script).each do |feature|
+        roles_to_revert(feature).each do |user_role|
+          user_role.miq_product_features.delete(ems_automation) if user_role.miq_product_features.include?(ems_automation)
+          user_role.miq_product_features.delete(automation_manager_configured_system) if user_role.miq_product_features.include?(automation_manager_configured_system)
+          user_role.miq_product_features.delete(configuration_script) if user_role.miq_product_features.include?(configuration_script)
+          user_role.miq_product_features << automation_manager
+          user_role.save!
+        end
+        end
+    end
+  end
+
+  def roles_to_revert(feature)
+    MiqUserRole
+      .includes(:miq_product_features)
+      .where(:read_only => false, :miq_product_features => {:identifier => feature})
+  end
+
+  def affected_user_roles
+    MiqUserRole
+      .includes(:miq_product_features)
+      .where(:read_only => false, :miq_product_features => {:identifier => %w(automation_manager)})
+  end
+end

--- a/spec/migrations/20210315161215_update_automation_provider_features_spec.rb
+++ b/spec/migrations/20210315161215_update_automation_provider_features_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe UpdateAutomationProviderFeatures do
+  let(:user_role_id) { anonymous_class_with_id_regions.id_in_region(1, anonymous_class_with_id_regions.my_region_number) }
+  let(:feature_stub) { migration_stub :MiqProductFeature }
+  let(:roles_feature_stub) { migration_stub :MiqRolesFeature }
+
+  migration_context :up do
+    describe 'product features renaming' do
+      it 'renames the features' do
+        UpdateAutomationProviderFeatures::FEATURE_MAPPING.keys.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+          roles_feature_stub.create!(:miq_product_feature_id => feature.id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        UpdateAutomationProviderFeatures::FEATURE_MAPPING.values.each do |identifier|
+          expect(feature_stub.find_by_identifier(identifier)).to be_truthy
+        end
+      end
+    end
+  end
+
+  migration_context :down do
+    describe 'product features revert' do
+      it 'reverts the Ansible Tower Provider explorer features' do
+        UpdateAutomationProviderFeatures::FEATURE_MAPPING.values.each do |identifier|
+          feature = feature_stub.create!(:identifier => identifier)
+          roles_feature_stub.create!(:miq_product_feature_id => feature.id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        UpdateAutomationProviderFeatures::FEATURE_MAPPING.keys.each do |identifier|
+          expect(feature_stub.find_by_identifier(identifier)).to be_truthy
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20210315161230_update_automation_provider_startpage_spec.rb
+++ b/spec/migrations/20210315161230_update_automation_provider_startpage_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe UpdateAutomationProviderStartpage do
+  let(:user_stub) { migration_stub :User }
+
+  migration_context :up do
+    describe 'starting page update' do
+      it 'update user start page if automation_manager/explorer' do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'automation_manager/explorer'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('ems_automation/show_list')
+      end
+    end
+
+    it "user start page remains unchanged if it is set to some other url" do
+      user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+      migrate
+      user.reload
+
+      expect(user.settings[:display][:startpage]).to eq('host/show_list')
+    end
+
+    it 'does not affect users without settings' do
+      user = user_stub.create!
+
+      migrate
+
+      expect(user_stub.find(user.id)).to eq(user)
+    end
+  end
+
+  migration_context :down do
+    describe 'revert start page' do
+      it "reverts user start page to automation_manager/explorer from mes_automation/show_list" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'ems_automation/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('automation_manager/explorer')
+      end
+
+      it "user start page remains unchanged if it is set to some other url" do
+        user = user_stub.create!(:settings => {:display => {:startpage => 'host/show_list'}})
+
+        migrate
+        user.reload
+
+        expect(user.settings[:display][:startpage]).to eq('host/show_list')
+      end
+
+      it 'does not affect users without settings' do
+        user = user_stub.create!
+
+        migrate
+
+        expect(user_stub.find(user.id)).to eq(user)
+      end
+    end
+  end
+end

--- a/spec/migrations/20210315161241_update_automation_provider_user_roles_spec.rb
+++ b/spec/migrations/20210315161241_update_automation_provider_user_roles_spec.rb
@@ -1,0 +1,94 @@
+require_migration
+
+describe UpdateAutomationProviderUserRoles do
+  migration_context :up do
+    let(:user_role_stub) { migration_stub(:MiqUserRole) }
+    let(:product_feature_stub) { migration_stub(:MiqProductFeature) }
+
+    it "adds 'ems_automation', 'automation_manager_configured_system' and 'configuration_script' to user roles product features with 'automation_manager'" do
+      ems_automation = product_feature_stub.create!(
+        :name         => "Automation Providers Access Rules",
+        :description  => "Access Rules for Automation Providers",
+        :feature_type => "node",
+        :identifier   => "ems_automation"
+      )
+      automation_manager_configured_system = product_feature_stub.create!(
+        :name         => "Configured Systems Access Rules",
+        :description  => "Access Rules for Configured Systems",
+        :feature_type => "node",
+        :identifier   => "automation_manager_configured_system"
+      )
+      configuration_script = product_feature_stub.create!(
+        :name         => "Templates Access Rules",
+        :description  => "Access Rules for Templates",
+        :feature_type => "node",
+        :identifier   => "configuration_script"
+      )
+      automation_manager = product_feature_stub.create!(
+        :name         => "Ansible Tower Explorer",
+        :description  => "Ansible Tower Views",
+        :feature_type => "node",
+        :identifier   => "automation_manager"
+      )
+      user_role = user_role_stub.create!(:miq_product_features => [automation_manager], :read_only => false)
+
+      expect(user_role.miq_product_features).not_to include(ems_automation)
+      expect(user_role.miq_product_features).not_to include(automation_manager_configured_system)
+      expect(user_role.miq_product_features).not_to include(configuration_script)
+
+      migrate
+      user_role.reload
+
+      expect(user_role.miq_product_features).not_to include(automation_manager)
+      expect(user_role.miq_product_features).to include(ems_automation)
+      expect(user_role.miq_product_features).to include(automation_manager_configured_system)
+      expect(user_role.miq_product_features).to include(configuration_script)
+    end
+  end
+
+  migration_context :down do
+    let(:user_role_stub) { migration_stub(:MiqUserRole) }
+    let(:product_feature_stub) { migration_stub(:MiqProductFeature) }
+
+    it "removes 'ems_automation', 'automation_manager_configured_system' and 'configuration_script' from user roles product features and adds 'automation_manager'" do
+      ems_automation = product_feature_stub.create!(
+        :name         => "Automation Providers Access Rules",
+        :description  => "Access Rules for Automation Providers",
+        :feature_type => "node",
+        :identifier   => "ems_automation"
+      )
+      automation_manager_configured_system = product_feature_stub.create!(
+        :name         => "Configured Systems Access Rules",
+        :description  => "Access Rules for Configured Systems",
+        :feature_type => "node",
+        :identifier   => "automation_manager_configured_system"
+      )
+      configuration_script = product_feature_stub.create!(
+        :name         => "Templates Access Rules",
+        :description  => "Access Rules for Templates",
+        :feature_type => "node",
+        :identifier   => "configuration_script"
+      )
+      automation_manager = product_feature_stub.create!(
+        :name         => "Ansible Tower Explorer",
+        :description  => "Ansible Tower Views",
+        :feature_type => "node",
+        :identifier   => "automation_manager"
+      )
+      user_role = user_role_stub.create!(:miq_product_features => [ems_automation, automation_manager_configured_system, configuration_script], :read_only => false)
+
+      expect(user_role.miq_product_features).to include(ems_automation)
+      expect(user_role.miq_product_features).to include(automation_manager_configured_system)
+      expect(user_role.miq_product_features).to include(configuration_script)
+      expect(user_role.miq_product_features).not_to include(automation_manager)
+
+      migrate
+      user_role.reload
+
+      expect(user_role.miq_product_features).to include(automation_manager)
+      expect(user_role.miq_product_features).not_to include(ems_automation)
+      expect(user_role.miq_product_features).not_to include(automation_manager_configured_system)
+      expect(user_role.miq_product_features).not_to include(configuration_script)
+    end
+  end
+end


### PR DESCRIPTION
- Data migration to support feature renaming
- Data migration to support updated startpage url
- Data migration to support OOTB user roles updates to add all 3 new de-explorized screens instead of unified Ansible Tower Explorer feature
Core [PR](https://github.com/ManageIQ/manageiq/pull/21108)