### PR TITLE
Update IBM Cloud 'vendor' attribute to 'ibm_cloud'

### DIFF
--- a/db/migrate/20210718074605_update_ibm_vendor_to_ibm_cloud.rb
+++ b/db/migrate/20210718074605_update_ibm_vendor_to_ibm_cloud.rb
@@ -1,0 +1,24 @@
+class UpdateIbmVendorToIbmCloud < ActiveRecord::Migration[6.0]
+  class Vm < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Updating vendor to "IBM Cloud" for VPC managers') do
+      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm').update_all(:vendor => 'ibm_cloud')
+    end
+    say_with_time('Updating vendor to "IBM Cloud" for PowerVirtualServer managers') do
+      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm').update_all(:vendor => 'ibm_cloud')
+    end
+  end
+
+  def down
+    say_with_time('Reverting vendor to "IBM" for VPC managers') do
+      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm').update_all(:vendor => 'ibm')
+    end
+    say_with_time('Reverting vendor to "IBM" for PowerVirtualServer managers') do
+      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm').update_all(:vendor => 'ibm')
+    end
+  end
+end

--- a/db/migrate/20210718074605_update_ibm_vendor_to_ibm_cloud.rb
+++ b/db/migrate/20210718074605_update_ibm_vendor_to_ibm_cloud.rb
@@ -1,24 +1,25 @@
 class UpdateIbmVendorToIbmCloud < ActiveRecord::Migration[6.0]
-  class Vm < ActiveRecord::Base
+  class VmOrTemplate < ActiveRecord::Base
     include ActiveRecord::IdRegions
     self.inheritance_column = :_type_disabled
+    self.table_name = 'vms'
   end
 
   def up
     say_with_time('Updating vendor to "IBM Cloud" for VPC managers') do
-      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm').update_all(:vendor => 'ibm_cloud')
+      VmOrTemplate.in_my_region.where(:type => %w[ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template]).update_all(:vendor => 'ibm_cloud')
     end
     say_with_time('Updating vendor to "IBM Cloud" for PowerVirtualServer managers') do
-      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm').update_all(:vendor => 'ibm_cloud')
+      VmOrTemplate.in_my_region.where(:type => %w[ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template]).update_all(:vendor => 'ibm_cloud')
     end
   end
 
   def down
     say_with_time('Reverting vendor to "IBM" for VPC managers') do
-      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm').update_all(:vendor => 'ibm')
+      VmOrTemplate.in_my_region.where(:type => %w[ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template]).update_all(:vendor => 'ibm')
     end
     say_with_time('Reverting vendor to "IBM" for PowerVirtualServer managers') do
