### PR TITLE
Creation of host initiator group

### DIFF
--- a/db/migrate/20211124180240_add_type_to_host_initiator_groups.rb
+++ b/db/migrate/20211124180240_add_type_to_host_initiator_groups.rb
@@ -1,0 +1,5 @@
+class AddTypeToHostInitiatorGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :host_initiator_groups, :type, :string
+  end
+end


### PR DESCRIPTION
In this set of PRs we will allow users to create new host-initiator-groups on their storage systems through MIQ.

Part of https://github.com/ManageIQ/manageiq-providers-autosde/issues/108

![image](https://user-images.githubusercontent.com/68283004/143038710-7020280e-7251-4bdb-b268-3f02e4d45f23.png)

![image](https://user-images.githubusercontent.com/68283004/143039248-ee83b398-7ad2-4052-9c70-81bbdfabd1c8.png)
