### PR TITLE
Add capability values schema as jsonb field to storage models

### DIFF
--- a/db/migrate/20221116104013_add_capabilities_to_physical_storage_models.rb
+++ b/db/migrate/20221116104013_add_capabilities_to_physical_storage_models.rb
@@ -1,0 +1,8 @@
+class AddCapabilitiesToPhysicalStorageModels < ActiveRecord::Migration[6.1]
+  def change
+    add_column :physical_storage_families, :capabilities, :jsonb, :default => {}
+    add_column :physical_storages, :capabilities, :jsonb, :default => {}
+    add_column :storage_resources, :capabilities, :jsonb, :default => {}
+    add_column :storage_services, :capabilities, :jsonb, :default => {}
+  end
+end


### PR DESCRIPTION
We added capability values schema as jsonb field to physical storage, storage family, storage services and storage resources as requested by @agrare . 

<img width="1133" alt="Screen Shot 2022-12-04 at 15 39 23" src="https://user-images.githubusercontent.com/74841666/205493775-da6d20b5-2daf-45b0-b4fb-5e777f9e48f6.png">

related pr: https://github.com/ManageIQ/manageiq-api/pull/1190

W/ @OrGur1987