### PR TITLE
fixed capability jsonb column default

### DIFF
--- a/db/migrate/20221116104013_add_capabilities_to_physical_storage_models.rb
+++ b/db/migrate/20221116104013_add_capabilities_to_physical_storage_models.rb
@@ -1,8 +1,8 @@
 class AddCapabilitiesToPhysicalStorageModels < ActiveRecord::Migration[6.1]
   def change
-    add_column :physical_storage_families, :capabilities, :jsonb, :default => {}
-    add_column :physical_storages, :capabilities, :jsonb, :default => {}
-    add_column :storage_resources, :capabilities, :jsonb, :default => {}
-    add_column :storage_services, :capabilities, :jsonb, :default => {}
+    add_column :physical_storage_families, :capabilities, :jsonb, :default => []
+    add_column :physical_storages, :capabilities, :jsonb, :default => []
+    add_column :storage_resources, :capabilities, :jsonb, :default => []
+    add_column :storage_services, :capabilities, :jsonb, :default => []
   end
 end


### PR DESCRIPTION
Change default value from {} to [] so that field will save capabilities as a array.

https://github.com/ManageIQ/manageiq-ui-classic/pull/8584
https://github.com/ManageIQ/manageiq-providers-autosde/pull/195