### PR TITLE
Add ExtManagementSystem#last_refresh_success_date

### DIFF
--- a/db/migrate/20220527165347_add_last_refresh_success_date.rb
+++ b/db/migrate/20220527165347_add_last_refresh_success_date.rb
@@ -1,0 +1,5 @@
+class AddLastRefreshSuccessDate < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ext_management_systems, :last_refresh_success_date, :datetime
+  end
+end


### PR DESCRIPTION
Currently we have `:last_refresh_date` and `:last_refresh_error`, but if the refresh is currently failing we don't have a way to see when the last successful refresh was.

Adding a `:last_refresh_success_date` allows us to show users when refresh was working if it is currently failing.