### PR TITLE
Set the instance_type for VPC provision requests

### DIFF
--- a/db/migrate/20230525200407_fix_vpc_provision_instance_type.rb
+++ b/db/migrate/20230525200407_fix_vpc_provision_instance_type.rb
@@ -1,0 +1,46 @@
+class FixVpcProvisionInstanceType < ActiveRecord::Migration[6.1]
+  class VmOrTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+    self.table_name = "vms"
+  end
+
+  class MiqRequest < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+
+    serialize :options, Hash
+  end
+
+  def up
+    say_with_time("Setting instance_type for VPC provision requests") do
+      MiqRequest.in_my_region.where(
+        :type        => "MiqProvisionRequestTemplate",
+        :source_type => "VmOrTemplate",
+        :source_id   => VmOrTemplate.where(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template")
+      ).each do |miq_request|
+        next if miq_request.options.key?(:instance_type) || !miq_request.options.key?(:provision_type)
+
+        miq_request.options[:instance_type] = miq_request.options.delete(:provision_type)
+        miq_request.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time("Setting provision_type for VPC provision requests") do
+      MiqRequest.in_my_region.where(
+        :type        => "MiqProvisionRequestTemplate",
+        :source_type => "VmOrTemplate",
+        :source_id   => VmOrTemplate.where(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template")
+      ).each do |miq_request|
+        next if !miq_request.options.key?(:instance_type) || miq_request.options.key?(:provision_type)
+
+        miq_request.options[:provision_type] = miq_request.options.delete(:instance_type)
+        miq_request.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20230525200407_fix_vpc_provision_instance_type_spec.rb
+++ b/spec/migrations/20230525200407_fix_vpc_provision_instance_type_spec.rb
@@ -1,0 +1,58 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe FixVpcProvisionInstanceType do
+  let(:vm_or_template_stub) { migration_stub(:VmOrTemplate) }
+  let(:miq_request_stub)    { migration_stub(:MiqRequest) }
+
+  migration_context :up do
+    it "Fixes VPC provision requests" do
+      vpc_template = vm_or_template_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template")
+      request      = miq_request_stub.create!(:type => "MiqProvisionRequestTemplate", :source_type => "VmOrTemplate", :source_id => vpc_template.id, :options => {:provision_type => [1, "t2.micro"]})
+
+      migrate
+
+      request.reload
+
+      expect(request.options[:instance_type]).to eq([1, "t2.micro"])
+      expect(request.options).not_to             have_key(:provision_type)
+    end
+
+    it "Doesn't impact other provision requests" do
+      vpc_template = vm_or_template_stub.create!(:type => "ManageIQ::Providers::Vmware::InfraManager::Template")
+      request      = miq_request_stub.create!(:type => "MiqProvisionRequestTemplate", :source_type => "VmOrTemplate", :source_id => vpc_template.id, :options => {:provision_type => ["pxe", "PXE"]})
+
+      migrate
+
+      request.reload
+
+      expect(request.options[:provision_type]).to eq(["pxe", "PXE"])
+    end
+  end
+
+  migration_context :down do
+    it "Resets VPC provision requests" do
+      vpc_template = vm_or_template_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template")
+      request      = miq_request_stub.create!(:type => "MiqProvisionRequestTemplate", :source_type => "VmOrTemplate", :source_id => vpc_template.id, :options => {:instance_type => [1, "t2.micro"]})
+
+      migrate
+
+      request.reload
+
+      expect(request.options[:provision_type]).to eq([1, "t2.micro"])
+      expect(request.options).not_to              have_key(:instance_type)
+    end
+
+    it "Doesn't impact other provision requests" do
+      vpc_template = vm_or_template_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::Template")
+      request      = miq_request_stub.create!(:type => "MiqProvisionRequestTemplate", :source_type => "VmOrTemplate", :source_id => vpc_template.id, :options => {:instance_type => [1, "t2.micro"]})
+
+      migrate
+
+      request.reload
+
+      expect(request.options[:instance_type]).to eq([1, "t2.micro"])
+    end
+  end
+end


### PR DESCRIPTION
Core quota code depends on having an `options[:instance_type]` set to the selected flavor.  VPC was using a different key for some reason (:provision_type) which means something completely different for Infra provision requests.

Related, co-dependent change: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/457

TODO:
- [x] spec tests