### PR TITLE
[WIP] Allow more specific restriction types for roles

### DIFF
--- a/db/migrate/20230808144930_allow_more_specific_restriction_types_for_roles.rb
+++ b/db/migrate/20230808144930_allow_more_specific_restriction_types_for_roles.rb
@@ -1,0 +1,62 @@
+class AllowMoreSpecificRestrictionTypesForRoles < ActiveRecord::Migration[6.0]
+  class MiqUserRole < ActiveRecord::Base
+    serialize :settings
+  end
+
+  def up
+    # auth_key_pairs
+    say_with_time("Updating MiqUserRole restictions so Auth Key Pairs match existing VMs") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%vms: :user%'").find_each do |role|
+        role.settings[:restrictions][:auth_key_pairs] = role.settings.dig(:restrictions, :vms)
+        role.save!
+      end
+    end
+    # orchestration_stacks
+    say_with_time("Updating MiqUserRole restictions so Orchestration Stacks match existing VMs") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%vms: :user%'").find_each do |role|
+        role.settings[:restrictions][:orchestration_stacks] = role.settings.dig(:restrictions, :vms)
+        role.save!
+      end
+    end
+    # services
+    say_with_time("Updating MiqUserRole restictions so Services match existing VMs") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%vms: :user%'").find_each do |role|
+        role.settings[:restrictions][:services] = role.settings.dig(:restrictions, :vms)
+        role.save!
+      end
+    end
+  end
+
+  def down
+    # auth_key_pairs
+    say_with_time("Remove Auth Key Pairs from MiqUserRole restictions") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%auth_key_pairs:%'").find_each do |role|
+        role.settings[:restrictions].delete(:auth_key_pairs)
+        if role.settings[:restrictions] == {} && role.settings.length == 1
+          role.settings = nil
+        end
+        role.save!
+      end
+    end
+    # orchestration_stacks
+    say_with_time("Remove Orchestration Stacks from MiqUserRole restictions") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%orchestration_stacks:%'").find_each do |role|
+        role.settings[:restrictions].delete(:orchestration_stacks)
+        if role.settings[:restrictions] == {} && role.settings.length == 1
+          role.settings = nil
+        end
+        role.save!
+      end
+    end
+    # services
+    say_with_time("Remove Services from MiqUserRole restictions") do
+      MiqUserRole.where(:read_only => false).where("settings LIKE '%services:%'").find_each do |role|
+        role.settings[:restrictions].delete(:services)
+        if role.settings[:restrictions] == {} && role.settings.length == 1
+          role.settings = nil
+        end
+        role.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20230808144930_allow_more_specific_restriction_types_for_roles_spec.rb
+++ b/spec/migrations/20230808144930_allow_more_specific_restriction_types_for_roles_spec.rb
@@ -1,0 +1,286 @@
+require_migration
+
+describe AllowMoreSpecificRestrictionTypesForRoles do
+  let(:miq_user_role_stub) { migration_stub(:MiqUserRole) }
+
+  migration_context :up do
+    it "Existing Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true,
+                                                :settings  => {:restrictions => {:vms => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+    end
+
+    it "Existing Role with something else in settings is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:foo => {:bar => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:foo => {:bar => :user}})
+    end
+
+    it "Existing Role with ':vms=>:user_or_group' adds ':user_or_group' values for each new restriction" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(
+        :settings => {
+          :restrictions => {
+            :vms                  => :user_or_group,
+            :auth_key_pairs       => :user_or_group,
+            :orchestration_stacks => :user_or_group,
+            :services             => :user_or_group
+          }
+        }
+      )
+    end
+
+    it "Existing Role with ':vms=>:user' adds ':user' values for each new restriction" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(
+        :settings => {
+          :restrictions => {
+            :vms                  => :user,
+            :auth_key_pairs       => :user,
+            :orchestration_stacks => :user,
+            :services             => :user
+          }
+        }
+      )
+    end
+
+    it "Existing Role with something else in settings and ':vms=>:user' adds ':user' values for each new restriction" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:foo => {:bar => :user}, :restrictions => {:vms => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(
+        :settings => {
+          :foo          => {:bar => :user},
+          :restrictions => {
+            :vms                  => :user,
+            :auth_key_pairs       => :user,
+            :orchestration_stacks => :user,
+            :services             => :user
+          }
+        }
+      )
+    end
+  end
+
+  migration_context :down do
+    it "Existing Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with no restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true, :settings => nil)
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role with something else in settings is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:foo => {:bar => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:foo => {:bar => :user}})
+    end
+
+    # auth_key_pairs
+    it "Existing read only Role with restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :auth_key_pairs => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group, :auth_key_pairs => :user_or_group}})
+    end
+
+    it "Existing Role removes ':auth_key_pairs=>:user_or_group'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :auth_key_pairs => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+    end
+
+    it "Existing Role removes ':auth_key_pairs=>:user_or_group' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:auth_key_pairs => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role removes ':auth_key_pairs=>:user'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user, :auth_key_pairs => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user}})
+    end
+
+    it "Existing Role removes ':auth_key_pairs=>:user' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:auth_key_pairs => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :orchestration_stacks => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group, :orchestration_stacks => :user_or_group}})
+    end
+
+    it "Existing Role removes ':orchestration_stacks=>:user_or_group'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :orchestration_stacks => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+    end
+
+    it "Existing Role removes ':orchestration_stacks=>:user_or_group' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:orchestration_stacks => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role removes ':orchestration_stacks=>:user'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user, :orchestration_stacks => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user}})
+    end
+
+    it "Existing Role removes ':orchestration_stacks=>:user' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:orchestration_stacks => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing read only Role with restrictions is unchanged" do
+      miq_user_role = miq_user_role_stub.create(:read_only => true,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :services => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group, :services => :user_or_group}})
+    end
+
+    it "Existing Role removes ':services=>:user_or_group'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user_or_group, :services => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user_or_group}})
+    end
+
+    it "Existing Role removes ':services=>:user_or_group' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:services => :user_or_group}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role removes ':services=>:user'" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:vms => :user, :services => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => {:restrictions => {:vms => :user}})
+    end
+
+    it "Existing Role removes ':services=>:user' (no :vms restrictions)" do
+      miq_user_role = miq_user_role_stub.create(:read_only => false,
+                                                :settings  => {:restrictions => {:services => :user}})
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(:settings => nil)
+    end
+
+    it "Existing Role removes mix of all new restrictions" do
+      miq_user_role = miq_user_role_stub.create(
+        :read_only => false,
+        :settings  => {
+          :restrictions => {
+            :vms                  => :user,
+            :auth_key_pairs       => :user,
+            :orchestration_stacks => :user,
+            :services             => :user,
+            :service_templates    => :user
+          }
+        }
+      )
+
+      migrate
+
+      expect(miq_user_role.reload).to have_attributes(
+        :read_only => false,
+        :settings  => {
+          :restrictions => {
+            :vms               => :user,
+            :service_templates => :user
+          }
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Related to:
- ManageIQ/manageiq#22650
- ManageIQ/manageiq-ui-classic#8891

Follow up to #697, which introduced separate restrictions for Catalog Items.

This changes further splits the role restriction settings to include the following types:
- Catalog Items
- Key Pairs
- Orchestration Stacks
- Services
- VMs and Templates