### PR TITLE
Delete any Foreman Provisioning SettingsChanges

### DIFF
--- a/db/migrate/20230322171110_delete_foreman_provisioning_refresh_settings.rb
+++ b/db/migrate/20230322171110_delete_foreman_provisioning_refresh_settings.rb
@@ -1,0 +1,11 @@
+class DeleteForemanProvisioningRefreshSettings < ActiveRecord::Migration[6.1]
+  class SettingsChange < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    say_with_time("Deleting Foreman ProvisioningManager Refresh SettingsChanges") do
+      SettingsChange.in_my_region.where("key LIKE '/ems_refresh/foreman_provisioning/%'").delete_all
+    end
+  end
+end

--- a/spec/migrations/20230322171110_delete_foreman_provisioning_refresh_settings_spec.rb
+++ b/spec/migrations/20230322171110_delete_foreman_provisioning_refresh_settings_spec.rb
@@ -1,0 +1,19 @@
+require_migration
+
+describe DeleteForemanProvisioningRefreshSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "Deletes Foreman ProvisioningManager Refresh settings" do
+      settings_change_stub.create(:key => "/ems_refresh/foreman_provisioning/refresh_interval", :value => "30.minutes")
+      migrate
+      expect(settings_change_stub.count).to be_zero
+    end
+
+    it "Doesn't impact unrelated settings" do
+      settings_change_stub.create(:key => "/ems_refresh/foreman_configuration/refresh_interval", :value => "30.minutes")
+      migrate
+      expect(settings_change_stub.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
We do not use the Forman ProvisioningManager RefreshWorker any longer so we should delete any associated settings_changes.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/113