### PR TITLE
remove regular expressions from settings

### DIFF
--- a/db/migrate/20210330012001_remove_regex_from_settings.rb
+++ b/db/migrate/20210330012001_remove_regex_from_settings.rb
@@ -1,0 +1,12 @@
+class RemoveRegexFromSettings < ActiveRecord::Migration[6.0]
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  def up
+    say_with_time("Changing regexps in configurations") do
+      SettingsChange.where("value LIKE ?", "%!ruby/regexp%")
+                    .update_all("value = REGEXP_REPLACE(value, '!ruby/regexp ','','g')")
+    end
+  end
+end

--- a/spec/migrations/20210330012001_remove_regex_from_settings_spec.rb
+++ b/spec/migrations/20210330012001_remove_regex_from_settings_spec.rb
@@ -1,0 +1,20 @@
+require_migration
+
+describe RemoveRegexFromSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "converts regular expression object to a string" do
+      record = settings_change_stub.create!(
+        :resource_type => "MiqServer",
+        :key           => "/ems/ems_nuage/event_handling/event_groups/addition/critical",
+        :value         => ["/hello/","beautiful",/world/]
+
+      )
+      migrate
+
+      record.reload
+      expect(record.value).to eq(["/hello/","beautiful","/world/"])
+    end
+  end
+end


### PR DESCRIPTION
This is part of https://github.com/ManageIQ/manageiq/pull/20907

We are no longer using ruby regular expressions in our settings since these are not compatible with json.

Instead we are using strings with the format of regular expressions and converting into regular expressions where necessary.

There should not be any settings overrides of regular expressions but this is here just in case