### PR TITLE
Subclass Snapshots under providers

### DIFF
--- a/db/migrate/20220927184751_add_type_to_snapshots.rb
+++ b/db/migrate/20220927184751_add_type_to_snapshots.rb
@@ -1,0 +1,6 @@
+class AddTypeToSnapshots < ActiveRecord::Migration[6.1]
+  def change
+    add_column :snapshots, :type, :string
+    add_index :snapshots, :type
+  end
+end

--- a/db/migrate/20220927185435_set_type_on_snapshots.rb
+++ b/db/migrate/20220927185435_set_type_on_snapshots.rb
@@ -1,0 +1,55 @@
+class SetTypeOnSnapshots < ActiveRecord::Migration[6.1]
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    has_many :vms_and_templates, :foreign_key => :ems_id, :class_name => "SetTypeOnSnapshots::VmOrTemplate"
+    has_many :snapshots, :through => :vms_and_templates, :class_name => "SetTypeOnSnapshots::Snapshot"
+  end
+
+  class Snapshot < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :vm_or_template, :class_name => "SetTypeOnSnapshots::VmOrTemplate"
+    has_one :ext_management_system, :through => :vm_or_template, :class_name => "SetTypeOnSnapshots::ExtManagementSystem"
+  end
+
+  class VmOrTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+    self.table_name         = :vms
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "SetTypeOnSnapshots::ExtManagementSystem"
+    has_many :snapshots, :class_name => "SetTypeOnSnapshots::Snapshot"
+  end
+
+  def up
+    say_with_time("Setting Snasphot type") do
+      [
+        'IbmCloud::PowerVirtualServers::CloudManager',
+        'IbmCic::CloudManager',
+        'IbmPowerVc::CloudManager',
+        'Openstack::CloudManager',
+        'Microsoft::InfraManager',
+        'Ovirt::InfraManager',
+        'Redhat::InfraManager',
+        'Vmware::InfraManager',
+      ].each do |provider|
+        ems_class_name      = "ManageIQ::Providers::#{provider}"
+        snapshot_class_name = "#{ems_class_name}::Snapshot"
+
+        Snapshot.in_my_region
+                .joins(:ext_management_system)
+                .where(:ext_management_systems => {:type => ems_class_name})
+                .update_all(:type => snapshot_class_name)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Resetting Snapshot type") do
+      Snapshot.in_my_region.update_all(:type => nil)
+    end
+  end
+end

--- a/spec/migrations/20220927185435_set_type_on_snapshots_spec.rb
+++ b/spec/migrations/20220927185435_set_type_on_snapshots_spec.rb
@@ -1,0 +1,68 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe SetTypeOnSnapshots do
+  let(:ems_stub)      { migration_stub(:ExtManagementSystem) }
+  let(:snapshot_stub) { migration_stub(:Snapshot) }
+  let(:vm_stub)       { migration_stub(:VmOrTemplate) }
+
+  migration_context :up do
+    it "Sets Snapshot#type propertly" do
+      powervs_ems      = ems_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager")
+      powervs_vm       = vm_stub.create!(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm", :ems_id => powervs_ems.id)
+      powervs_snapshot = snapshot_stub.create!(:vm_or_template_id => powervs_vm.id)
+
+      openstack_ems      = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
+      openstack_vm       = vm_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::Vm", :ems_id => openstack_ems.id)
+      openstack_snapshot = snapshot_stub.create!(:vm_or_template_id => openstack_vm.id)
+
+      powervc_ems      = ems_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager")
+      powervc_vm       = vm_stub.create!(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager::Vm", :ems_id => powervc_ems.id)
+      powervc_snapshot = snapshot_stub.create!(:vm_or_template_id => powervc_vm.id)
+
+      ibm_cic_ems      = ems_stub.create!(:type => "ManageIQ::Providers::IbmCic::CloudManager")
+      ibm_cic_vm       = vm_stub.create!(:type => "ManageIQ::Providers::IbmCic::CloudManager::Vm", :ems_id => ibm_cic_ems.id)
+      ibm_cic_snapshot = snapshot_stub.create!(:vm_or_template_id => ibm_cic_vm.id)
+
+      scvmm_ems      = ems_stub.create!(:type => "ManageIQ::Providers::Microsoft::InfraManager")
+      scvmm_vm       = vm_stub.create!(:type => "ManageIQ::Providers::Microsoft::InfraManager::Vm", :ems_id => scvmm_ems.id)
+      scvmm_snapshot = snapshot_stub.create!(:vm_or_template_id => scvmm_vm.id)
+
+      ovirt_ems      = ems_stub.create!(:type => "ManageIQ::Providers::Ovirt::InfraManager")
+      ovirt_vm       = vm_stub.create!(:type => "ManageIQ::Providers::Ovirt::InfraManager::Vm", :ems_id => ovirt_ems.id)
+      ovirt_snapshot = snapshot_stub.create!(:vm_or_template_id => ovirt_vm.id)
+
+      rhv_ems      = ems_stub.create!(:type => "ManageIQ::Providers::Redhat::InfraManager")
+      rhv_vm       = vm_stub.create!(:type => "ManageIQ::Providers::Redhat::InfraManager::Vm", :ems_id => rhv_ems.id)
+      rhv_snapshot = snapshot_stub.create!(:vm_or_template_id => rhv_vm.id)
+
+      vmware_ems      = ems_stub.create!(:type => "ManageIQ::Providers::Vmware::InfraManager")
+      vmware_vm       = vm_stub.create!(:type => "ManageIQ::Providers::Vmware::InfraManager::Vm", :ems_id => vmware_ems.id)
+      vmware_snapshot = snapshot_stub.create!(:vm_or_template_id => vmware_vm.id)
+
+      migrate
+
+      expect(powervs_snapshot.reload.type).to eq("#{powervs_ems.type}::Snapshot")
+      expect(powervc_snapshot.reload.type).to eq("#{powervc_ems.type}::Snapshot")
+      expect(openstack_snapshot.reload.type).to eq("#{openstack_ems.type}::Snapshot")
+      expect(ibm_cic_snapshot.reload.type).to eq("#{ibm_cic_ems.type}::Snapshot")
+      expect(scvmm_snapshot.reload.type).to eq("#{scvmm_ems.type}::Snapshot")
+      expect(ovirt_snapshot.reload.type).to eq("#{ovirt_ems.type}::Snapshot")
+      expect(rhv_snapshot.reload.type).to eq("#{rhv_ems.type}::Snapshot")
+      expect(vmware_snapshot.reload.type).to eq("#{vmware_ems.type}::Snapshot")
+    end
+  end
+
+  migration_context :down do
+    it "Resets Snapshot#type to nil" do
+      ems      = ems_stub.create!(:type => "ManageIQ::Providers::Vmware::InfraManager")
+      vm       = vm_stub.create!(:type => "ManageIQ::Providers::Vmware::InfraManager::Vm", :ems_id => ems.id)
+      snapshot = snapshot_stub.create!(:vm_or_template_id => vm.id)
+
+      migrate
+
+      expect(snapshot.reload.type).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Certain providers (VMware) require adding provider specific logic in the Snapshot class, to keep this out of core we should allow subclassing the Snapshot class with STI

Dependents:
* https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/422
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/827
* https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/21
* https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/70
* https://github.com/ManageIQ/manageiq-providers-scvmm/pull/211
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/617
* https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization/pull/13
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/828

Cross Repo Test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/711