### PR TITLE
Drop unused pglogical references

### DIFF
--- a/db/migrate/20171031010000_add_schema_migrations_ran.rb
+++ b/db/migrate/20171031010000_add_schema_migrations_ran.rb
@@ -4,16 +4,6 @@ class AddSchemaMigrationsRan < ActiveRecord::Migration[5.0]
       t.string :version
       t.datetime :created_at, :null => false
     end
-
-    require 'pg/pglogical'
-    require 'pg/pglogical/active_record_extension'
-
-    pglogical = ActiveRecord::Base.connection.pglogical
-    if pglogical.enabled? && pglogical.replication_sets.include?('miq')
-      # don't do an initial data sync for this table
-      # we want the data do come in as it's replicated rather than in bulk
-      pglogical.replication_set_add_table('miq', "schema_migrations_ran", false)
-    end
   end
 
   def down

--- a/lib/manageiq/schema.rb
+++ b/lib/manageiq/schema.rb
@@ -13,9 +13,6 @@ require 'reserved_shared_mixin'
 require 'reserved_migration_mixin'
 require 'reserved_mixin'
 
-require 'pg/pglogical'
-require 'pg/pglogical/active_record_extension'
-
 module ManageIQ
   module Schema
     SYSTEM_TABLES = %w(ar_internal_metadata schema_migrations repl_events repl_monitor repl_nodes).freeze

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-password",       "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"
   spec.add_dependency "pg"
-  spec.add_dependency "pg-pglogical",            "~> 2.1.1"
   spec.add_dependency "rails",                   "~>6.0.0"
 
   spec.add_development_dependency "manageiq-style"

--- a/spec/replication/util/primary_key_spec.rb
+++ b/spec/replication/util/primary_key_spec.rb
@@ -7,8 +7,8 @@ describe "Replication" do
 
       #{no_pk.join("\n")}
 
-      All tables must have a primary key called "id"
-      Replication with pglogical requires all tables to have a primary key
+      All tables must have a primary key called "id".
+      Logical replication requires all tables to have a primary key.
       We have chosen to use "id" rather than a composite key to avoid future migration
       problems should a table need to move away from a composite key in the future.
     EOS


### PR DESCRIPTION
As of https://github.com/ManageIQ/manageiq/pull/18686 we moved from pglogical
to the pg-logical_replication using postgresql's native logical replication.

We switched as of ivanchuk.  It should be safe to drop this now.

Funny enough, this actually helps with getting ruby 3.0 support because the AR
extension signature for drop_table needs to change to work with ruby 2.x and
3.x.