### PR TITLE
remove ws_cockpit role from /server/roles

### DIFF
--- a/db/migrate/20220909190221_drop_cockpit_role.rb
+++ b/db/migrate/20220909190221_drop_cockpit_role.rb
@@ -1,0 +1,15 @@
+class DropCockpitRole < ActiveRecord::Migration[6.0]
+  class SettingsChange < ActiveRecord::Base; end
+
+  def up
+    say_with_time("Deleting cockpit role configuration") do
+      SettingsChange.where("key = '/server/role' AND value LIKE '%ws_cockpit%'").select('id', 'value').each do |row|
+        if row.value == 'ws_cockpit'
+          row.delete
+        else
+          row.update(:value => row.value.split(',').tap { |a| a.delete("ws_cockpit") }.join(','))
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20220909190221_drop_cockpit_role_spec.rb
+++ b/spec/migrations/20220909190221_drop_cockpit_role_spec.rb
@@ -1,0 +1,23 @@
+require_migration
+
+describe DropCockpitRole do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "removes roles in the beginning" do
+      only  = settings_change_stub.create!(:key => "/server/role", :value => "ws_cockpit")
+      first = settings_change_stub.create!(:key => "/server/role", :value => "ws_cockpit,database,websocket")
+      middle = settings_change_stub.create!(:key => "/server/role", :value => "database,ws_cockpit,websocket")
+      last  = settings_change_stub.create!(:key => "/server/role", :value => "database,websocket,ws_cockpit")
+      none  = settings_change_stub.create!(:key => "/server/role", :value => "database,websocket")
+
+      migrate
+
+      expect(settings_change_stub.exists?(:id => only.id)).to eq(false)
+      expect(first.reload.value).to eq("database,websocket")
+      expect(middle.reload.value).to eq("database,websocket")
+      expect(last.reload.value).to  eq("database,websocket")
+      expect(none.reload.value).to  eq("database,websocket")
+    end
+  end
+end


### PR DESCRIPTION
Extracted from https://github.com/ManageIQ/manageiq/issues/22097

#613 / aka 01f6a17c had dropped cockpit from the server roles table, but did not remove it from the configuration overrides.

This removes the role from the settings