### PR TITLE
Use rails61 by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,9 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # your gem to rubygems.org.
 
 case ENV['TEST_RAILS_VERSION']
-when "6.1"
-  gem "rails",  "~>6.1.4"
-else
+when "6.0"
   # Default local bundling to use 6.0 for generating migrations
   gem "rails",  "~>6.0.4"
+else
+  gem "rails",  "~>6.1.6"
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -8,8 +8,7 @@ Bundler.require(*Rails.groups)
 
 module Dummy
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults Rails::VERSION::STRING.to_f
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
Default tests to rails 6.1

we can delete the 6.0 matrix option if we want.