### PR TITLE
drop rails 60 build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
         - '2.6'
         - '2.7'
         rails-version:
-        - '6.0'
         - '6.1'
     services:
       postgres:


### PR DESCRIPTION
running rails 6.1 migrations on rails 6.0 fails. Which is to be expected

> Unknown migration version "6.1"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0"

This upgrades the builds to only run 6.1