### PR TITLE
Add Shared property to NetworkService

### DIFF
--- a/db/migrate/20210329120600_add_shared_to_network_service.rb
+++ b/db/migrate/20210329120600_add_shared_to_network_service.rb
@@ -1,0 +1,5 @@
+class AddSharedToNetworkService < ActiveRecord::Migration[6.0]
+  def change
+    add_column :network_services, :shared, :boolean
+  end
+end


### PR DESCRIPTION
Add Shared property to NetworkService so a Network Service can be made available for all tenants.