### PR TITLE
Update the dummy app to use_yaml_unsafe_load in rails 6.0.5.1

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,5 +19,7 @@ module Dummy
     # HACK: Temporary override of the default setting until we can update the
     # migration specs to honor it.
     config.active_record.belongs_to_required_by_default = false
+
+    config.active_record.use_yaml_unsafe_load = true
   end
 end


### PR DESCRIPTION
Rails 6.0.5.1 changed the default behavior to use yaml safe load in 6.0.5.1 so
we need to tell it use the old behavior in the dummy app.

Related to the core change in:
https://github.com/ManageIQ/manageiq/pull/21988