### PR TITLE
[WIP] Drop unused LifecycleEvent table

### DIFF
--- a/db/migrate/20210909212144_drop_lifecycle_events.rb
+++ b/db/migrate/20210909212144_drop_lifecycle_events.rb
@@ -1,0 +1,20 @@
+class DropLifecycleEvents < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :lifecycle_events
+  end
+
+  def down
+    create_table "lifecycle_events", force: :cascade do |t|
+      t.string "guid"
+      t.string "status"
+      t.string "event"
+      t.string "message"
+      t.string "location"
+      t.bigint "vm_or_template_id"
+      t.string "created_by"
+      t.datetime "created_on"
+      t.index ["guid"], name: "index_lifecycle_events_on_guid", unique: true
+      t.index ["vm_or_template_id"], name: "index_lifecycle_events_on_vm_id"
+    end
+  end
+end

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -133,7 +133,6 @@ iso_images
 jobs
 key_pairs_vms
 lans
-lifecycle_events
 load_balancer_health_check_members
 load_balancer_health_checks
 load_balancer_listener_pools


### PR DESCRIPTION
This was added back in 2008 in commit d866a691c57073d44d24eba284f962e62f87a706
and isn't used.  It was never reportable but was available in the API.

Part of https://github.com/ManageIQ/manageiq/issues/21204

Merge with:

- [ ] https://github.com/ManageIQ/manageiq/pull/21205
- [ ]  API PR to remove lifecycle event