### PR TITLE
Remove cockpit from assigned services

### DIFF
--- a/db/migrate/20211022131607_drop_cockpit.rb
+++ b/db/migrate/20211022131607_drop_cockpit.rb
@@ -1,0 +1,31 @@
+class DropCockpit < ActiveRecord::Migration[6.0]
+  class AssignedServerRole < ActiveRecord::Base; end
+
+  class ServerRole < ActiveRecord::Base; end
+
+  class SettingsChange < ActiveRecord::Base; end
+
+  class MiqUserRole < ActiveRecord::Base; end
+
+  class MiqRolesFeature < ApplicationRecord; end
+
+  class MiqProductFeature < ApplicationRecord
+    # habtm :miq_user_roles :join_table => MiqRolesFeature
+  end
+
+  def up
+    say_with_time("Deleting cockpit configuration") do
+      if (cockpit = ServerRole.find_by(:name => "cockpit_ws"))
+        AssignedServerRole.where(:server_role_id => cockpit.id).delete_all
+        cockpit.delete
+      end
+
+      SettingsChange.where("key LIKE '%/cockpit_ws_worker/%'").delete_all
+
+      if (feature = MiqProductFeature.find_by(:identifier => "cockpit_console"))
+        MiqRolesFeature.where(:miq_product_feature_id => feature.id).delete_all
+        feature.delete
+      end
+    end
+  end
+end

--- a/spec/migrations/20211022131607_drop_cockpit_spec.rb
+++ b/spec/migrations/20211022131607_drop_cockpit_spec.rb
@@ -1,0 +1,47 @@
+require_migration
+
+describe DropCockpit do
+  let(:server_role_stub)          { migration_stub(:ServerRole) }
+  let(:assigned_server_role_stub) { migration_stub(:AssignedServerRole) }
+  let(:miq_product_feature_stub)  { migration_stub(:MiqProductFeature) }
+  let(:miq_user_role_stub)        { migration_stub(:MiqUserRole) }
+  let(:miq_role_feature_stub)     { migration_stub(:MiqRolesFeature) }
+
+  migration_context :up do
+    it "deletes only cockpit active services" do
+      cockpit = server_role_stub.find_or_create_by!(:name => "cockpit_ws")
+      other   = server_role_stub.create!(:name => "other_service")
+
+      assigned_server_role_stub.create!(:server_role_id => other.id)
+      3.times do
+        assigned_server_role_stub.create!(:server_role_id => cockpit.id)
+      end
+
+      expect(assigned_server_role_stub.where(:server_role_id => cockpit.id).count).to eq(3)
+      expect(assigned_server_role_stub.where(:server_role_id => other.id).count).to eq(1)
+
+      migrate
+
+      expect(assigned_server_role_stub.where(:server_role_id => other.id).count).to eq(1)
+      expect(assigned_server_role_stub.where(:server_role_id => cockpit.id).count).to eq(0)
+
+      expect(server_role_stub.where(:name => "other_service").count).to eq(1)
+      expect(server_role_stub.where(:name => "cockpit_ws").count).to eq(0)
+    end
+
+    it "deletes product features" do
+      product_feature = miq_product_feature_stub.find_or_create_by!(:identifier => "cockpit_console")
+      other_feature   = miq_product_feature_stub.create!(:identifier => "other_console")
+      role = miq_user_role_stub.create(:name => "role1")
+
+      miq_role_feature_stub.create(:miq_user_role_id => role.id, :miq_product_feature_id => product_feature.id)
+      other_role_feature = miq_role_feature_stub.create(:miq_user_role_id => role.id, :miq_product_feature_id => other_feature.id)
+
+      migrate
+
+      expect(miq_role_feature_stub.all).to eq([other_role_feature])
+      expect(miq_product_feature_stub.where(:identifier => "other_console").count).to eq(1)
+      expect(miq_product_feature_stub.where(:identifier => "cockpit_console").count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
part of ManageIQ/manageiq#21378

cockpit is no longer an available service
remove it from the assigned services table