### PR TITLE
Delete invalid nil timestamp event streams

### DIFF
--- a/db/migrate/20230830134742_delete_nil_timestamp_event_streams.rb
+++ b/db/migrate/20230830134742_delete_nil_timestamp_event_streams.rb
@@ -1,0 +1,11 @@
+class DeleteNilTimestampEventStreams < ActiveRecord::Migration[6.1]
+  class EventStream < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Deleting event_streams with nil timestamp values") do
+      EventStream.where(:timestamp => nil).delete_all
+    end
+  end
+end

--- a/spec/migrations/20230830134742_delete_nil_timestamp_event_streams_spec.rb
+++ b/spec/migrations/20230830134742_delete_nil_timestamp_event_streams_spec.rb
@@ -1,0 +1,18 @@
+require_migration
+
+describe DeleteNilTimestampEventStreams do
+  let(:event_stream_stub) { migration_stub(:EventStream) }
+
+  migration_context :up do
+    it "removes nil timestamp events, leaving others" do
+      good = event_stream_stub.create!(:timestamp => Time.now.utc)
+      event_stream_stub.create!(:timestamp => nil)
+
+      migrate
+
+      expect(event_stream_stub.count).to eq(1)
+      expect(event_stream_stub.first.id).to eq(good.id)
+      expect(event_stream_stub.first.timestamp).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Until https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/501 code lands, openshift events with nil timestamps will be added to event streams.

These are invalid events and really mess up our queries since we timestamp is a lookup field and expected to use an index which doesn't happen when it's nil.