### PR TITLE
Remove unused column old_ems_id from multiple container tables

### DIFF
--- a/db/migrate/20210728143006_remove_old_ems_id_from_container_tables.rb
+++ b/db/migrate/20210728143006_remove_old_ems_id_from_container_tables.rb
@@ -1,0 +1,9 @@
+class RemoveOldEmsIdFromContainerTables < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :containers,         :old_ems_id, :bigint
+    remove_column :container_groups,   :old_ems_id, :bigint
+    remove_column :container_images,   :old_ems_id, :bigint
+    remove_column :container_nodes,    :old_ems_id, :bigint
+    remove_column :container_projects, :old_ems_id, :bigint
+  end
+end


### PR DESCRIPTION
Seems to be the last part of https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/196

This [GitHub search](https://github.com/search?q=org%3AManageIQ+old_ems_id&type=code) shows it is no longer used.