### PR TITLE
Convert NetworkRouter#admin_state_up from varchar to boolean

### DIFF
--- a/db/migrate/20210819145618_update_network_router_admin_state_up.rb
+++ b/db/migrate/20210819145618_update_network_router_admin_state_up.rb
@@ -1,0 +1,20 @@
+class UpdateNetworkRouterAdminStateUp < ActiveRecord::Migration[6.0]
+  class NetworkRouter < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    change_column :network_routers, :admin_state_up,
+      "BOOLEAN USING COALESCE(admin_state_up::BOOLEAN, FALSE)"
+
+    change_column_default :network_routers, :admin_state_up, false
+    change_column_null :network_routers, :admin_state_up, false
+  end
+
+  def down
+    change_column_null :network_routers, :admin_state_up, true
+    change_column_default :network_routers, :admin_state_up, nil
+
+    change_column :network_routers, :admin_state_up, "varchar"
+  end
+end

--- a/spec/migrations/20210819145618_update_network_router_admin_state_up_spec.rb
+++ b/spec/migrations/20210819145618_update_network_router_admin_state_up_spec.rb
@@ -1,0 +1,191 @@
+require_migration
+
+# conversions and reloading the schema were causing problems
+# that is why there are so many entries here
+describe UpdateNetworkRouterAdminStateUp do
+  let(:network_router_stub) { migration_stub(:NetworkRouter) }
+
+  migration_context :up do
+    context "conversion" do
+      it "converts to boolean" do
+        record = network_router_stub.create!(:admin_state_up => false)
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to be_kind_of(FalseClass)
+      end
+
+      it "converts null to false" do
+        record = network_router_stub.create!
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(nil)
+
+        migrate
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(false)
+      end
+
+      it "converts false to false" do
+        record = network_router_stub.create!(:admin_state_up => false)
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq('f')
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(false)
+      end
+
+      it "converts 'false' to false" do
+        record = network_router_stub.create!(:admin_state_up => 'false')
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(false)
+      end
+
+      it "converts 'f' to false" do
+        record = network_router_stub.create!(:admin_state_up => 'f')
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(false)
+      end
+
+      it "converts 'true' to true" do
+        record = network_router_stub.create!(:admin_state_up => 'true')
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(true)
+      end
+
+      it "converts true to true" do
+        record = network_router_stub.create!(:admin_state_up => true)
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq('t')
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(true)
+      end
+
+      it "converts 't' to true" do
+        record = network_router_stub.create!(:admin_state_up => 't')
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq('t')
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(true)
+      end
+    end
+
+    it "defaults to false" do
+      migrate
+      record = network_router_stub.create!
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq(false)
+    end
+
+    it "doesn't support nil" do
+      migrate
+      expect do
+        record = network_router_stub.create!(:admin_state_up => nil)
+      end.to raise_error(ActiveRecord::NotNullViolation)
+    end
+
+    it "supports false" do
+      migrate
+      record = network_router_stub.create!(:admin_state_up => false)
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq(false)
+    end
+
+    it "supports 'f'" do
+      migrate
+      record = network_router_stub.create!(:admin_state_up => 'f')
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq(false)
+    end
+
+    it "supports true" do
+      migrate
+      record = network_router_stub.create!(:admin_state_up => true)
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq(true)
+    end
+
+    it "supports 't'" do
+      migrate
+      record = network_router_stub.create!(:admin_state_up => 't')
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq(true)
+    end
+  end
+
+  migration_context :down do
+    context "conversion" do
+      it "converts to string" do
+        record = network_router_stub.create!(:admin_state_up => false)
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(false)
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to be_kind_of(String)
+      end
+
+      # exact string does not matter here
+      it "converts false to 'false'" do
+        record = network_router_stub.create!(:admin_state_up => false)
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(false)
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq('false')
+        expect(admin_state_up).to be_kind_of(String)
+      end
+
+      it "converts 'true' to true" do
+        record = network_router_stub.create!(:admin_state_up => true)
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq(true)
+
+        migrate
+
+        admin_state_up = record.reload.admin_state_up
+        expect(admin_state_up).to eq('true')
+      end
+    end
+
+    it "defaults to nulls" do
+      migrate
+      record = network_router_stub.create!
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq(nil)
+    end
+
+    it "supports false" do
+      migrate
+      record = network_router_stub.create!(:admin_state_up => false)
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq('f')
+    end
+
+    it "supports true" do
+      migrate
+      record = network_router_stub.create!(:admin_state_up => true)
+      admin_state_up = record.reload.admin_state_up
+      expect(admin_state_up).to eq('t')
+    end
+  end
+end


### PR DESCRIPTION
We have this column as a boolean in NetworkPort#admin_state_up
but it is a string/text in NetworkRouter

This is a boolean column so converting it in the database
This helps the api handle proper typing for this column

fixes https://github.com/ManageIQ/manageiq-providers-openstack/issues/680