### PR TITLE
Add ems_ref to authentications table.

### DIFF
--- a/db/migrate/20210317135305_add_ems_ref_to_authentications.rb
+++ b/db/migrate/20210317135305_add_ems_ref_to_authentications.rb
@@ -1,0 +1,5 @@
+class AddEmsRefToAuthentications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :authentications, :ems_ref, :string
+  end
+end


### PR DESCRIPTION
Used for storing UUID of SSH keys in IBM Cloud VPC.