### PR TITLE
Use configuration_scripts table for Workflows

### DIFF
--- a/db/migrate/20230407170430_add_payload_credentials_configuration_scripts.rb
+++ b/db/migrate/20230407170430_add_payload_credentials_configuration_scripts.rb
@@ -3,6 +3,7 @@ class AddPayloadCredentialsConfigurationScripts < ActiveRecord::Migration[6.1]
     change_table :configuration_scripts do |t|
       t.string     :run_by_userid
       t.jsonb      :payload
+      t.string     :payload_type
       t.jsonb      :credentials
       t.jsonb      :context
       t.jsonb      :output

--- a/db/migrate/20230407170430_add_payload_credentials_configuration_scripts.rb
+++ b/db/migrate/20230407170430_add_payload_credentials_configuration_scripts.rb
@@ -2,7 +2,7 @@ class AddPayloadCredentialsConfigurationScripts < ActiveRecord::Migration[6.1]
   def change
     change_table :configuration_scripts do |t|
       t.string     :run_by_userid
-      t.jsonb      :payload
+      t.string     :payload
       t.string     :payload_type
       t.jsonb      :credentials
       t.jsonb      :context

--- a/db/migrate/20230407170430_add_payload_credentials_configuration_scripts.rb
+++ b/db/migrate/20230407170430_add_payload_credentials_configuration_scripts.rb
@@ -1,0 +1,13 @@
+class AddPayloadCredentialsConfigurationScripts < ActiveRecord::Migration[6.1]
+  def change
+    change_table :configuration_scripts do |t|
+      t.string     :run_by_userid
+      t.jsonb      :payload
+      t.jsonb      :credentials
+      t.jsonb      :context
+      t.jsonb      :output
+      t.string     :status
+      t.references :miq_task
+    end
+  end
+end


### PR DESCRIPTION
Rather than introduce new workflows/workflow_instances tables reuse the existing configuration_scripts table that ansible_tower and embedded_ansible use.

Dependents:
- [ ] https://github.com/ManageIQ/manageiq/pull/22477
- [ ] https://github.com/ManageIQ/manageiq-providers-workflows/pull/12

https://github.com/ManageIQ/manageiq/issues/22311