### PR TITLE
Support ruby 3.1

### DIFF
--- a/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
+++ b/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
@@ -14,6 +14,10 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
     update_authentications
   end
 
+  def self.read_token(file)
+    File.read(file)
+  end
+
   private
 
   def containerized?
@@ -88,7 +92,7 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
   def request_params
     {
       'Accept'         => "application/json",
-      'Authorization'  => "Bearer #{File.read(TOKEN_FILE)}",
+      'Authorization'  => "Bearer #{self.class.read_token(TOKEN_FILE)}",
       :ssl_ca_cert     => CA_CERT_FILE,
       :ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER
     }

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ancestry"
   spec.add_dependency "activerecord-id_regions", "~> 0.3.2"
   spec.add_dependency "linux_admin",             "~> 2.0"
-  spec.add_dependency "manageiq-password",       "< 2"
+  spec.add_dependency "manageiq-password",       ">= 1.2.0", "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"
   spec.add_dependency "pg"
   spec.add_dependency "rails",                   ">=6.0.4", "<7.0"

--- a/spec/migrations/20180606155924_move_ansible_container_secrets_into_database_spec.rb
+++ b/spec/migrations/20180606155924_move_ansible_container_secrets_into_database_spec.rb
@@ -111,7 +111,7 @@ describe MoveAnsibleContainerSecretsIntoDatabase do
   end
 
   def expect_request
-    expect(File).to receive(:read).with(token_path).and_return("totally-a-token")
+    expect(described_class).to receive(:read_token).with(token_path).and_return("totally-a-token")
     response = double("RequestIO", :read => secret_json)
     expect(uri_stub).to receive(:open).with({
       'Accept'         => "application/json",

--- a/spec/support/yaml_alias_load_as_unsafe_load.rb
+++ b/spec/support/yaml_alias_load_as_unsafe_load.rb
@@ -1,0 +1,4 @@
+if Psych::VERSION >= "4.0"
+  require 'yaml'
+  YAML.singleton_class.alias_method :load, :unsafe_load
+end


### PR DESCRIPTION
* Update stubs to work with manageiq-password 1.2.0+
* For tests, use YAML.unsafe load in psych 4+

Part of https://github.com/ManageIQ/manageiq/issues/22696