### PR TITLE
Enable ems_storage* feature if ems_block_storage* is enabled

### DIFF
--- a/db/migrate/20210601125525_ensure_ems_storage_features.rb
+++ b/db/migrate/20210601125525_ensure_ems_storage_features.rb
@@ -1,0 +1,40 @@
+class EnsureEmsStorageFeatures < ActiveRecord::Migration[6.0]
+  class MiqUserRole < ActiveRecord::Base
+    has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features, :class_name => "EnsureEmsStorageFeatures::MiqProductFeature"
+  end
+
+  class MiqProductFeature < ActiveRecord::Base
+    has_and_belongs_to_many :miq_user_roles, :join_table => :miq_roles_features, :class_name => "EnsureEmsStorageFeatures::MiqUserRole"
+  end
+
+  BLOCK_STORAGE_FEATURES = %w[ems_block_storage ems_block_storage_view ems_block_storage_show_list
+                              ems_block_storage_show ems_block_storage_timeline ems_block_storage_control
+                              ems_block_storage_tag ems_block_storage_protect ems_block_storage_refresh
+                              ems_block_storage_admin ems_block_storage_new ems_block_storage_edit
+                              ems_block_storage_delete].freeze
+  OBJECT_STORAGE_FEATURES = %w[ems_object_storage ems_object_storage_view ems_object_storage_show_list
+                               ems_object_storage_show ems_object_storage_timeline ems_object_storage_control
+                               ems_object_storage_tag ems_object_storage_protect ems_object_storage_refresh
+                               ems_object_storage_admin ems_object_storage_delete].freeze
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time("Enabling ems_storage* product features") do
+      block_storage_features = MiqProductFeature.where(:identifier => BLOCK_STORAGE_FEATURES + OBJECT_STORAGE_FEATURES)
+      block_storage_features.each do |block_storage_feature|
+        block_storage_feature_name = block_storage_feature.identifier
+        storage_feature_name       = block_storage_feature_name.gsub(/ems_(block|object)_/, 'ems_')
+
+        storage_feature = MiqProductFeature.find_by(:identifier => storage_feature_name)
+        next if storage_feature.nil?
+
+        block_storage_feature.miq_user_roles.each do |user_role|
+          next if user_role.miq_product_features.include?(storage_feature)
+
+          user_role.miq_product_features << storage_feature
+          user_role.save!
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210601125525_ensure_ems_storage_features.rb
+++ b/db/migrate/20210601125525_ensure_ems_storage_features.rb
@@ -29,6 +29,7 @@ class EnsureEmsStorageFeatures < ActiveRecord::Migration[6.0]
         next if storage_feature.nil?
 
         block_storage_feature.miq_user_roles.each do |user_role|
+          # Skip if the user already has the role enabled
           next if user_role.miq_product_features.include?(storage_feature)
 
           user_role.miq_product_features << storage_feature
@@ -37,4 +38,7 @@ class EnsureEmsStorageFeatures < ActiveRecord::Migration[6.0]
       end
     end
   end
+
+  # There is no down migration because there is no way to tell if the ems_storage_* features
+  # were enabled for a user previously or not.
 end

--- a/spec/migrations/20210601125525_ensure_ems_storage_features_spec.rb
+++ b/spec/migrations/20210601125525_ensure_ems_storage_features_spec.rb
@@ -1,0 +1,87 @@
+require_migration
+
+RSpec.describe EnsureEmsStorageFeatures do
+  migration_context :up do
+    let(:user_role_stub) { migration_stub(:MiqUserRole) }
+    let(:product_feature_stub) { migration_stub(:MiqProductFeature) }
+    let!(:ems_block_storage_view) do
+      product_feature_stub.create!(
+        :name         => "View",
+        :description  => "View Block Storage Managers",
+        :feature_type => "view",
+        :identifier   => "ems_block_storage_view"
+      )
+    end
+
+    let!(:ems_object_storage_view) do
+      product_feature_stub.create!(
+        :name         => "View",
+        :description  => "View Object Storage Managers",
+        :feature_type => "view",
+        :identifier   => "ems_object_storage_view"
+      )
+    end
+
+    let!(:ems_storage_view) do
+      product_feature_stub.create!(
+        :name         => "View",
+        :description  => "View Storage Managers",
+        :feature_type => "view",
+        :identifier   => "ems_storage_view"
+      )
+    end
+
+    it "adds ems_storage* feature if ems_block_storage* feature is enabled" do
+      user_role = user_role_stub.create!(
+        :miq_product_features => [ems_block_storage_view],
+        :read_only            => false
+      )
+
+      migrate
+
+      expect(user_role.reload.miq_product_features).to include(ems_storage_view)
+    end
+
+    it "adds ems_storage* feature if ems_object_storage* feature is enabled" do
+      user_role = user_role_stub.create!(
+        :miq_product_features => [ems_object_storage_view],
+        :read_only            => false
+      )
+
+      migrate
+
+      expect(user_role.reload.miq_product_features).to include(ems_storage_view)
+    end
+
+    it "doesn't duplicate if ems_storage* feature already enabled" do
+      user_role = user_role_stub.create!(
+        :miq_product_features => [ems_block_storage_view, ems_object_storage_view, ems_storage_view],
+        :read_only            => false
+      )
+
+      expect(user_role.miq_product_features).to match_array([ems_storage_view, ems_object_storage_view, ems_block_storage_view])
+
+      migrate
+
+      expect(user_role.reload.miq_product_features).to match_array([ems_storage_view, ems_object_storage_view, ems_block_storage_view])
+    end
+
+    it "skips user roles without any ems_(block|object)_storage* features" do
+      ems_cloud_view = product_feature_stub.create!(
+        :name         => "View",
+        :description  => "View Cloud Managers",
+        :feature_type => "view",
+        :identifier   => "ems_cloud_view"
+      )
+
+      user_role = user_role_stub.create!(
+        :miq_product_features => [ems_cloud_view],
+        :read_only            => false
+      )
+
+      migrate
+
+      expect(user_role.reload.miq_product_features).to match_array([ems_cloud_view])
+    end
+  end
+end


### PR DESCRIPTION
As we transition to combined storage managers we need to ensure anyone that had ems_block_storage* features enabled also has the equivalent ems_storage* feature on.

https://github.com/ManageIQ/manageiq-api/pull/1041
https://github.com/ManageIQ/manageiq-ui-classic/issues/7675