-      Vm.in_my_region.where(:type => 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm').update_all(:vendor => 'ibm')
+      VmOrTemplate.in_my_region.where(:type => %w[ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template]).update_all(:vendor => 'ibm')
     end
   end
 end

--- a/spec/migrations/20210718074605_update_ibm_vendor_to_ibm_cloud_spec.rb
+++ b/spec/migrations/20210718074605_update_ibm_vendor_to_ibm_cloud_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe UpdateIbmVendorToIbmCloud do
       powervc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Vm", :vendor => "ibm_power_vc")
       powervc_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Template", :vendor => "ibm_power_vc")
 
-      openstack_vm = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Vm", :vendor => "ibm")
-      openstack_template = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Template", :vendor => "ibm")
+      openstack_vm = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Vm", :vendor => "openstack")
+      openstack_template = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Template", :vendor => "openstack")
 
       migrate
 
@@ -58,8 +58,8 @@ RSpec.describe UpdateIbmVendorToIbmCloud do
       expect(powervc_vm.reload).to have_attributes(:vendor => "ibm_power_vc")
       expect(powervc_template.reload).to have_attributes(:vendor => "ibm_power_vc")
 
-      expect(openstack_vm.reload).to have_attributes(:vendor => "ibm")
-      expect(openstack_template.reload).to have_attributes(:vendor => "ibm")
+      expect(openstack_vm.reload).to have_attributes(:vendor => "openstack")
+      expect(openstack_template.reload).to have_attributes(:vendor => "openstack")
     end
   end
 end

--- a/spec/migrations/20210718074605_update_ibm_vendor_to_ibm_cloud_spec.rb
+++ b/spec/migrations/20210718074605_update_ibm_vendor_to_ibm_cloud_spec.rb
@@ -1,29 +1,65 @@
 require_migration
 
 RSpec.describe UpdateIbmVendorToIbmCloud do
-  let(:vm_stub) { migration_stub(:Vm) }
+  let(:vm_stub) { migration_stub(:VmOrTemplate) }
 
   migration_context :up do
     it "updates vendor to 'ibm_cloud' for IBM Cloud managers" do
       vpc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm", :vendor => "ibm")
+      vpc_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template", :vendor => "ibm")
+
       powervs_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm", :vendor => "ibm")
+      powervs_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template", :vendor => "ibm")
+
+      powervc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Vm", :vendor => "ibm_power_vc")
+      powervc_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Template", :vendor => "ibm_power_vc")
+
+      openstack_vm = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Vm", :vendor => "ibm")
+      openstack_template = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Template", :vendor => "ibm")
 
       migrate
 
       expect(vpc_vm.reload).to have_attributes(:vendor => "ibm_cloud")
+      expect(vpc_template.reload).to have_attributes(:vendor => "ibm_cloud")
+
       expect(powervs_vm.reload).to have_attributes(:vendor => "ibm_cloud")
+      expect(powervs_template.reload).to have_attributes(:vendor => "ibm_cloud")
+
+      expect(powervc_vm.reload).to have_attributes(:vendor => "ibm_power_vc")
+      expect(powervc_template.reload).to have_attributes(:vendor => "ibm_power_vc")
+
+      expect(openstack_vm.reload).to have_attributes(:vendor => "ibm")
+      expect(openstack_template.reload).to have_attributes(:vendor => "ibm")
     end
   end
 
   migration_context :down do
     it "reverts vendor to 'ibm' for IBM Cloud managers" do
       vpc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm", :vendor => "ibm_cloud")
+      vpc_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template", :vendor => "ibm_cloud")
+
       powervs_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm", :vendor => "ibm_cloud")
+      powervs_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template", :vendor => "ibm_cloud")
+
+      powervc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Vm", :vendor => "ibm_power_vc")
+      powervc_template = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Template", :vendor => "ibm_power_vc")
+
+      openstack_vm = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Vm", :vendor => "ibm")
+      openstack_template = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Template", :vendor => "ibm")
 
       migrate
 
       expect(vpc_vm.reload).to have_attributes(:vendor => "ibm")
+      expect(vpc_template.reload).to have_attributes(:vendor => "ibm")
+
       expect(powervs_vm.reload).to have_attributes(:vendor => "ibm")
+      expect(powervs_template.reload).to have_attributes(:vendor => "ibm")
+
+      expect(powervc_vm.reload).to have_attributes(:vendor => "ibm_power_vc")
+      expect(powervc_template.reload).to have_attributes(:vendor => "ibm_power_vc")
+
+      expect(openstack_vm.reload).to have_attributes(:vendor => "ibm")
+      expect(openstack_template.reload).to have_attributes(:vendor => "ibm")
     end
   end
 end

--- a/spec/migrations/20210718074605_update_ibm_vendor_to_ibm_cloud_spec.rb
+++ b/spec/migrations/20210718074605_update_ibm_vendor_to_ibm_cloud_spec.rb
@@ -1,0 +1,29 @@
+require_migration
+
+RSpec.describe UpdateIbmVendorToIbmCloud do
+  let(:vm_stub) { migration_stub(:Vm) }
+
+  migration_context :up do
+    it "updates vendor to 'ibm_cloud' for IBM Cloud managers" do
+      vpc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm", :vendor => "ibm")
+      powervs_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm", :vendor => "ibm")
+
+      migrate
+
+      expect(vpc_vm.reload).to have_attributes(:vendor => "ibm_cloud")
+      expect(powervs_vm.reload).to have_attributes(:vendor => "ibm_cloud")
+    end
+  end
+
+  migration_context :down do
+    it "reverts vendor to 'ibm' for IBM Cloud managers" do
+      vpc_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm", :vendor => "ibm_cloud")
+      powervs_vm = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm", :vendor => "ibm_cloud")
+
+      migrate
+
+      expect(vpc_vm.reload).to have_attributes(:vendor => "ibm")
+      expect(powervs_vm.reload).to have_attributes(:vendor => "ibm")
+    end
+  end
+end


### PR DESCRIPTION
Since there are multiple IBM providers in ManageIQ (IBM Cloud, IBM
PowerVC) more descriptive 'vendor' values are needed to differentiate.