### PR TITLE
Migrate Authentication#become_method out of :options

### DIFF
--- a/db/migrate/20220617140212_add_become_method_to_authentications.rb
+++ b/db/migrate/20220617140212_add_become_method_to_authentications.rb
@@ -1,0 +1,5 @@
+class AddBecomeMethodToAuthentications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :authentications, :become_method, :string
+  end
+end

--- a/db/migrate/20220617140542_move_become_method_from_options.rb
+++ b/db/migrate/20220617140542_move_become_method_from_options.rb
@@ -8,7 +8,7 @@ class MoveBecomeMethodFromOptions < ActiveRecord::Migration[6.0]
 
   def up
     say_with_time("Move Authentication become_method out of options text field") do
-      Authentication.in_my_region.find_each do |authentication|
+      Authentication.in_my_region.where("options LIKE '%become_method%'").find_each do |authentication|
         next unless authentication.options&.key?(:become_method)
 
         authentication.become_method = authentication.options.delete(:become_method)

--- a/db/migrate/20220617140542_move_become_method_from_options.rb
+++ b/db/migrate/20220617140542_move_become_method_from_options.rb
@@ -1,0 +1,29 @@
+class MoveBecomeMethodFromOptions < ActiveRecord::Migration[6.0]
+  class Authentication < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    serialize :options
+  end
+
+  def up
+    say_with_time("Move Authentication become_method out of options text field") do
+      Authentication.in_my_region.find_each do |authentication|
+        next unless authentication.options&.key?(:become_method)
+
+        authentication.become_method = authentication.options.delete(:become_method)
+        authentication.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time("Move Authentication become_method back to options text field") do
+      Authentication.in_my_region.where.not(:become_method => nil).find_each do |authentication|
+        authentication.options = {} if authentication.options.nil?
+        authentication.options[:become_method] = authentication.become_method
+        authentication.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20220617140542_move_become_method_from_options.rb
+++ b/db/migrate/20220617140542_move_become_method_from_options.rb
@@ -1,4 +1,19 @@
 class MoveBecomeMethodFromOptions < ActiveRecord::Migration[6.0]
+  ALLOWED_VALUES = %w[
+    sudo
+    su
+    pbrum
+    pfexec
+    doas
+    dzdo
+    pmrun
+    runas
+    enable
+    ksu
+    sesu
+    machinectl
+  ].freeze
+
   class Authentication < ActiveRecord::Base
     include ActiveRecord::IdRegions
     self.inheritance_column = :_type_disabled
@@ -11,7 +26,12 @@ class MoveBecomeMethodFromOptions < ActiveRecord::Migration[6.0]
       Authentication.in_my_region.where("options LIKE '%become_method%'").find_each do |authentication|
         next unless authentication.options&.key?(:become_method)
 
-        authentication.become_method = authentication.options.delete(:become_method)
+        # Delete the old value out of options
+        become_method = authentication.options.delete(:become_method)
+
+        # Only set the new column if the existing value is valid
+        authentication.become_method = become_method if ALLOWED_VALUES.include?(become_method)
+
         authentication.save!
       end
     end
@@ -19,7 +39,7 @@ class MoveBecomeMethodFromOptions < ActiveRecord::Migration[6.0]
 
   def down
     say_with_time("Move Authentication become_method back to options text field") do
-      Authentication.in_my_region.where.not(:become_method => nil).find_each do |authentication|
+      Authentication.in_my_region.where(:become_method => ALLOWED_VALUES).find_each do |authentication|
         authentication.options = {} if authentication.options.nil?
         authentication.options[:become_method] = authentication.become_method
         authentication.save!

--- a/spec/migrations/20220617140542_move_become_method_from_options_spec.rb
+++ b/spec/migrations/20220617140542_move_become_method_from_options_spec.rb
@@ -1,0 +1,49 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe MoveBecomeMethodFromOptions do
+  let(:authentication_stub) { migration_stub(:Authentication) }
+
+  migration_context :up do
+    it "without options[:become_method] set doesn't modify authentication records" do
+      authentication = authentication_stub.create!
+
+      updated_on = authentication.updated_on
+
+      migrate
+
+      expect(authentication.reload.updated_on).to be_within(0.01).of(updated_on)
+    end
+
+    it "moves options[:become_method] to column" do
+      authentication = authentication_stub.create!(:options => {:become_method => "su"})
+
+      migrate
+
+      authentication.reload
+      expect(authentication.become_method).to eq("su")
+      expect(authentication.options.keys).not_to include(:become_method)
+    end
+  end
+
+  migration_context :down do
+    it "without :become_method set doesn't modify authentication records" do
+      authentication = authentication_stub.create!
+
+      updated_on = authentication.updated_on
+
+      migrate
+
+      expect(authentication.reload.updated_on).to be_within(0.01).of(updated_on)
+    end
+
+    it "moves :become_method to :options" do
+      authentication = authentication_stub.create!(:become_method => "su")
+
+      migrate
+
+      expect(authentication.reload.options).to include(:become_method => "su")
+    end
+  end
+end

--- a/spec/migrations/20220617140542_move_become_method_from_options_spec.rb
+++ b/spec/migrations/20220617140542_move_become_method_from_options_spec.rb
@@ -25,6 +25,16 @@ describe MoveBecomeMethodFromOptions do
       expect(authentication.become_method).to eq("su")
       expect(authentication.options.keys).not_to include(:become_method)
     end
+
+    it "clears invalid values" do
+      authentication = authentication_stub.create!(:options => {:become_method => "rm -rf"})
+
+      migrate
+
+      authentication.reload
+      expect(authentication.become_method).to be_nil
+      expect(authentication.options.keys).not_to include(:become_method)
+    end
   end
 
   migration_context :down do


### PR DESCRIPTION
Having become_method in the options text column is causing issues for patching via the API, and become_username/become_password are already proper columns on the authentications table.

Add a :become_method column and migrate existing data out of the :options column.