### PR TITLE
Service request connected to Automation request

### DIFF
--- a/db/migrate/20220202122417_add_parent_relation_to_miq_requests.rb
+++ b/db/migrate/20220202122417_add_parent_relation_to_miq_requests.rb
@@ -1,0 +1,5 @@
+class AddParentRelationToMiqRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :miq_requests, :parent, :type => :bigint
+  end
+end


### PR DESCRIPTION
When an automation request is created for ansible, a sub-service request is created and it processes the ansible tasks. Currently, there is no connection between the automation request and the newly created request so we can't write a function to connect the existing requests. :-( But it will work for future requests.