### PR TITLE
Remove rhn and rhms/satellite columns

### DIFF
--- a/db/migrate/20210720180318_remove_rh_subscription_columns.rb
+++ b/db/migrate/20210720180318_remove_rh_subscription_columns.rb
@@ -1,0 +1,43 @@
+class RemoveRhSubscriptionColumns < ActiveRecord::Migration[6.0]
+  def up
+    change_table "miq_servers" do |t|
+      t.remove "rh_registered"
+      t.remove "rh_subscribed"
+      t.remove "last_update_check"
+      t.remove "updates_available"
+      t.remove "upgrade_status"
+      t.remove "upgrade_message"
+    end
+
+    change_table "miq_databases" do |t|
+      t.remove "cfme_version_available"
+      t.remove "postgres_update_available"
+      t.remove "registration_type"
+      t.remove "registration_organization"
+      t.remove "registration_server"
+      t.remove "registration_http_proxy_server"
+      t.remove "registration_organization_display_name"
+    end
+  end
+
+  def down
+    change_table "miq_databases" do |t|
+      t.string "cfme_version_available"
+      t.boolean "postgres_update_available"
+      t.string "registration_type"
+      t.string "registration_organization"
+      t.string "registration_server"
+      t.string "registration_http_proxy_server"
+      t.string "registration_organization_display_name"
+    end
+
+    change_table "miq_servers" do |t|
+      t.boolean "rh_registered"
+      t.boolean "rh_subscribed"
+      t.string "last_update_check"
+      t.boolean "updates_available"
+      t.string "upgrade_status"
+      t.string "upgrade_message"
+    end
+  end
+end

--- a/db/migrate/20210726194608_delete_rhn_authentications.rb
+++ b/db/migrate/20210726194608_delete_rhn_authentications.rb
@@ -1,0 +1,12 @@
+class DeleteRhnAuthentications < ActiveRecord::Migration[6.0]
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("removing authentication records for Red Hat Network") do
+      Authentication.where(:authtype => %w[registration registration_http_proxy])
+                    .destroy_all
+    end
+  end
+end

--- a/db/migrate/20210810191933_remove_update_repo_names_from_settings.rb
+++ b/db/migrate/20210810191933_remove_update_repo_names_from_settings.rb
@@ -1,0 +1,11 @@
+class RemoveUpdateRepoNamesFromSettings < ActiveRecord::Migration[6.0]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("deleting update_repo_names that are no longer used") do
+      SettingsChange.where(:resource_type => "MiqRegion", :key => "/product/update_repo_names")
+                    .destroy_all
+    end
+  end
+end

--- a/spec/migrations/20210726194608_delete_rhn_authentications_spec.rb
+++ b/spec/migrations/20210726194608_delete_rhn_authentications_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe DeleteRhnAuthentications do
+  let(:authentication_stub) { migration_stub(:Authentication) }
+
+  migration_context :up do
+    it "deletes" do
+      authentication_stub.create!(:authtype => "registration")
+      authentication_stub.create!(:authtype => "registration_http_proxy")
+
+      migrate
+
+      expect(authentication_stub.count).to eq(0)
+    end
+
+    it "leaves" do
+      authentication_stub.create!(:authtype => "default")
+      authentication_stub.create!(:authtype => nil)
+
+      migrate
+
+      expect(authentication_stub.count).to eq(2)
+    end
+  end
+end

--- a/spec/migrations/20210810191933_remove_update_repo_names_from_settings_spec.rb
+++ b/spec/migrations/20210810191933_remove_update_repo_names_from_settings_spec.rb
@@ -1,0 +1,24 @@
+require_migration
+
+describe RemoveUpdateRepoNamesFromSettings do
+  let(:settings_change) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "deletes only desired key" do
+      settings_change.create!(:resource_type => "MiqRegion", :key => "/product/update_repo_names")
+
+      migrate
+
+      expect(settings_change.count).to eq(0)
+    end
+
+    it "leaves" do
+      settings_change.create!(:resource_type => "MiqRegion", :key => "/product/keep_me")
+      settings_change.create!(:resource_type => "MiqServer", :key => "/product/keep_me_too")
+
+      migrate
+
+      expect(settings_change.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/issues/5547

rhn went away in 2017 and we are no longer supporting satellite:

- Removing the columns that were used by the update manager and the subscription manager
- remove rhn and proxy authentication credentials
- remove setting for `update_repo_name`