### PR TITLE
Fix the namespace of Azure/AzureStack ResourceGroups

### DIFF
--- a/db/migrate/20210428122020_fix_resource_group_namespace.rb
+++ b/db/migrate/20210428122020_fix_resource_group_namespace.rb
@@ -1,0 +1,24 @@
+class FixResourceGroupNamespace < ActiveRecord::Migration[6.0]
+  class ResourceGroup < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    ResourceGroup.in_my_region
+                 .where(:type => "ManageIQ::Providers::Azure::ResourceGroup")
+                 .update_all(:type => "ManageIQ::Providers::Azure::CloudManager::ResourceGroup")
+    ResourceGroup.in_my_region
+                 .where(:type => "ManageIQ::Providers::AzureStack::ResourceGroup")
+                 .update_all(:type => "ManageIQ::Providers::AzureStack::CloudManager::ResourceGroup")
+  end
+
+  def down
+    ResourceGroup.in_my_region
+                 .where(:type => "ManageIQ::Providers::Azure::CloudManager::ResourceGroup")
+                 .update_all(:type => "ManageIQ::Providers::Azure::ResourceGroup")
+    ResourceGroup.in_my_region
+                 .where(:type => "ManageIQ::Providers::AzureStack::CloudManager::ResourceGroup")
+                 .update_all(:type => "ManageIQ::Providers::AzureStack::ResourceGroup")
+  end
+end

--- a/spec/migrations/20210428122020_fix_resource_group_namespace_spec.rb
+++ b/spec/migrations/20210428122020_fix_resource_group_namespace_spec.rb
@@ -1,0 +1,45 @@
+require_migration
+
+RSpec.describe FixResourceGroupNamespace do
+  let(:resource_group_stub) { migration_stub(:ResourceGroup) }
+
+  migration_context :up do
+    it "Updates the Azure and AzureStack Resource Groups" do
+      azure_resource_group       = resource_group_stub.create!(:type => "ManageIQ::Providers::Azure::ResourceGroup")
+      azure_stack_resource_group = resource_group_stub.create!(:type => "ManageIQ::Providers::AzureStack::ResourceGroup")
+
+      migrate
+
+      expect(azure_resource_group.reload.type).to       eq("ManageIQ::Providers::Azure::CloudManager::ResourceGroup")
+      expect(azure_stack_resource_group.reload.type).to eq("ManageIQ::Providers::AzureStack::CloudManager::ResourceGroup")
+    end
+
+    it "Doesn't impact other Resource Groups" do
+      resource_group = resource_group_stub.create!(:type => "ManageIQ::Providers::AwesomeCloud::CloudManager::ResourceGroup")
+
+      migrate
+
+      expect(resource_group.reload.type).to eq("ManageIQ::Providers::AwesomeCloud::CloudManager::ResourceGroup")
+    end
+  end
+
+  migration_context :down do
+    it "Updates the Azure and AzureStack Resource Groups" do
+      azure_resource_group       = resource_group_stub.create!(:type => "ManageIQ::Providers::Azure::CloudManager::ResourceGroup")
+      azure_stack_resource_group = resource_group_stub.create!(:type => "ManageIQ::Providers::AzureStack::CloudManager::ResourceGroup")
+
+      migrate
+
+      expect(azure_resource_group.reload.type).to       eq("ManageIQ::Providers::Azure::ResourceGroup")
+      expect(azure_stack_resource_group.reload.type).to eq("ManageIQ::Providers::AzureStack::ResourceGroup")
+    end
+
+    it "Doesn't impact other Resource Groups" do
+      resource_group = resource_group_stub.create!(:type => "ManageIQ::Providers::AwesomeCloud::CloudManager::ResourceGroup")
+
+      migrate
+
+      expect(resource_group.reload.type).to eq("ManageIQ::Providers::AwesomeCloud::CloudManager::ResourceGroup")
+    end
+  end
+end


### PR DESCRIPTION
These should belong to the CloudManager not live at the same level as the Managers under the vendor.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/457
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/63