### PR TITLE
display events for physical storage

### DIFF
--- a/db/migrate/20220719151539_add_physical_storage_to_event_streams.rb
+++ b/db/migrate/20220719151539_add_physical_storage_to_event_streams.rb
@@ -1,0 +1,6 @@
+class AddPhysicalStorageToEventStreams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :event_streams, :physical_storage_id, :bigint
+    add_column :event_streams, :physical_storage_name, :string
+  end
+end


### PR DESCRIPTION
* Following this PR: https://github.com/ManageIQ/manageiq-providers-autosde/pull/151
This is an implementation of the monitoring page for physical storage where we'll show our critical alerts (storage events).

Before:
![image](https://user-images.githubusercontent.com/33315712/180793645-fbba6ec8-fdb6-425c-9028-123cf77961df.png)

After:
![image](https://user-images.githubusercontent.com/33315712/180792764-f926449c-d76a-4aca-ae34-da2110fb7f11.png)

# related PRs:
- https://github.com/ManageIQ/manageiq-providers-autosde/pull/154
- https://github.com/ManageIQ/manageiq/pull/22008
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8373