### PR TITLE
Support rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ cache: bundler
 rvm:
 - 2.6.6
 - 2.7.2
+env:
+  matrix:
+  - TEST_RAILS_VERSION=6.1
+  - TEST_RAILS_VERSION=6.0
 addons:
   postgresql: '10'
 install: bin/setup

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,11 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+
+case ENV['TEST_RAILS_VERSION']
+when "6.1"
+  gem "rails",  "~>6.1.4"
+else
+  # Default local bundling to use 6.0 for generating migrations
+  gem "rails",  "~>6.0.4"
+end

--- a/db/migrate/20190617191109_move_awx_credentials_to_authentications.rb
+++ b/db/migrate/20190617191109_move_awx_credentials_to_authentications.rb
@@ -285,6 +285,10 @@ class MoveAwxCredentialsToAuthentications < ActiveRecord::Migration[5.0]
     raise
   end
 
+  def self.pg_connection(options)
+    PG::Connection.new(options)
+  end
+
   private
 
   def embedded_ansible_authentications
@@ -314,7 +318,7 @@ class MoveAwxCredentialsToAuthentications < ActiveRecord::Migration[5.0]
   end
 
   def awx_connection
-    @awx_connection ||= PG::Connection.new(ApplicationRecord.connection.raw_connection.conninfo_hash.merge(:dbname => "awx").delete_blanks)
+    @awx_connection ||= self.class.pg_connection(ApplicationRecord.connection.raw_connection.conninfo_hash.merge(:dbname => "awx").delete_blanks)
   end
 
   def update_authentication(auth, awx_info)

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-password",       "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"
   spec.add_dependency "pg"
-  spec.add_dependency "rails",                   "~>6.0.0"
+  spec.add_dependency "rails",                   ">=6.0.4", "<7.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rspec"

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ancestry"
-  spec.add_dependency "activerecord-id_regions", "~> 0.3.0"
+  spec.add_dependency "activerecord-id_regions", "~> 0.3.2"
   spec.add_dependency "linux_admin",             "~> 2.0"
   spec.add_dependency "manageiq-password",       "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"

--- a/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
+++ b/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
@@ -97,7 +97,7 @@ describe MoveAwxCredentialsToAuthentications do
         :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential"
       )
       expect(auth.manager_ref).to be_nil
-      expect(PG::Connection).to_not receive(:new)
+      expect(described_class).to_not receive(:pg_connection)
 
       migrate
     end
@@ -108,7 +108,7 @@ describe MoveAwxCredentialsToAuthentications do
         :type        => "ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential",
         :manager_ref => "1"
       )
-      expect(PG::Connection).to_not receive(:new)
+      expect(described_class).to_not receive(:pg_connection)
 
       migrate
     end
@@ -121,14 +121,14 @@ describe MoveAwxCredentialsToAuthentications do
         :options     => {:become_method => ""},
         :manager_ref => "1"
       )
-      expect(PG::Connection).to receive(:new).and_raise(PG::ConnectionBad)
+      expect(described_class).to receive(:pg_connection).and_raise(PG::ConnectionBad)
 
       migrate
     end
 
     context "with an awx database connection" do
       before do
-        allow(PG::Connection).to receive(:new).with(a_hash_including(:dbname => "awx")).and_return(awx_conn)
+        allow(described_class).to receive(:pg_connection).with(a_hash_including(:dbname => "awx")).and_return(awx_conn)
       end
 
       it "removes unwanted data from options when the credential doesn't exist in the awx database" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,3 +22,7 @@ RSpec.configure do |config|
   config.include Spec::Support::MigrationHelper, :migrations => :down
   config.include Spec::Support::MigrationIdRegionsHelper, :migrations => :down
 end
+
+require "rails"
+puts
+puts "\e[93mUsing Rails #{Rails.version}\e[0m"


### PR DESCRIPTION
* Use id_regions with 6.1 support
* Allow rails 6.1 but force local migration creation to still use 6.0
* Fix the global stubbing of the PG::Connection class that was causing failures in rails 6.1