### PR TITLE
Modify host initiators listing page

### DIFF
--- a/db/migrate/20210726060426_add_fields_to_host_initiators.rb
+++ b/db/migrate/20210726060426_add_fields_to_host_initiators.rb
@@ -1,0 +1,6 @@
+class AddFieldsToHostInitiators < ActiveRecord::Migration[6.0]
+  def change
+    add_column :host_initiators, :status, :string
+    add_column :host_initiators, :host_cluster_name, :string
+  end
+end


### PR DESCRIPTION
two fields were added to host initiators listing page:
- status
- host_cluster_name

![Screenshot 2021-07-28 150036](https://user-images.githubusercontent.com/53213107/127433149-73563b89-76a4-44a7-a69f-00967c7eb647.jpg)

links
-----
https://github.com/ManageIQ/manageiq-providers-autosde/pull/73 - need to be merged after this PR
https://github.com/ManageIQ/manageiq-ui-classic/pull/7803 - need to be merged after this PR