### PR TITLE
Introducing Host Initiator Group

### DIFF
--- a/db/migrate/20210810114405_create_host_initiator_groups.rb
+++ b/db/migrate/20210810114405_create_host_initiator_groups.rb
@@ -1,0 +1,15 @@
+class CreateHostInitiatorGroups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :host_initiator_groups do |t|
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.references :physical_storage, :type => :bigint, :index => true
+
+      t.string :name
+      t.string :status
+      t.string :ems_ref
+      t.string :uid_ems
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210923144304_add_host_initiator_group_references.rb
+++ b/db/migrate/20210923144304_add_host_initiator_group_references.rb
@@ -1,0 +1,6 @@
+class AddHostInitiatorGroupReferences < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :host_initiators, :host_initiator_group, :type => :bigint
+    add_reference :volume_mappings, :host_initiator_group, :type => :bigint
+  end
+end

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -123,6 +123,7 @@ hardwares
 host_aggregate_hosts
 host_aggregates
 host_initiators
+host_initiator_groups
 host_service_groups
 host_storages
 host_switches


### PR DESCRIPTION
Block storage devices have a configuration item commonly called "host cluster". Its role is to aggregate hosts on the storage into groups (in MIQ, storage hosts are called host-initiators). These host clusters allow an administrator to map a volume to several hosts in one operation.

This PR is part of this issue: https://github.com/ManageIQ/manageiq-providers-autosde/issues/93
