### PR TITLE
SDE-1726_add_wwpn_candidates

### DIFF
--- a/db/migrate/20210801104200_create_storage_hosts_wwpn_candidates.rb
+++ b/db/migrate/20210801104200_create_storage_hosts_wwpn_candidates.rb
@@ -1,0 +1,14 @@
+class CreateStorageHostsWwpnCandidates < ActiveRecord::Migration[6.0]
+  def change
+    create_table :storage_hosts_wwpn_candidates do |t|
+      # stores WWPN candidate
+      t.string :candidate
+
+      t.string :ems_ref
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :physical_storage, :type => :bigint, :index => true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210925144400_create_wwpn_candidates.rb
+++ b/db/migrate/20210925144400_create_wwpn_candidates.rb
@@ -1,6 +1,6 @@
-class CreateStorageHostsWwpnCandidates < ActiveRecord::Migration[6.0]
+class CreateWwpnCandidates < ActiveRecord::Migration[6.0]
   def change
-    create_table :storage_hosts_wwpn_candidates do |t|
+    create_table :wwpn_candidates do |t|
       # stores WWPN candidate
       t.string :candidate
 

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -309,6 +309,7 @@ showback_rates
 showback_tiers
 snapshots
 storage_files
+storage_hosts_wwpn_candidates
 storage_profile_storages
 storage_profiles
 storage_resources

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -309,7 +309,6 @@ showback_rates
 showback_tiers
 snapshots
 storage_files
-storage_hosts_wwpn_candidates
 storage_profile_storages
 storage_profiles
 storage_resources
@@ -335,4 +334,5 @@ vms
 volume_mappings
 volumes
 windows_images
+wwpn_candidates
 zones


### PR DESCRIPTION
When creating host initiator, for FC ports, we need to fill in wwpn
So-called wwpn candidates will be populated to help make a choice