### PR TITLE
Fix IBM PowerVC STI classes

### DIFF
--- a/db/migrate/20220809152005_fix_ibm_power_vc_sti_classes.rb
+++ b/db/migrate/20220809152005_fix_ibm_power_vc_sti_classes.rb
@@ -1,0 +1,189 @@
+class FixIbmPowerVcStiClasses < ActiveRecord::Migration[6.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class CloudNetwork < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class CloudSubnet < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class FloatingIp < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class NetworkPort < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class NetworkRouter < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class SecurityGroup < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class CloudVolume < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class CloudVolumeBackup < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class CloudVolumeSnapshot < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  class CloudVolumeType < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "FixIbmPowerVcStiClasses::ExtManagementSystem"
+  end
+
+  def up
+    say_with_time("Fixing IBM PowerVC Network STI classes") do
+      ibm_power_vc_network_klass = "ManageIQ::Providers::IbmPowerVc::NetworkManager"
+      openstack_network_klass = "ManageIQ::Providers::Openstack::NetworkManager"
+
+      network_managers = ExtManagementSystem.in_my_region.where(:type => ibm_power_vc_network_klass)
+
+      CloudNetwork.in_my_region
+                  .where(:ext_management_system => network_managers)
+                  .where(:type => "#{openstack_network_klass}::CloudNetwork")
+                  .update_all(:type => "#{ibm_power_vc_network_klass}::CloudNetwork")
+      CloudNetwork.in_my_region
+                  .where(:ext_management_system => network_managers)
+                  .where(:type => "#{openstack_network_klass}::CloudNetwork::Public")
+                  .update_all(:type => "#{ibm_power_vc_network_klass}::CloudNetwork::Public")
+      CloudNetwork.in_my_region
+                  .where(:ext_management_system => network_managers)
+                  .where(:type => "#{openstack_network_klass}::CloudNetwork::Private")
+                  .update_all(:type => "#{ibm_power_vc_network_klass}::CloudNetwork::Private")
+      CloudSubnet.in_my_region
+                 .where(:ext_management_system => network_managers)
+                 .update_all(:type => "#{ibm_power_vc_network_klass}::CloudSubnet")
+      FloatingIp.in_my_region
+                .where(:ext_management_system => network_managers)
+                .update_all(:type => "#{ibm_power_vc_network_klass}::FloatingIp")
+      NetworkPort.in_my_region
+                 .where(:ext_management_system => network_managers)
+                 .update_all(:type => "#{ibm_power_vc_network_klass}::NetworkPort")
+      NetworkRouter.in_my_region
+                   .where(:ext_management_system => network_managers)
+                   .update_all(:type => "#{ibm_power_vc_network_klass}::NetworkRouter")
+      SecurityGroup.in_my_region
+                   .where(:ext_management_system => network_managers)
+                   .update_all(:type => "#{ibm_power_vc_network_klass}::SecurityGroup")
+    end
+
+    say_with_time("Fixing IBM PowerVC Storage (Cinder) STI classes") do
+      ibm_power_vc_cinder_klass = "ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager"
+
+      cinder_managers = ExtManagementSystem.in_my_region.where(:type => ibm_power_vc_cinder_klass)
+
+      CloudVolume.in_my_region
+                 .where(:ext_management_system => cinder_managers)
+                 .update_all(:type => "#{ibm_power_vc_cinder_klass}::CloudVolume")
+      CloudVolumeBackup.in_my_region
+                       .where(:ext_management_system => cinder_managers)
+                       .update_all(:type => "#{ibm_power_vc_cinder_klass}::CloudVolumeBackup")
+      CloudVolumeSnapshot.in_my_region
+                         .where(:ext_management_system => cinder_managers)
+                         .update_all(:type => "#{ibm_power_vc_cinder_klass}::CloudVolumeSnapshot")
+      CloudVolumeType.in_my_region
+                     .where(:ext_management_system => cinder_managers)
+                     .update_all(:type => "#{ibm_power_vc_cinder_klass}::CloudVolumeType")
+    end
+  end
+
+  def down
+    say_with_time("Resetting IBM PowerVC Network STI classes") do
+      ibm_power_vc_network_klass = "ManageIQ::Providers::IbmPowerVc::NetworkManager"
+      openstack_network_klass = "ManageIQ::Providers::Openstack::NetworkManager"
+
+      network_managers = ExtManagementSystem.in_my_region.where(:type => ibm_power_vc_network_klass)
+
+      CloudNetwork.in_my_region
+                  .where(:ext_management_system => network_managers)
+                  .where(:type => "#{ibm_power_vc_network_klass}::CloudNetwork")
+                  .update_all(:type => "#{openstack_network_klass}::CloudNetwork")
+      CloudNetwork.in_my_region
+                  .where(:ext_management_system => network_managers)
+                  .where(:type => "#{ibm_power_vc_network_klass}::CloudNetwork::Public")
+                  .update_all(:type => "#{openstack_network_klass}::CloudNetwork::Public")
+      CloudNetwork.in_my_region
+                  .where(:ext_management_system => network_managers)
+                  .where(:type => "#{ibm_power_vc_network_klass}::CloudNetwork::Private")
+                  .update_all(:type => "#{openstack_network_klass}::CloudNetwork::Private")
+      CloudSubnet.in_my_region
+                 .where(:ext_management_system => network_managers)
+                 .update_all(:type => "#{openstack_network_klass}::CloudSubnet")
+      FloatingIp.in_my_region
+                .where(:ext_management_system => network_managers)
+                .update_all(:type => "#{openstack_network_klass}::FloatingIp")
+      NetworkPort.in_my_region
+                 .where(:ext_management_system => network_managers)
+                 .update_all(:type => "#{openstack_network_klass}::NetworkPort")
+      NetworkRouter.in_my_region
+                   .where(:ext_management_system => network_managers)
+                   .update_all(:type => "#{openstack_network_klass}::NetworkRouter")
+      SecurityGroup.in_my_region
+                   .where(:ext_management_system => network_managers)
+                   .update_all(:type => "#{openstack_network_klass}::SecurityGroup")
+    end
+
+    say_with_time("Resetting IBM PowerVC Storage (Cinder) STI classes") do
+      ibm_power_vc_cinder_klass = "ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager"
+      openstack_cinder_klass = "ManageIQ::Providers::Openstack::StorageManager::CinderManager"
+
+      cinder_managers = ExtManagementSystem.in_my_region.where(:type => ibm_power_vc_cinder_klass)
+
+      CloudVolume.in_my_region
+                 .where(:ext_management_system => cinder_managers)
+                 .update_all(:type => "#{openstack_cinder_klass}::CloudVolume")
+      CloudVolumeBackup.in_my_region
+                       .where(:ext_management_system => cinder_managers)
+                       .update_all(:type => "#{openstack_cinder_klass}::CloudVolumeBackup")
+      CloudVolumeSnapshot.in_my_region
+                         .where(:ext_management_system => cinder_managers)
+                         .update_all(:type => "#{openstack_cinder_klass}::CloudVolumeSnapshot")
+      CloudVolumeType.in_my_region
+                     .where(:ext_management_system => cinder_managers)
+                     .update_all(:type => "#{openstack_cinder_klass}::CloudVolumeType")
+    end
+  end
+end

--- a/spec/migrations/20220809152005_fix_ibm_power_vc_sti_classes_spec.rb
+++ b/spec/migrations/20220809152005_fix_ibm_power_vc_sti_classes_spec.rb
@@ -1,0 +1,110 @@
+require_migration
+
+describe FixIbmPowerVcStiClasses do
+  let(:ems_stub)                   { migration_stub(:ExtManagementSystem) }
+  let(:cloud_network_stub)         { migration_stub(:CloudNetwork) }
+  let(:cloud_subnet_stub)          { migration_stub(:CloudSubnet) }
+  let(:floating_ip_stub)           { migration_stub(:FloatingIp) }
+  let(:network_port_stub)          { migration_stub(:NetworkPort) }
+  let(:network_router_stub)        { migration_stub(:NetworkRouter) }
+  let(:security_group_stub)        { migration_stub(:SecurityGroup) }
+  let(:cloud_volume_stub)          { migration_stub(:CloudVolume) }
+  let(:cloud_volume_backup_stub)   { migration_stub(:CloudVolumeBackup) }
+  let(:cloud_volume_snapshot_stub) { migration_stub(:CloudVolumeSnapshot) }
+  let(:cloud_volume_type_stub)     { migration_stub(:CloudVolumeType) }
+
+  migration_context :up do
+    it "Fixes IBM PowerVC Network STI classes" do
+      ibm_power_vc_network_klass = "ManageIQ::Providers::IbmPowerVc::NetworkManager"
+      openstack_network_klass = "ManageIQ::Providers::Openstack::NetworkManager"
+
+      network_manager = ems_stub.create(:type => ibm_power_vc_network_klass)
+
+      cloud_network         = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{openstack_network_klass}::CloudNetwork")
+      cloud_network_public  = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{openstack_network_klass}::CloudNetwork::Public")
+      cloud_network_private = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{openstack_network_klass}::CloudNetwork::Private")
+      cloud_subnet          = cloud_subnet_stub.create(:ext_management_system => network_manager)
+      floating_ip           = floating_ip_stub.create(:ext_management_system => network_manager)
+      network_port          = network_port_stub.create(:ext_management_system => network_manager)
+      network_router        = network_router_stub.create(:ext_management_system => network_manager)
+      security_group        = security_group_stub.create(:ext_management_system => network_manager)
+
+      migrate
+
+      expect(cloud_network.reload.type).to         eq("#{ibm_power_vc_network_klass}::CloudNetwork")
+      expect(cloud_network_public.reload.type).to  eq("#{ibm_power_vc_network_klass}::CloudNetwork::Public")
+      expect(cloud_network_private.reload.type).to eq("#{ibm_power_vc_network_klass}::CloudNetwork::Private")
+      expect(cloud_subnet.reload.type).to          eq("#{ibm_power_vc_network_klass}::CloudSubnet")
+      expect(floating_ip.reload.type).to           eq("#{ibm_power_vc_network_klass}::FloatingIp")
+      expect(network_port.reload.type).to          eq("#{ibm_power_vc_network_klass}::NetworkPort")
+      expect(network_router.reload.type).to        eq("#{ibm_power_vc_network_klass}::NetworkRouter")
+      expect(security_group.reload.type).to        eq("#{ibm_power_vc_network_klass}::SecurityGroup")
+    end
+
+    it "Fixes IBM PowerVC Storage (Cinder) STI classes" do
+      ibm_power_vc_cinder_klass = "ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager"
+
+      cinder_manager = ems_stub.create(:type => ibm_power_vc_cinder_klass)
+
+      cloud_volume          = cloud_volume_stub.create(:ext_management_system => cinder_manager)
+      cloud_volume_backup   = cloud_volume_backup_stub.create(:ext_management_system => cinder_manager)
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ext_management_system => cinder_manager)
+      cloud_volume_type     = cloud_volume_type_stub.create(:ext_management_system => cinder_manager)
+
+      migrate
+
+      expect(cloud_volume.reload.type).to          eq("#{ibm_power_vc_cinder_klass}::CloudVolume")
+      expect(cloud_volume_backup.reload.type).to   eq("#{ibm_power_vc_cinder_klass}::CloudVolumeBackup")
+      expect(cloud_volume_snapshot.reload.type).to eq("#{ibm_power_vc_cinder_klass}::CloudVolumeSnapshot")
+      expect(cloud_volume_type.reload.type).to     eq("#{ibm_power_vc_cinder_klass}::CloudVolumeType")
+    end
+  end
+
+  migration_context :down do
+    it "Resets IBM PowerVC Network STI classes" do
+      ibm_power_vc_network_klass = "ManageIQ::Providers::IbmPowerVc::NetworkManager"
+      openstack_network_klass = "ManageIQ::Providers::Openstack::NetworkManager"
+
+      network_manager = ems_stub.create(:type => ibm_power_vc_network_klass)
+
+      cloud_network         = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudNetwork")
+      cloud_network_public  = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudNetwork::Public")
+      cloud_network_private = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudNetwork::Private")
+      cloud_subnet          = cloud_subnet_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudSubnet")
+      floating_ip           = floating_ip_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::FloatingIp")
+      network_port          = network_port_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::NetworkPort")
+      network_router        = network_router_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::NetworkRouter")
+      security_group        = security_group_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::SecurityGroup")
+
+      migrate
+
+      expect(cloud_network.reload.type).to         eql("#{openstack_network_klass}::CloudNetwork")
+      expect(cloud_network_public.reload.type).to  eql("#{openstack_network_klass}::CloudNetwork::Public")
+      expect(cloud_network_private.reload.type).to eql("#{openstack_network_klass}::CloudNetwork::Private")
+      expect(cloud_subnet.reload.type).to          eql("#{openstack_network_klass}::CloudSubnet")
+      expect(floating_ip.reload.type).to           eql("#{openstack_network_klass}::FloatingIp")
+      expect(network_port.reload.type).to          eql("#{openstack_network_klass}::NetworkPort")
+      expect(network_router.reload.type).to        eql("#{openstack_network_klass}::NetworkRouter")
+      expect(security_group.reload.type).to        eql("#{openstack_network_klass}::SecurityGroup")
+    end
+
+    it "Resets IBM PowerVC Storage (Cinder) STI classes" do
+      ibm_power_vc_cinder_klass = "ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager"
+      openstack_cinder_klass = "ManageIQ::Providers::Openstack::StorageManager::CinderManager"
+
+      cinder_manager = ems_stub.create(:type => ibm_power_vc_cinder_klass)
+
+      cloud_volume = cloud_volume_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolume")
+      cloud_volume_backup = cloud_volume_backup_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeBackup")
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeSnapshot")
+      cloud_volume_type = cloud_volume_type_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeType")
+
+      migrate
+
+      expect(cloud_volume.reload.type).to          eql("#{openstack_cinder_klass}::CloudVolume")
+      expect(cloud_volume_backup.reload.type).to   eql("#{openstack_cinder_klass}::CloudVolumeBackup")
+      expect(cloud_volume_snapshot.reload.type).to eql("#{openstack_cinder_klass}::CloudVolumeSnapshot")
+      expect(cloud_volume_type.reload.type).to     eql("#{openstack_cinder_klass}::CloudVolumeType")
+    end
+  end
+end


### PR DESCRIPTION
Database migrations to cover quite a few subclass fixes to the IBM PowerVC provider:
- ManageIQ/manageiq-providers-ibm_power_vc#52
- ManageIQ/manageiq-providers-ibm_power_vc#53
- ManageIQ/manageiq-providers-ibm_power_vc#55
- ManageIQ/manageiq-providers-ibm_power_vc#56