### PR TITLE
added a `fixed` string field to model `event_streams`

### DIFF
--- a/db/migrate/20220827142531_add_fixed_to_event_streams.rb
+++ b/db/migrate/20220827142531_add_fixed_to_event_streams.rb
@@ -1,0 +1,5 @@
+class AddFixedToEventStreams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :event_streams, :fixed, :string
+  end
+end


### PR DESCRIPTION
This field indicates whether the event was fixed or not, but could also hold a more complex status, since it's a string rather than a boolean.