### PR TITLE
Add spec generator for migration generator

### DIFF
--- a/lib/generators/migration/migration_generator.rb
+++ b/lib/generators/migration/migration_generator.rb
@@ -1,0 +1,52 @@
+require 'rails/generators/active_record/migration/migration_generator'
+
+# Overwrites the default `ActiveRecord::Generators::MigrationGenerator` to
+# include our own spec file for each migration generated.
+#
+module ManageIQ::Schema
+  class MigrationGenerator < ActiveRecord::Generators::MigrationGenerator
+    # Using both `source_root` (standard) and `source_paths` here so that we
+    # can default to the rails sources for the `migration.rb` template, but
+    # then use our own for the `migration_spec.rb` file.
+    source_root ActiveRecord::Generators::MigrationGenerator.source_root
+    source_paths << File.expand_path('templates', __dir__)
+
+    # Overwrite the defaulted generated .namespace method so that this class is
+    # found as the `migration` class.
+    #
+    # Some Thor/Rails magic happeninghere ... but basically it allows this to
+    # overwrite and work properly
+    #
+    def self.namespace(name = nil)
+      return super if name
+
+      "migration"
+    end
+
+    def self.miq_schema_root
+      ManageIQ::Schema::Engine.root
+    end
+
+    # Overwrites the default method to do the original code, but then also
+    # generate the spec file.
+    def create_migration_file
+      super
+
+      migration_template("migration_spec.rb", File.join(spec_dir, "#{file_name}_spec.rb"))
+    end
+
+    private
+
+    def db_migrate_path
+      self.class.miq_schema_root.join("db", "migrate")
+    end
+
+    def spec_dir
+      self.class.miq_schema_root.join("spec", "migrations")
+    end
+
+    def spec_class_name
+      migration_class_name.sub(/Spec$/, "")
+    end
+  end
+end

--- a/lib/generators/migration/templates/migration_spec.rb.tt
+++ b/lib/generators/migration/templates/migration_spec.rb.tt
@@ -1,0 +1,39 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe <%= spec_class_name %> do
+  # let(:my_model_stub) { migration_stub(:MyModel) }
+
+  migration_context :up do
+    # Create data
+    #
+    # Example:
+    #
+    #   my_model_stub.create!(attributes)
+
+    migrate
+
+    # Ensure data exists
+    #
+    # Example:
+    #
+    #   expect(record).to have_attributes()
+  end
+
+  migration_context :down do
+    # Create data
+    #
+    # Example:
+    #
+    #   my_model_stub.create!(attributes)
+
+    migrate
+
+    # Ensure data exists
+    #
+    # Example:
+    #
+    #   expect(MyModel.count).to eq(0)
+  end
+end

--- a/spec/lib/generators/migration_generator_spec.rb
+++ b/spec/lib/generators/migration_generator_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'rails/generators/test_case'
+require 'generators/migration/migration_generator'
+
+describe ManageIQ::Schema::MigrationGenerator do
+  include Rails::Generators::Testing::Behaviour
+  include Rails::Generators::Testing::SetupAndTeardown
+  include Rails::Generators::Testing::Assertions
+  include FileUtils
+
+  tests       ManageIQ::Schema::MigrationGenerator
+  destination Rails.root.join('tmp/generators')
+
+  before do
+    prepare_destination
+    allow(described_class).to receive(:miq_schema_root).and_return(destination_root)
+  end
+
+  let(:migration_name)     { "my_test_migration" }
+  let(:migration_path)     { File.join("db", "migrate", migration_name) }
+  let(:migration_filename) { migration_file_name(migration_path) }
+  let(:spec_path)          { File.join("spec", "migrations", migration_name) }
+  let(:spec_filename)      { migration_filename.sub(/db\/migrate/, "spec/migrations").sub(".rb", "_spec.rb") }
+
+  it "runs the generator without errors" do
+    expect { run_generator [migration_name] }.not_to raise_error
+  end
+
+  it "creates both a migration file and migration spec" do
+    run_generator [migration_name]
+
+    expect(migration_filename).to_not be_nil
+    expect(spec_filename).to_not      be_nil
+    expect(File.exist?(migration_filename)).to be_truthy
+    expect(File.exist?(spec_filename)).to      be_truthy
+  end
+
+  it "uses content from rails for for migration" do
+    run_generator [migration_name]
+
+    content = File.read(migration_filename)
+    expect(content).to include("class MyTestMigration < ActiveRecord::Migration")
+    expect(content).to include("def change")
+  end
+
+  it "uses content from manageiq-scheme for for spec" do
+    run_generator [migration_name]
+
+    content = File.read(spec_filename)
+    expect(content).to include("describe MyTestMigration")
+    expect(content).to include("  # let(:my_model_stub) { migration_stub(:MyModel) }")
+    expect(content).to include("    # Example").exactly(4).times
+    expect(content).to include("    #   my_model_stub.create!(attributes)").twice
+  end
+end


### PR DESCRIPTION
Overwrites `rails generate migration` to allow a spec file to be generated when a migration is generated with the same file name.

QA
--

To test, you can run something like the following:

```ruby
$ bin/rails g migration foo_bar_baz -p
      create  db/migrate/20210727212808_foo_bar_baz.rb
      create  spec/migrations/20210727212808_foo_bar_baz_spec.rb
```

And just validate that the file names are as you would expect.  To validate the files are created properly, just remove the `-p` argument:

```ruby
$ bin/rails g migration test_two
      create  db/migrate/20210727213008_test_two.rb
      create  spec/migrations/20210727213008_test_two_spec.rb
```

Closes https://github.com/ManageIQ/manageiq-schema/issues/479