### PR TITLE
Separate Role Access Restrictions for Service Templates

### DIFF
--- a/db/migrate/20230709065227_separate_role_access_restrictions_for_service_templates.rb
+++ b/db/migrate/20230709065227_separate_role_access_restrictions_for_service_templates.rb
@@ -1,0 +1,26 @@
+class SeparateRoleAccessRestrictionsForServiceTemplates < ActiveRecord::Migration[6.0]
+  class MiqUserRole < ActiveRecord::Base
+    serialize :settings
+  end
+
+  def up
+    say_with_time("Updating MiqUserRole restictions so Service Templates match existing VMs") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%vms: :user%'").find_each do |role|
+        role.settings[:restrictions][:service_templates] = role.settings.dig(:restrictions, :vms)
+        role.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time("Remove Service Templates from MiqUserRole restictions") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%service_templates:%'").find_each do |role|
+        role.settings[:restrictions].delete(:service_templates)
+        if role.settings[:restrictions] == {} && role.settings.length == 1
+          role.settings = nil
+        end
+        role.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20230709065227_separate_role_access_restrictions_for_service_templates_spec.rb
+++ b/spec/migrations/20230709065227_separate_role_access_restrictions_for_service_templates_spec.rb
@@ -1,0 +1,140 @@
+require_migration
+
+describe SeparateRoleAccessRestrictionsForServiceTemplates do
+  let(:miq_user_role_stub) { migration_stub(:MiqUserRole) }
+
+  migration_context :up do
+    it "Existing Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true,
+                                                :settings  => {:restrictions => {:vms => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+    end
+
+    it "Existing Role with ':vms=>:user_or_group' adds ':service_templates=>:user_or_group'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group, :service_templates => :user_or_group}})
+    end
+
+    it "Existing Role with ':vms=>:user' adds ':service_templates=>:user'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user, :service_templates => :user}})
+    end
+
+    it "Existing Role with something else in settings is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:foo => {:bar => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:foo => {:bar => :user}})
+    end
+
+    it "Existing Role with something else in settings and ':vms=>:user' adds ':service_templates=>:user'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:foo => {:bar => :user}, :restrictions => {:vms => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:foo => {:bar => :user}, :restrictions => {:vms => :user, :service_templates => :user}})
+    end
+  end
+
+  migration_context :down do
+    it "Existing Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :service_templates => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group, :service_templates => :user_or_group}})
+    end
+
+    it "Existing Role removes ':service_templates=>:user_or_group'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :service_templates => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+    end
+
+    it "Existing Role removes ':service_templates=>:user_or_group' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:service_templates => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role removes ':service_templates=>:user'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user, :service_templates => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user}})
+    end
+
+    it "Existing Role removes ':service_templates=>:user' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:service_templates => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role with something else in settings is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:foo => {:bar => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:foo => {:bar => :user}})
+    end
+  end
+end


### PR DESCRIPTION
Related to:
- ManageIQ/manageiq#22573
- ManageIQ/manageiq#22613
- ManageIQ/manageiq-ui-classic#8833

Migration to handle the separate access restrictions for service templates. Note that the migration only affects custom roles, which can easily be filtered by `:read_only = false`. [The 6072d2c core commit](https://github.com/ManageIQ/manageiq/pull/22573/commits/6072d2c82c4036bed6668e6086c0d7fa2fad3bf8) takes care of updating the read-only, built-in `EvmRole-user_limited_self_service` and `EvmRole-user_self_service` roles so that they are functionally the same before and after the separate access restrictions.