### PR TITLE
Add table for cloud database server

### DIFF
--- a/db/migrate/20220707150906_create_cloud_database_server.rb
+++ b/db/migrate/20220707150906_create_cloud_database_server.rb
@@ -1,0 +1,17 @@
+class CreateCloudDatabaseServer < ActiveRecord::Migration[6.0]
+  def change
+    create_table :cloud_database_servers do |t|
+      t.string :name
+      t.string :type, :index => true
+      t.string :ems_ref
+      t.string :server_type
+      t.string :status
+      t.string :version
+      t.bigint :resource_group_id
+      t.references :ems, :type => :bigint, :index => true, :references => :ext_management_system
+      t.timestamps
+    end
+
+    add_reference :cloud_databases, :cloud_database_server
+  end
+end

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -20,6 +20,7 @@ chargeback_rates
 chargeback_tiers
 classifications
 cloud_database_flavors
+cloud_database_servers
 cloud_databases
 cloud_networks
 cloud_object_store_containers
@@ -253,10 +254,10 @@ physical_chassis
 physical_disks
 physical_network_ports
 physical_racks
+physical_server_profiles
 physical_servers
 physical_storage_families
 physical_storages
-physical_server_profiles
 pictures
 placement_groups
 policy_event_contents


### PR DESCRIPTION
i.e.
```
 #<ManageIQ::Providers::Azure::CloudManager::CloudDatabaseServer:0x00007febc4205f78
  id: 9,
  name: "miq-sql-server",
  ems_ref:
   "/subscriptions/2b01dec2-6684-4f25-abfc-a2453e0ae52f/resourceGroups/test-group/providers/Microsoft.Sql/servers/miq-sql-server",
  ems_id: 15,
  server_type: "SQL",
  region: "East US",
  status: "Ready",
  version: "12.0",
  resource_group_id: 6>,
```

Dependent:
- [ ] https://github.com/ManageIQ/manageiq/pull/21977
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/513

@miq-bot assign @agrare 
@miq-bot add_labels enhancement, providers_cloud