### PR TITLE
replace miq_set relationships with miq_set_memberships table

### DIFF
--- a/db/migrate/20210519200613_add_miq_set_memberships.rb
+++ b/db/migrate/20210519200613_add_miq_set_memberships.rb
@@ -1,0 +1,10 @@
+class AddMiqSetMemberships < ActiveRecord::Migration[5.0]
+  def change
+    create_table :miq_set_memberships do |t|
+      t.belongs_to :member, :polymorphic => true, :type => :bigint
+      t.belongs_to :miq_set, :type => :bigint
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210519204247_move_miq_set_memberships.rb
+++ b/db/migrate/20210519204247_move_miq_set_memberships.rb
@@ -1,0 +1,69 @@
+class MoveMiqSetMemberships < ActiveRecord::Migration[5.0]
+  class Relationship < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  class MiqSetMembership < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Converting set relationships to miq_set_memberships") do
+      # The `ancestry` column holds the id for the `relationship` record that
+      # references the miq_set the parent record contains the miq_set object
+      #
+      # Because these are trivial trees (1 parent with 1 level of children),
+      # the `miq_set_id` can be derived from the `resource_id` of the parent
+      miq_set_id = "(SELECT rel2.resource_id FROM relationships rel2 WHERE rel2.id = rels.ancestry::bigint)"
+
+      connection.execute(<<-SQL.squish)
+        INSERT INTO miq_set_memberships (member_type, member_id, miq_set_id, created_at, updated_at)
+          SELECT rels.resource_type, rels.resource_id, #{miq_set_id}, rels.created_at, rels.updated_at
+          FROM relationships rels
+          WHERE rels.relationship = 'membership' AND rels.ancestry IS NOT NULL
+      SQL
+
+      Relationship.where(:relationship => "membership").delete_all
+    end
+  end
+
+  def down
+    say_with_time("Converting miq_set_memberships to set relationships") do
+      # Find the find the id for the `relationships` record that is from the
+      # 'membership' relationship, `miq_set_id` that matches the `resource_id`,
+      # and has a `ancestry` column value of NULL, all of which should be
+      # created in the first query.
+      ancestry_id = <<~ANCESTRY_ID.squish
+        (
+          SELECT rel2.id::varchar
+          FROM relationships rel2
+          WHERE rel2.relationship = 'membership'
+            AND rel2.resource_type = set_mem.member_type || 'Set'
+            AND rel2.resource_id = set_mem.miq_set_id
+            AND rel2.ancestry IS NULL
+          LIMIT 1
+        )
+      ANCESTRY_ID
+
+      # First Query:   Add root nodes (only if children exist)
+      connection.execute(<<~SQL.squish)
+        INSERT INTO relationships (relationship, resource_type, resource_id, ancestry, created_at, updated_at)
+          SELECT 'membership', set_mem.member_type || 'Set', set_mem.miq_set_id, NULL, set_mem.created_at, set_mem.updated_at
+          FROM miq_set_memberships set_mem
+          WHERE set_mem.miq_set_id IN (
+            SELECT set_mem_2.miq_set_id
+            FROM miq_set_memberships set_mem_2
+            GROUP BY set_mem_2.miq_set_id
+          );
+      SQL
+
+      # Second Query:  Add child nodes (based on root notes for ancestry column)
+      connection.execute(<<~SQL.squish)
+        INSERT INTO relationships (relationship, resource_type, resource_id, ancestry, created_at, updated_at)
+          SELECT 'membership', set_mem.member_type, set_mem.member_id, #{ancestry_id}, set_mem.created_at, set_mem.updated_at
+          FROM miq_set_memberships set_mem;
+      SQL
+
+      MiqSetMembership.delete_all
+    end
+  end
+end

