### PR TITLE
added server placement group

### DIFF
--- a/db/migrate/20220407210610_placement_group_additions.rb
+++ b/db/migrate/20220407210610_placement_group_additions.rb
@@ -1,0 +1,18 @@
+class PlacementGroupAdditions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :placement_groups do |t|
+      t.string :name
+      t.string :policy
+      t.string :ems_ref
+      t.string :type,                  :index => true
+
+      t.references :availability_zone, :type => :bigint
+      t.references :cloud_tenant,      :type => :bigint
+      t.references :ems,               :type => :bigint
+
+      t.timestamps
+    end
+
+    add_reference :vms, :placement_group, :type => :bigint
+  end
+end

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -257,6 +257,7 @@ physical_servers
 physical_storage_families
 physical_storages
 pictures
+placement_groups
 policy_event_contents
 policy_events
 provider_tag_mappings


### PR DESCRIPTION
This is a dependent PR for adding and enabling Server Placement Group as Menu in the Core

1. Manageiq schema changes.
    https://github.com/ManageIQ/manageiq-schema/pull/644
2. Server Placement Group in ManageIQ UI Changes.
    https://github.com/ManageIQ/manageiq-ui-classic/pull/8214
3. PowerVS changes.
    https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/363
4. ManageIQ Core changes
    https://github.com/ManageIQ/manageiq/pull/21807


server_group table consist of 
   . **id**:                                      
   . **name**: same of the server placement group                             
   . **policy** : cloud provider specific policy. In case of the PowerVC and PowerVS it is right now `affinity` and `anti-affinity` 
   . **ems_id**                                                
   . **ems_ref**                             
   . **type**       
   . availability_zone_id                                    
   . cloud_tenant_id
 
Each VM can belongs to atmost 1 server group.                                           
