### PR TITLE
[WIP] use be_deleted instead of catching RecordNotFound

### DIFF
--- a/spec/migrations/20180718132840_remove_transformation_product_setting_spec.rb
+++ b/spec/migrations/20180718132840_remove_transformation_product_setting_spec.rb
@@ -10,7 +10,7 @@ describe RemoveTransformationProductSetting do
 
       migrate
 
-      expect { setting_changed.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(setting_changed).to be_deleted
       expect(setting_ignored.reload.value).to eq(true)
     end
   end

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -52,7 +52,7 @@ describe AddConversionHostIdToMiqRequestTasks do
 
       task.reload
       expect(task.options[:transformation_host_id]).to eq(host.id)
-      expect { conversion_host.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(conversion_host).to be_deleted
     end
   end
 end

--- a/spec/migrations/20190918133037_remove_rails_server_from_settings_spec.rb
+++ b/spec/migrations/20190918133037_remove_rails_server_from_settings_spec.rb
@@ -12,7 +12,7 @@ describe RemoveRailsServerFromSettings do
 
       migrate
 
-      expect { setting_changed.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(setting_changed).to be_deleted
       expect(setting_ignored.reload.value).to eq("something")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require "manageiq/password/rspec_matchers"
 ManageIQ::Password.key_root = File.expand_path("dummy/certs", __dir__)
 
 Dir[File.expand_path("support/**/*.rb", __dir__)].each { |f| require f }
+Dir[Rails.root.join('spec', 'shared', '**', '*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true


### PR DESCRIPTION
I'm a fan of [be_deleted](https://github.com/ManageIQ/manageiq/blob/master/spec/custom_matchers/be_deleted_spec.rb)

this change does nothing and drop if you don't like