### PR TITLE
Add `#options` to Endpoints

### DIFF
--- a/db/migrate/20210729132849_add_options_to_endpoints.rb
+++ b/db/migrate/20210729132849_add_options_to_endpoints.rb
@@ -1,0 +1,5 @@
+class AddOptionsToEndpoints < ActiveRecord::Migration[6.0]
+  def change
+    add_column :endpoints, :options, :jsonb, :default => {}
+  end
+end


### PR DESCRIPTION
Some data for an endpoint doesn't always fit in just the URL properties, an extra options jsonb column can be used to store endpoint-related info that isn't strictly about the URL.