### PR TITLE
Migrate one more feature renamed previously

### DIFF
--- a/db/migrate/20210521192754_update_product_features_where_identifier_was_renamed_since_lasker.rb
+++ b/db/migrate/20210521192754_update_product_features_where_identifier_was_renamed_since_lasker.rb
@@ -1,0 +1,25 @@
+class UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker < ActiveRecord::Migration[6.0]
+  class MiqProductFeature < ActiveRecord::Base; end
+
+  FEATURE_MAPPING = {'automation_manager_add_provider' => 'ems_automation_add_provider'}.freeze
+
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjusting Automation Provider add provider feature' do
+      FEATURE_MAPPING.each do |from, to|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+
+  def down
+    return if MiqProductFeature.none?
+
+    say_with_time 'Adjusting Automation Provider add provider feature' do
+      FEATURE_MAPPING.each do |to, from|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+end

--- a/spec/migrations/20210521192754_update_product_features_where_identifier_was_renamed_since_lasker_spec.rb
+++ b/spec/migrations/20210521192754_update_product_features_where_identifier_was_renamed_since_lasker_spec.rb
@@ -1,0 +1,51 @@
+require_migration
+
+class UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker
+  class MiqRolesFeature < ActiveRecord::Base; end
+end
+
+describe UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker do
+  let(:user_role_id) { anonymous_class_with_id_regions.id_in_region(1, anonymous_class_with_id_regions.my_region_number) }
+  let(:feature_stub) { migration_stub :MiqProductFeature }
+  let(:roles_feature_stub) { migration_stub :MiqRolesFeature }
+
+  migration_context :up do
+    describe 'product features update' do
+      it "renamed features aren't removed from user roles" do
+        features = {}
+        UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker::FEATURE_MAPPING.each do |before, _|
+          features[before] = feature_stub.create!(:identifier => before)
+          roles_feature_stub.create!(:miq_product_feature_id => features[before].id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker::FEATURE_MAPPING.each do |before, after|
+          after_feature = features[before].reload
+          expect(after_feature.identifier).to eq(after)
+        end
+        expect(roles_feature_stub.where(:miq_user_role_id => user_role_id).count).to eq(features.keys.length)
+      end
+    end
+  end
+
+  migration_context :down do
+    describe 'product features update' do
+      it "renamed features aren't removed from user roles" do
+        features = {}
+        UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker::FEATURE_MAPPING.each do |_, after|
+          features[after] = feature_stub.create!(:identifier => after)
+          roles_feature_stub.create!(:miq_product_feature_id => features[after].id, :miq_user_role_id => user_role_id)
+        end
+
+        migrate
+
+        UpdateProductFeaturesWhereIdentifierWasRenamedSinceLasker::FEATURE_MAPPING.each do |before, after|
+          before_feature = features[after].reload
+          expect(before_feature.identifier).to eq(before)
+        end
+        expect(roles_feature_stub.where(:miq_user_role_id => user_role_id).count).to eq(features.keys.length)
+      end
+    end
+  end
+end


### PR DESCRIPTION
NOTE:  The PRs below are since lasker so this is needed only on master.

The product feature was renamed along with the others for de-explorization of ansible
tower in: https://github.com/ManageIQ/manageiq/pull/21108

The database migration in https://github.com/ManageIQ/manageiq-schema/pull/564
handled most of the renames but one feature was missed.

This commit handles automation_manager_add_provider => ems_automation_add_provider.