### PR TITLE
[WIP] Fix Openstack Orchestration Stack subclass

### DIFF
--- a/db/migrate/20210419114541_fix_openstack_orchestration_stack_sti_class.rb
+++ b/db/migrate/20210419114541_fix_openstack_orchestration_stack_sti_class.rb
@@ -1,0 +1,22 @@
+class FixOpenstackOrchestrationStackStiClass < ActiveRecord::Migration[6.0]
+  class OrchestrationStack < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Fix Openstack OrchestrationStack STI class") do
+      OrchestrationStack.in_my_region
+                        .where(:type => "ManageIQ::Providers::CloudManager::OrchestrationStack")
+                        .update_all(:type => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack")
+    end
+  end
+
+  def down
+    say_with_time("Fix Openstack OrchestrationStack STI class") do
+      OrchestrationStack.in_my_region
+                        .where(:type => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack")
+                        .update_all(:type => "ManageIQ::Providers::CloudManager::OrchestrationStack")
+    end
+  end
+end

--- a/spec/migrations/20210419114541_fix_openstack_orchestration_stack_sti_class_spec.rb
+++ b/spec/migrations/20210419114541_fix_openstack_orchestration_stack_sti_class_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+RSpec.describe FixOpenstackOrchestrationStackStiClass do
+  let(:stack_stub) { migration_stub(:OrchestrationStack) }
+
+  migration_context :up do
+    it "Fixes the STI class of the OpenStack Orchestration Stacks" do
+      stack = stack_stub.create!(:type => "ManageIQ::Providers::CloudManager::OrchestrationStack")
+
+      migrate
+
+      expect(stack.reload.type).to eq("ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack")
+    end
+
+    it "Doesn't impact other Orchestration Stack types" do
+      stack = stack_stub.create!(:type => "ManageIQ::Providers::AwesomeCloud::CloudManager::OrchestrationStack")
+
+      migrate
+
+      expect(stack.reload.type).to eq("ManageIQ::Providers::AwesomeCloud::CloudManager::OrchestrationStack")
+    end
+  end
+
+  migration_context :down do
+    it "Reverts the STI class of the OpenStack Orchestration Stacks" do
+      stack = stack_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack")
+
+      migrate
+
+      expect(stack.reload.type).to eq("ManageIQ::Providers::CloudManager::OrchestrationStack")
+    end
+
+    it "Doesn't impact other Orchestration Stack types" do
+      stack = stack_stub.create!(:type => "ManageIQ::Providers::AwesomeCloud::CloudManager::OrchestrationStack")
+
+      migrate
+
+      expect(stack.reload.type).to eq("ManageIQ::Providers::AwesomeCloud::CloudManager::OrchestrationStack")
+    end
+  end
+end


### PR DESCRIPTION
Openstack isn't subclassing the OrchestrationStacks collected in inventory under their CloudManager.

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/711