### PR TITLE
Transfer IsoDatastore records to Storage and drop table

### DIFF
--- a/db/migrate/20221107195522_move_existing_iso_datastore_records.rb
+++ b/db/migrate/20221107195522_move_existing_iso_datastore_records.rb
@@ -1,0 +1,67 @@
+class MoveExistingIsoDatastoreRecords < ActiveRecord::Migration[6.1]
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    has_many :iso_datastores, :foreign_key => :ems_id, :class_name => "MoveExistingIsoDatastoreRecords::IsoDatastore"
+  end
+
+  class Storage < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "MoveExistingIsoDatastoreRecords::ExtManagementSystem"
+    has_many :iso_images, :class_name => "MoveExistingIsoDatastoreRecords::IsoImage"
+  end
+
+  class IsoDatastore < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "MoveExistingIsoDatastoreRecords::ExtManagementSystem"
+    has_many :iso_images, :class_name => "MoveExistingIsoDatastoreRecords::IsoImage"
+  end
+
+  class IsoImage < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+
+    belongs_to :storage, :class_name => "MoveExistingIsoDatastoreRecords::Storage"
+    belongs_to :iso_datastore, :class_name => "MoveExistingIsoDatastoreRecords::IsoDatastore"
+  end
+
+  def up
+    say_with_time("Transfer existing IsoDatastore records to Storage") do
+      add_reference :iso_images, :storage
+
+      IsoDatastore.in_my_region
+                  .joins(:ext_management_system)
+                  .where(:ext_management_systems => {:type => ["ManageIQ::Providers::Ovirt::InfraManager", "ManageIQ::Providers::Redhat::InfraManager"]})
+                  .each do |datastore|
+        datastore_class_name = "#{datastore.ext_management_system.type}::IsoDatastore"
+        storage = Storage.create!(:ems_id => datastore.ems_id, :store_type => "ISO", :type => datastore_class_name)
+
+        datastore.iso_images.each do |image|
+          image.update!(:storage_id => storage.id)
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time("Transfer eligible Storage records to IsoDatastore") do
+      Storage.in_my_region
+             .where(:type => ["ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore", "ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore"])
+             .each do |storage|
+        datastore = IsoDatastore.create!(:ems_id => storage.ems_id)
+
+        storage.iso_images.each do |image|
+          image.update!(:iso_datastore_id => datastore.id)
+        end
+
+        storage.destroy!
+      end
+
+      remove_reference :iso_images, :storage
+    end
+  end
+end

--- a/db/migrate/20221107195559_drop_iso_datastore.rb
+++ b/db/migrate/20221107195559_drop_iso_datastore.rb
@@ -1,0 +1,19 @@
+class DropIsoDatastore < ActiveRecord::Migration[6.1]
+  def up
+    say_with_time("Drop IsoDatastore table") do
+      remove_reference :iso_images, :iso_datastore
+      drop_table :iso_datastores
+    end
+  end
+
+  def down
+    say_with_time("Create IsoDatastore table") do
+      create_table :iso_datastores, :force => :cascade do |t|
+        t.bigint :ems_id
+        t.datetime :last_refresh_on
+      end
+
+      add_reference :iso_images, :iso_datastore
+    end
+  end
+end

--- a/spec/migrations/20221107195522_move_existing_iso_datastore_records_spec.rb
+++ b/spec/migrations/20221107195522_move_existing_iso_datastore_records_spec.rb
@@ -1,0 +1,65 @@
+require_migration
+
+describe MoveExistingIsoDatastoreRecords do
+  let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
+  let(:datastore_stub) { migration_stub(:IsoDatastore) }
+  let(:storage_stub) { migration_stub(:Storage) }
+  let(:iso_image_stub) { migration_stub(:IsoImage) }
+
+  migration_context :up do
+    it "transfers datastore records to storages" do
+      emss = %w[Ovirt Redhat].map do |vendor|
+        ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
+      end
+
+      emss.each { |ems| datastore_stub.create!(:ext_management_system => ems) }
+
+      migrate
+
+      storage_stub.all.each do |storage|
+        expect(storage.reload.type).to eq("#{storage.ext_management_system.type}::IsoDatastore")
+      end
+    end
+
+    it "transfers datastore records with iso images to storages" do
+      emss = %w[Ovirt Redhat].map do |vendor|
+        ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
+      end
+
+      emss.each do |ems|
+        datastore = datastore_stub.create!(:ext_management_system => ems)
+        iso_image_stub.create!(:iso_datastore_id => datastore.id)
+      end
+
+      migrate
+
+      storage_stub.all.each do |storage|
+        expect(storage.reload.type).to eq("#{storage.ext_management_system.type}::IsoDatastore")
+        expect(storage.iso_images.first.storage_id).to eq(storage.id)
+      end
+    end
+  end
+
+  migration_context :down do
+    it "transfers eligible storage records to datastores" do
+      storage = storage_stub.create!(:type => "ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore")
+
+      migrate
+
+      datastore = datastore_stub.first
+      expect(datastore).to have_attributes(:ems_id => storage.ems_id)
+    end
+
+    it "transfers eligible storage records with iso images to datastores" do
+      storage = storage_stub.create!(:type => "ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore")
+      iso_image_stub.create!(:storage_id => storage.id)
+
+      migrate
+
+      datastore = datastore_stub.first
+      iso_image = iso_image_stub.first
+      expect(datastore).to have_attributes(:ems_id => storage.ems_id)
+      expect(iso_image).to have_attributes(:iso_datastore_id => datastore.id)
+    end
+  end
+end

--- a/spec/support/table_list.txt
+++ b/spec/support/table_list.txt
@@ -128,7 +128,6 @@ host_storages
 host_switches
 hosts
 import_file_uploads
-iso_datastores
 iso_images
 jobs
 key_pairs_vms


### PR DESCRIPTION
- schema changes to facilitate transfer of `:iso_datastore` records to `:storage` table
- iso datastores will be modelled as `Storage` objects with STI `:type => ManageIQ::Providers::Ovirt::InfraManager::IsoDatastore`

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/621

@miq-bot add_labels enhancement, technical debt
@miq-bot assign @agrare 