### PR TITLE
Add ConfigurationScript to ResourceAction

### DIFF
--- a/db/migrate/20230426164308_add_configuration_script_to_resource_action.rb
+++ b/db/migrate/20230426164308_add_configuration_script_to_resource_action.rb
@@ -1,0 +1,5 @@
+class AddConfigurationScriptToResourceAction < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :resource_actions, :configuration_script
+  end
+end


### PR DESCRIPTION
Allow for configuration_scripts to be referenced by resource_actions for dynamic_dialogs / service provisioning/reconfiguration/retirement

Dependents:
* https://github.com/ManageIQ/manageiq/pull/22487