### PR TITLE
Remove VimString from MiqRequestTask#options

### DIFF
--- a/db/migrate/20221114165219_remove_vim_string_from_miq_request_task_options.rb
+++ b/db/migrate/20221114165219_remove_vim_string_from_miq_request_task_options.rb
@@ -1,0 +1,38 @@
+class RemoveVimStringFromMiqRequestTaskOptions < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+  include MigrationHelper
+
+  class MiqRequestTask < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Removing VimStrings from MiqRequestTask") do
+      base_relation = MiqRequestTask.in_my_region.where("options LIKE ?", "%ruby/string:VimString%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("options = REGEXP_REPLACE(options, '!ruby/string:VimString', '!ruby/string:String', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Restoring VimStrings from MiqRequestTask") do
+      base_relation = MiqRequestTask.in_my_region.where("options LIKE ?", "%ruby/string:String%")
+      say_batch_started(base_relation.size)
+
+      loop do
+        count = base_relation.limit(50_000).update_all("options = REGEXP_REPLACE(options, '!ruby/string:String', '!ruby/string:VimString', 'g')")
+        break if count == 0
+
+        say_batch_processed(count)
+      end
+    end
+  end
+end

--- a/spec/migrations/20221114165219_remove_vim_string_from_miq_request_task_options_spec.rb
+++ b/spec/migrations/20221114165219_remove_vim_string_from_miq_request_task_options_spec.rb
@@ -1,0 +1,71 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe RemoveVimStringFromMiqRequestTaskOptions do
+  let(:miq_request_task_stub) { migration_stub(:MiqRequestTask) }
+
+  migration_context :up do
+    it "Converts VimStrings to String" do
+      options_value = <<~OPTIONS_VALUE
+        ---
+        name: ems_ref_obj
+        value_before_type_cast: |
+          --- !ruby/string:VimString
+          str: domain-c4006
+          xsiType: :ManagedObjectReference
+          vimType: :ClusterComputeResource\n
+      OPTIONS_VALUE
+
+      miq_request_task = miq_request_task_stub.create!(
+        :options => options_value
+      )
+
+      migrate
+
+      expect(miq_request_task.reload.options).not_to include("VimString")
+    end
+
+    it "doesn't impact standard strings" do
+      miq_request_task = miq_request_task_stub.create!(
+        :options => "---\name: ems_ref\nvalue: vm-1"
+      )
+
+      migrate
+
+      expect(miq_request_task.reload.options).to eq("---\name: ems_ref\nvalue: vm-1")
+    end
+  end
+
+  migration_context :down do
+    it "Resets VimStrings" do
+      options_value = <<~OPTIONS_VALUE
+        ---
+        name: ems_ref_obj
+        value_before_type_cast: |
+          --- !ruby/string:String
+          str: domain-c4006
+          xsiType: :ManagedObjectReference
+          vimType: :ClusterComputeResource\n
+      OPTIONS_VALUE
+
+      miq_request_task = miq_request_task_stub.create!(
+        :options => options_value
+      )
+
+      migrate
+
+      expect(miq_request_task.reload.options).to include("VimString")
+    end
+
+    it "doesn't impact standard strings" do
+      miq_request_task = miq_request_task_stub.create!(
+        :options => "---\name: ems_ref\nvalue: vm-1"
+      )
+
+      migrate
+
+      expect(miq_request_task.reload.options).to eq("---\name: ems_ref\nvalue: vm-1")
+    end
+  end
+end


### PR DESCRIPTION
There are occasions where a full VM object was serialized to the `#options` column of `MiqRequestTask` prior to the migration to remove the ems_ref_obj serialized column.  This means we still had serialized VimStrings in the options column causing load of these records to fail.

This is not something which is an issue after the migration to drop ems_ref_obj, but old miq_request_tasks could have this problem.

```
name: ems_ref_obj\n      value_before_type_cast: |\n        --- !ruby/string:VimString\n        str: domain-c4006\n        xsiType: :ManagedObjectReference\n        vimType: :ClusterComputeResource\n
```

Similar issue to https://github.com/ManageIQ/manageiq-schema/pull/670