### PR TITLE
Fix Redhat NetworkManager resource STI types

### DIFF
--- a/db/migrate/20210506225927_fix_redhat_network_manager_sti_type.rb
+++ b/db/migrate/20210506225927_fix_redhat_network_manager_sti_type.rb
@@ -1,0 +1,116 @@
+class FixRedhatNetworkManagerStiType < ActiveRecord::Migration[6.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudNetwork < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudSubnet < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class FloatingIp < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class NetworkPort < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class NetworkRouter < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class SecurityGroup < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Updating Redhat NetworkManager STI classes") do
+      redhat_network_managers = ExtManagementSystem.in_my_region.where(:type => "ManageIQ::Providers::Redhat::NetworkManager").pluck(:id)
+
+      CloudNetwork.in_my_region
+                  .where(:ems_id => redhat_network_managers)
+                  .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork")
+                  .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork")
+      CloudNetwork.in_my_region
+                  .where(:ems_id => redhat_network_managers)
+                  .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public")
+                  .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Public")
+      CloudNetwork.in_my_region
+                  .where(:ems_id => redhat_network_managers)
+                  .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private")
+                  .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Private")
+      CloudSubnet.in_my_region
+                 .where(:ems_id => redhat_network_managers)
+                 .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet")
+                 .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet")
+      FloatingIp.in_my_region
+                .where(:ems_id => redhat_network_managers)
+                .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::FloatingIp")
+                .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::FloatingIp")
+      NetworkPort.in_my_region
+                 .where(:ems_id => redhat_network_managers)
+                 .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::NetworkPort")
+                 .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::NetworkPort")
+      NetworkRouter.in_my_region
+                   .where(:ems_id => redhat_network_managers)
+                   .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter")
+                   .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::NetworkRouter")
+      SecurityGroup.in_my_region
+                   .where(:ems_id => redhat_network_managers)
+                   .where(:type => "ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup")
+                   .update_all(:type => "ManageIQ::Providers::Redhat::NetworkManager::SecurityGroup")
+    end
+  end
+
+  def down
+    say_with_time("Updating Redhat NetworkManager STI classes") do
+      redhat_network_managers =
+        ExtManagementSystem.in_my_region
+                           .where(:type => "ManageIQ::Providers::Redhat::NetworkManager").pluck(:id)
+
+      CloudNetwork.in_my_region
+                  .where(:ems_id => redhat_network_managers)
+                  .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork")
+                  .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork")
+      CloudNetwork.in_my_region
+                  .where(:ems_id => redhat_network_managers)
+                  .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Public")
+                  .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public")
+      CloudNetwork.in_my_region
+                  .where(:ems_id => redhat_network_managers)
+                  .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Private")
+                  .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private")
+      CloudSubnet.in_my_region
+                 .where(:ems_id => redhat_network_managers)
+                 .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet")
+                 .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet")
+      FloatingIp.in_my_region
+                .where(:ems_id => redhat_network_managers)
+                .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::FloatingIp")
+                .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::FloatingIp")
+      NetworkPort.in_my_region
+                 .where(:ems_id => redhat_network_managers)
+                 .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::NetworkPort")
+                 .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::NetworkPort")
+      NetworkRouter.in_my_region
+                   .where(:ems_id => redhat_network_managers)
+                   .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::NetworkRouter")
+                   .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter")
+      SecurityGroup.in_my_region
+                   .where(:ems_id => redhat_network_managers)
+                   .where(:type => "ManageIQ::Providers::Redhat::NetworkManager::SecurityGroup")
+                   .update_all(:type => "ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup")
+    end
+  end
+end

--- a/spec/migrations/20210506225927_fix_redhat_network_manager_sti_type_spec.rb
+++ b/spec/migrations/20210506225927_fix_redhat_network_manager_sti_type_spec.rb
@@ -1,0 +1,61 @@
+require_migration
+
+RSpec.describe FixRedhatNetworkManagerStiType do
+  let(:ems_stub)            { migration_stub(:ExtManagementSystem) }
+  let(:cloud_network_stub)  { migration_stub(:CloudNetwork) }
+  let(:cloud_subnet_stub)   { migration_stub(:CloudSubnet) }
+  let(:floating_ip_stub)    { migration_stub(:FloatingIp) }
+  let(:network_port_stub)   { migration_stub(:NetworkPort) }
+  let(:network_router_stub) { migration_stub(:NetworkRouter) }
+  let(:security_group_stub) { migration_stub(:SecurityGroup) }
+
+  migration_context :up do
+    it "Fixes the Ovirt NetworkManager inventory classes" do
+      redhat_network_manager = ems_stub.create!(:type => "ManageIQ::Providers::Redhat::NetworkManager")
+      cloud_network          = cloud_network_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork")
+      cloud_network_public   = cloud_network_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public")
+      cloud_network_private  = cloud_network_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private")
+      cloud_subnet           = cloud_subnet_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet")
+      floating_ip            = floating_ip_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::FloatingIp")
+      network_port           = network_port_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::NetworkPort")
+      network_router         = network_router_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter")
+      security_group         = security_group_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup")
+
+      migrate
+
+      expect(cloud_network.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork")
+      expect(cloud_network_public.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Public")
+      expect(cloud_network_private.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Private")
+      expect(cloud_subnet.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet")
+      expect(floating_ip.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::FloatingIp")
+      expect(network_port.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::NetworkPort")
+      expect(network_router.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::NetworkRouter")
+      expect(security_group.reload.type).to eq("ManageIQ::Providers::Redhat::NetworkManager::SecurityGroup")
+    end
+  end
+
+  migration_context :down do
+    it "Reverts the Ovirt NetworkManager inventory classes" do
+      redhat_network_manager = ems_stub.create!(:type => "ManageIQ::Providers::Redhat::NetworkManager")
+      cloud_network          = cloud_network_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork")
+      cloud_network_public   = cloud_network_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Public")
+      cloud_network_private  = cloud_network_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::CloudNetwork::Private")
+      cloud_subnet           = cloud_subnet_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::CloudSubnet")
+      floating_ip            = floating_ip_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::FloatingIp")
+      network_port           = network_port_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::NetworkPort")
+      network_router         = network_router_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::NetworkRouter")
+      security_group         = security_group_stub.create!(:ems_id => redhat_network_manager.id, :type => "ManageIQ::Providers::Redhat::NetworkManager::SecurityGroup")
+
+      migrate
+
+      expect(cloud_network.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork")
+      expect(cloud_network_public.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public")
+      expect(cloud_network_private.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private")
+      expect(cloud_subnet.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet")
+      expect(floating_ip.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::FloatingIp")
+      expect(network_port.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::NetworkPort")
+      expect(network_router.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter")
+      expect(security_group.reload.type).to eq("ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup")
+    end
+  end
+end


### PR DESCRIPTION
The Ovirt Refresher wasn't creating properly subclassed network_manager records, fixed by: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/559

TODO:
- [x] spec tests