### PR TITLE
make both admin_state_up columns have the same defaults

### DIFF
--- a/db/migrate/20210824000038_default_admin_state_up.rb
+++ b/db/migrate/20210824000038_default_admin_state_up.rb
@@ -1,0 +1,13 @@
+class DefaultAdminStateUp < ActiveRecord::Migration[6.0]
+  def up
+    change_column_default :network_ports, :admin_state_up, false
+
+    change_column_null :network_routers, :admin_state_up, true
+  end
+
+  def down
+    change_column_default :network_ports, :admin_state_up, false
+
+    change_column_null :network_routers, :admin_state_up, false
+  end
+end


### PR DESCRIPTION
Just converted network_routers#admin_state_up to a boolean.
Gave it a default and marked it as not-null

This was different from network_port#admin_state_up.
This PR now makes the defaults, null, and type the same between the two

Follow up to https://github.com/ManageIQ/manageiq-schema/pull/602

If we want different defaults for these fields, lets discuss here.