### PR TITLE
Converge batch_size and concurrent_requests

### DIFF
--- a/db/migrate/20230522194044_move_concurrent_requests_settings_to_vmware.rb
+++ b/db/migrate/20230522194044_move_concurrent_requests_settings_to_vmware.rb
@@ -1,0 +1,25 @@
+class MoveConcurrentRequestsSettingsToVmware < ActiveRecord::Migration[6.1]
+  class SettingsChange < ActiveRecord::Base
+  end
+
+  def up
+    # global concurrent_requests
+    #   only currently read by vmware
+    #
+    # rename "/performance/concurrent_requests/{realtime,historical,}" =>
+    #        "/ems/ems_vmware/concurrent_requests/*"
+    say_with_time("Moving global concurrent requests to provider") do
+      SettingsChange.where("key LIKE ?", "/performance/concurrent_requests/%")
+                    .update_all("key = REPLACE(key, '/performance/concurrent_requests/', '/ems/ems_vmware/concurrent_requests/')")
+    end
+  end
+
+  def down
+    # rename "/ems/ems_vmware/concurrent_requests/*" =>
+    #        "/performance/concurrent_requests/{realtime,historical,}"
+    say_with_time("Moving provider concurrent requests to global") do
+      SettingsChange.where("key LIKE ?", "/ems/ems_vmware/concurrent_requests/%")
+                    .update_all("key = REPLACE(key, '/ems/ems_vmware/concurrent_requests/', '/performance/concurrent_requests/')")
+    end
+  end
+end

--- a/spec/migrations/20230522194044_move_concurrent_requests_settings_to_vmware_spec.rb
+++ b/spec/migrations/20230522194044_move_concurrent_requests_settings_to_vmware_spec.rb
@@ -1,0 +1,31 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe MoveConcurrentRequestsSettingsToVmware do
+  let(:settings_change) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "moves global concurrent_requests to vmware" do
+      record1 = settings_change.create!(:key => "/performance/concurrent_requests/realtime", :value => '250')
+      record2 = settings_change.create!(:key => "/performance/concurrent_requests/historical", :value => '250')
+      record3 = settings_change.create!(:key => "/other/key", :value => 'x')
+      migrate
+      expect(record1.reload.key).to eq("/ems/ems_vmware/concurrent_requests/realtime")
+      expect(record2.reload.key).to eq("/ems/ems_vmware/concurrent_requests/historical")
+      expect(record3.reload.key).to eq("/other/key")
+    end
+  end
+
+  migration_context :down do
+    it "moves concurrent_requests back to global settings" do
+      record1 = settings_change.create!(:key => "/ems/ems_vmware/concurrent_requests/realtime", :value => '250')
+      record2 = settings_change.create!(:key => "/ems/ems_vmware/concurrent_requests/historical", :value => '250')
+      record3 = settings_change.create!(:key => "/other/key", :value => 'x')
+      migrate
+      expect(record1.reload.key).to eq("/performance/concurrent_requests/realtime")
+      expect(record2.reload.key).to eq("/performance/concurrent_requests/historical")
+      expect(record3.reload.key).to eq("/other/key")
+    end
+  end
+end


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/22510

2 settings concepts have been merged

Had originally intended to keep the batch_size, but there wasn't a good way to keep it
and avoid duplicates from the /performance/concurrent_requests keys.
It is so new that we are ignoring it for now. No one would have populated the value.


The values that are currently used are 20,1,1 -- which are way low.
locally I use 250,100,100 -- so may want to keep that in mind