### PR TITLE
Remove VimStrings from CustomAttribute#serialized_value

### DIFF
--- a/db/migrate/20221111201223_remove_vim_strings_from_custom_attributes.rb
+++ b/db/migrate/20221111201223_remove_vim_strings_from_custom_attributes.rb
@@ -1,0 +1,36 @@
+class RemoveVimStringsFromCustomAttributes < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+  include MigrationHelper
+
+  class CustomAttribute < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    say_with_time("Removing VimStrings from CustomAttribute") do
+      base_relation = CustomAttribute.in_my_region.where("serialized_value LIKE ?", "%ruby/string:VimString%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("serialized_value = REGEXP_REPLACE(serialized_value, '!ruby/string:VimString', '!ruby/string:String', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Restoring VimStrings from CustomAttribute") do
+      base_relation = CustomAttribute.in_my_region.where("serialized_value LIKE ?", "%ruby/string:String%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("serialized_value = REGEXP_REPLACE(serialized_value, '!ruby/string:String', '!ruby/string:VimString', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+end

--- a/spec/migrations/20221111201223_remove_vim_strings_from_custom_attributes_spec.rb
+++ b/spec/migrations/20221111201223_remove_vim_strings_from_custom_attributes_spec.rb
@@ -1,0 +1,92 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe RemoveVimStringsFromCustomAttributes do
+  let(:custom_attribute_stub) { migration_stub(:CustomAttribute) }
+
+  migration_context :up do
+    it "converts VimStrings to String" do
+      serialized_value = <<~SERIALIZED_VALUE
+        ---
+        !ruby/string:VimString
+        str: BAR
+        xsiType: :SOAP::SOAPString
+        vimType:
+      SERIALIZED_VALUE
+
+      custom_attribute = custom_attribute_stub.create!(
+        :section          => "custom_field",
+        :name             => "FOO",
+        :value            => "BAR",
+        :source           => "VC",
+        :serialized_value => serialized_value
+      )
+
+      migrate
+
+      # We have to use YAML.load here instead of .safe_load because
+      # otherwise it will fail with `Tried to load unspecified class: String`
+      new_serialized_value = YAML.load(custom_attribute.reload.serialized_value)
+
+      expect(new_serialized_value.class).to eq(String)
+      expect(new_serialized_value).to eq("BAR")
+    end
+
+    it "doesn't impact standard strings" do
+      custom_attribute = custom_attribute_stub.create!(
+        :section          => "custom_field",
+        :name             => "FOO",
+        :value            => "BAR",
+        :source           => "VC",
+        :serialized_value => "BAR"
+      )
+
+      migrate
+
+      custom_attribute.reload
+      expect(custom_attribute.serialized_value.class).to eq(String)
+      expect(custom_attribute.serialized_value).to eq("BAR")
+    end
+  end
+
+  migration_context :down do
+    it "resets VimStrings to String" do
+      serialized_value = <<~SERIALIZED_VALUE
+        ---
+        !ruby/string:String
+        str: BAR
+        xsiType: :SOAP::SOAPString
+        vimType:
+      SERIALIZED_VALUE
+
+      custom_attribute = custom_attribute_stub.create!(
+        :section          => "custom_field",
+        :name             => "FOO",
+        :value            => "BAR",
+        :source           => "VC",
+        :serialized_value => serialized_value
+      )
+
+      migrate
+
+      expect(custom_attribute.reload.serialized_value).to include("ruby/string:VimString")
+    end
+
+    it "doesn't impact standard strings" do
+      custom_attribute = custom_attribute_stub.create!(
+        :section          => "custom_field",
+        :name             => "FOO",
+        :value            => "BAR",
+        :source           => "VC",
+        :serialized_value => "BAR"
+      )
+
+      migrate
+
+      custom_attribute.reload
+      expect(custom_attribute.serialized_value.class).to eq(String)
+      expect(custom_attribute.serialized_value).to eq("BAR")
+    end
+  end
+end


### PR DESCRIPTION
CustomAttribute records created by the old VimBroker style of VMware Refresher would have a serialized_value that includes VimStrings

The streaming refresh model which uses RbVmomi does not suffer the same potential problem but databases upgraded from before this change can still exhibit this issue.