### PR TITLE
Rename messaging_type settings and default to Kafka

### DIFF
--- a/db/migrate/20220713200350_rename_messaging_type_settings.rb
+++ b/db/migrate/20220713200350_rename_messaging_type_settings.rb
@@ -1,0 +1,10 @@
+class RenameMessagingTypeSettings < ActiveRecord::Migration[6.0]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def change
+    say_with_time("Renaming SettingsChange /prototype/messaging_type") do
+      SettingsChange.where(:key => "/prototype/messaging_type").update_all(:key => "/messaging_type", :value => "kafka")
+    end
+  end
+end

--- a/spec/migrations/20220713200350_rename_messaging_type_settings_spec.rb
+++ b/spec/migrations/20220713200350_rename_messaging_type_settings_spec.rb
@@ -1,0 +1,27 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe RenameMessagingTypeSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "renames messaging_type out of prototype and defaults to kafka" do
+      settings_change = settings_change_stub.create!(:key => "/prototype/messaging_type")
+      migrate
+      settings_change.reload
+      expect(settings_change.key).to eq("/messaging_type")
+      expect(settings_change.value).to eq("kafka")
+    end
+  end
+
+  migration_context :down do
+    it "renames messaging_type out of prototype and defaults to kafka" do
+      settings_change = settings_change_stub.create!(:key => "/prototype/messaging_type")
+      migrate
+      settings_change.reload
+      expect(settings_change.key).to eq("/messaging_type")
+      expect(settings_change.value).to eq("kafka")
+    end
+  end
+end


### PR DESCRIPTION
- settings `/prototype/messaging_type` renamed to `/messaging_type` and `kafka` set as the default value (previously `miq_queue`)

@miq-bot add_labels enhancement, refactoring
@miq-bot assign @agrare 