--- a/spec/migrations/20210519204247_move_miq_set_memberships_spec.rb
+++ b/spec/migrations/20210519204247_move_miq_set_memberships_spec.rb
@@ -1,0 +1,133 @@
+require_migration
+
+# rubocop:disable Style/HashSyntax
+describe MoveMiqSetMemberships do
+  let(:rel_stub)        { migration_stub(:Relationship) }
+  let(:membership_stub) { migration_stub(:MiqSetMembership) }
+  let(:set_stub)        { Class.new(ActiveRecord::Base) { self.table_name = "miq_sets" } }
+  let(:item_stub)       { Class.new(ActiveRecord::Base) { self.table_name = "scan_items" } }
+  let(:rp_stub)         { Class.new(ActiveRecord::Base) { self.table_name = "resource_pools" } }
+
+  migration_context :up do
+    it 'converts relationship records to set membership table records' do
+      # Empty Set
+      set1 = set_stub.create!
+      create_rel(set1, resource_type: "ScanItemSet")
+
+      # Single Child
+      set2  = set_stub.create!
+      item1 = item_stub.create!
+
+      set2_rel = create_rel(set2, resource_type: "ScanItemSet")
+      create_rel(item1, ancestry: set2_rel.id.to_s)
+
+      # Multi Child (with shared child)
+      set3  = set_stub.create!
+      item2 = item_stub.create!
+      item3 = item_stub.create!
+      item4 = item_stub.create!
+
+      set3_rel = create_rel(set3, resource_type: "ScanItemSet")
+      create_rel(item1, ancestry: set3_rel.id.to_s)
+      create_rel(item2, ancestry: set3_rel.id.to_s)
+      create_rel(item3, ancestry: set3_rel.id.to_s)
+      create_rel(item4, ancestry: set3_rel.id.to_s)
+
+      # Extra non-MiqSet relations
+      create_resource_pool
+
+      migrate
+
+      membership1 = membership_stub.find_by(:member_id => item1.id, :miq_set_id => set2.id)
+      membership2 = membership_stub.find_by(:member_id => item1.id, :miq_set_id => set3.id)
+      membership3 = membership_stub.find_by(:member_id => item2.id, :miq_set_id => set3.id)
+      membership4 = membership_stub.find_by(:member_id => item3.id, :miq_set_id => set3.id)
+      membership5 = membership_stub.find_by(:member_id => item4.id, :miq_set_id => set3.id)
+
+      expect(membership1).to have_attributes(:miq_set_id => set2.id, :member_type => "ScanItem")
+      expect(membership2).to have_attributes(:miq_set_id => set3.id, :member_type => "ScanItem")
+      expect(membership3).to have_attributes(:miq_set_id => set3.id, :member_type => "ScanItem")
+      expect(membership4).to have_attributes(:miq_set_id => set3.id, :member_type => "ScanItem")
+      expect(membership5).to have_attributes(:miq_set_id => set3.id, :member_type => "ScanItem")
+
+      # Total MiqSetMembership records after migration
+      expect(membership_stub.count).to eq(5)
+      # Remaining Membership relationships after migration
+      expect(rel_stub.where(:relationship => 'membership').count).to eq(0)
+      # Remaining ResourcePool relationships after migration
+      expect(rel_stub.count).to eq(2)
+    end
+  end
+
+  migration_context :down do
+    it 'converts set membership table records to relationship records' do
+      # Empty Set
+      set1 = set_stub.create!
+
+      # Single Child
+      set2  = set_stub.create!
+      item1 = item_stub.create!
+
+      membership_stub.create!(:miq_set_id => set2.id, :member_type => "ScanItem", :member_id => item1.id)
+
+      # Multi Child (with shared child)
+      set3  = set_stub.create!
+      item2 = item_stub.create!
+      item3 = item_stub.create!
+      item4 = item_stub.create!
+
+      membership_stub.create!(:miq_set_id => set3.id, :member_type => "ScanItem", :member_id => item1.id)
+      membership_stub.create!(:miq_set_id => set3.id, :member_type => "ScanItem", :member_id => item2.id)
+      membership_stub.create!(:miq_set_id => set3.id, :member_type => "ScanItem", :member_id => item3.id)
+      membership_stub.create!(:miq_set_id => set3.id, :member_type => "ScanItem", :member_id => item4.id)
+
+      # Extra non-MiqSet relations
+      create_resource_pool
+
+      migrate
+
+      # Ensure we now are back to 7 records.  3 parents and 5 children (one shared between 2 parents).
+      parent_rel1 = rel_stub.find_by(:resource_type => "ScanItemSet", :resource_id => set1.id, :ancestry => nil)
+      parent_rel2 = rel_stub.find_by(:resource_type => "ScanItemSet", :resource_id => set2.id, :ancestry => nil)
+      parent_rel3 = rel_stub.find_by(:resource_type => "ScanItemSet", :resource_id => set3.id, :ancestry => nil)
+      child_rel1  = rel_stub.find_by(:resource_type => "ScanItem", :resource_id => item1.id, :ancestry => parent_rel2.id.to_s)
+      child_rel2  = rel_stub.find_by(:resource_type => "ScanItem", :resource_id => item1.id, :ancestry => parent_rel3.id.to_s)
+      child_rel3  = rel_stub.find_by(:resource_type => "ScanItem", :resource_id => item2.id, :ancestry => parent_rel3.id.to_s)
+      child_rel4  = rel_stub.find_by(:resource_type => "ScanItem", :resource_id => item3.id, :ancestry => parent_rel3.id.to_s)
+      child_rel5  = rel_stub.find_by(:resource_type => "ScanItem", :resource_id => item4.id, :ancestry => parent_rel3.id.to_s)
+
+      # Won't get created since there was no members.  However, in the code,
+      # when `.add_member` is called, it will create one if it doesn't exist.
+      #
+      #   https://github.com/ManageIQ/manageiq/blob/470e8b42/lib/extensions/ar_miq_set.rb#L95-L98
+      #   https://github.com/ManageIQ/manageiq/blob/470e8b42/app/models/mixins/relationship_mixin.rb#L612
+      #
+      # expect(parent_rel1).to have_attributes(:relationship => "membership", :resource_type => "ScanItemSet", :ancestry => nil)
+
+      expect(parent_rel2).to have_attributes(:relationship => "membership", :resource_type => "ScanItemSet", :ancestry => nil)
+      expect(parent_rel3).to have_attributes(:relationship => "membership", :resource_type => "ScanItemSet", :ancestry => nil)
+      expect(child_rel1).to  have_attributes(:relationship => "membership", :resource_type => "ScanItem", :ancestry => parent_rel2.id.to_s)
+      expect(child_rel2).to  have_attributes(:relationship => "membership", :resource_type => "ScanItem", :ancestry => parent_rel3.id.to_s)
+      expect(child_rel3).to  have_attributes(:relationship => "membership", :resource_type => "ScanItem", :ancestry => parent_rel3.id.to_s)
+      expect(child_rel4).to  have_attributes(:relationship => "membership", :resource_type => "ScanItem", :ancestry => parent_rel3.id.to_s)
+      expect(child_rel5).to  have_attributes(:relationship => "membership", :resource_type => "ScanItem", :ancestry => parent_rel3.id.to_s)
+
+      expect(membership_stub.count).to eq(0)
+      expect(rel_stub.where(:relationship => 'ems_metadata').count).to eq(2)
+    end
+  end
+
+  def create_rel(resource, ancestry: nil, relationship: "membership", resource_type: "ScanItem")
+    rel_stub.create!(:relationship => relationship, :ancestry => ancestry, :resource_id => resource.id, :resource_type => resource_type)
+  end
+
+  def create_resource_pool
+    rp_stub.find_or_create_by!(:name => "large pool").tap do |resource_pool|
+      parent = create_rel(resource_pool, relationship: 'ems_metadata', resource_type: "ResourcePool")
+
+      sub_resource_pool = rp_stub.create!(:name => "kiddie pool")
+      create_rel(sub_resource_pool, ancestry: parent.id.to_s, relationship: 'ems_metadata', resource_type: "ResourcePool")
+    end
+  end
+end
+# rubocop:enable Style/HashSyntax

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -218,6 +218,7 @@ miq_scsi_luns
 miq_scsi_targets
 miq_searches
 miq_servers
+miq_set_memberships
 miq_sets
 miq_shortcuts
 miq_tasks


### PR DESCRIPTION
**Requires https://github.com/ManageIQ/manageiq/pull/21241**

This is a alternative to https://github.com/ManageIQ/manageiq-schema/pull/536 with some fixes.  Details below:


To mirror things properly in the `:down` of the second migration, it is required to execute 2 queries to add in the records back into the `relationships` table:

- First:   add in the root nodes for the relationships (parents)
- Second:  use the ids from those records to build the ancestry column for the child nodes

This was not done in the previous iteration of this ~~commit~~ PR, but has been updated to do so here.

Extra test cases have been added to ensure we are rebuilding the records properly, and that it only migrates the records we want moved (since I don't trust my SQL).