### PR TITLE
Add physical server profile

### DIFF
--- a/db/migrate/20220401093502_create_physical_server_profiles.rb
+++ b/db/migrate/20220401093502_create_physical_server_profiles.rb
@@ -1,0 +1,14 @@
+class CreatePhysicalServerProfiles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :physical_server_profiles do |t|
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.string :ems_ref
+      t.string :name
+      t.string :type, :index => true
+      t.references :assigned_server, :type => :bigint, :index => true, :references => :physical_server
+      t.references :associated_server, :type => :bigint, :index => true, :references => :physical_server
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -256,6 +256,7 @@ physical_racks
 physical_servers
 physical_storage_families
 physical_storages
+physical_server_profiles
 pictures
 policy_event_contents
 policy_events


### PR DESCRIPTION
This commit adds a new table for storing server profiles that are used
in Cisco Intersight provider.

Related PR from core: https://github.com/ManageIQ/manageiq/pull/21830