### PR TITLE
Migrate placement group 'list' feature to 'view'

### DIFF
--- a/db/migrate/20221010195912_update_placement_group_view_feature_identifier.rb
+++ b/db/migrate/20221010195912_update_placement_group_view_feature_identifier.rb
@@ -1,0 +1,17 @@
+class UpdatePlacementGroupViewFeatureIdentifier < ActiveRecord::Migration[6.0]
+  class MiqProductFeature < ActiveRecord::Base; end
+
+  def up
+    say_with_time("Updating Placement Group list feature to view") do
+      MiqProductFeature.find_by(:identifier => 'placement_group_list')
+                       &.update!(:identifier => 'placement_group_view')
+    end
+  end
+
+  def down
+    say_with_time("Resetting Placement Group view feature back to list") do
+      MiqProductFeature.find_by(:identifier => 'placement_group_view')
+                       &.update!(:identifier => 'placement_group_list')
+    end
+  end
+end

--- a/spec/migrations/20221010195912_update_placement_group_view_feature_identifier_spec.rb
+++ b/spec/migrations/20221010195912_update_placement_group_view_feature_identifier_spec.rb
@@ -1,0 +1,20 @@
+require_migration
+
+describe UpdatePlacementGroupViewFeatureIdentifier do
+  let(:miq_product_feature_stub) { migration_stub(:MiqProductFeature) }
+
+  migration_context :up do
+    it "Update Placement Group '_list' feature to be '_view'" do
+      miq_product_feature = miq_product_feature_stub.create(:identifier => 'placement_group_list')
+      migrate
+      expect(miq_product_feature.reload[:identifier]).to eq('placement_group_view')
+    end
+  end
+  migration_context :down do
+    it "Reset Placement Group '_view' feature back to '_list'" do
+      miq_product_feature = miq_product_feature_stub.create(:identifier => 'placement_group_view')
+      migrate
+      expect(miq_product_feature.reload[:identifier]).to eq('placement_group_list')
+    end
+  end
+end


### PR DESCRIPTION
The 'placement_group_list' product feature was renamed to 'placement_group_view' in ManageIQ/manageiq#22156