### PR TITLE
Add new resource_pools column for cpu_cores_*

### DIFF
--- a/db/migrate/20231018141450_add_cpu_cores_columns_to_resource_pools.rb
+++ b/db/migrate/20231018141450_add_cpu_cores_columns_to_resource_pools.rb
@@ -1,0 +1,34 @@
+class AddCpuCoresColumnsToResourcePools < ActiveRecord::Migration[6.0]
+  class ResourcePool < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    add_column :resource_pools, :cpu_cores_available, :float
+    add_column :resource_pools, :cpu_cores_reserve, :float
+    add_column :resource_pools, :cpu_cores_limit, :float
+
+    say_with_time('Removing non-applicable data from IbmCloud::PowerVirtualServer resource pools') do
+      ResourcePool.in_my_region.where(:type => %w[ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ResourcePool]).update_all(
+        :cpu_shares  => nil,
+        :cpu_reserve => nil,
+        :cpu_limit   => nil
+      )
+    end
+
+    say_with_time('Removing non-applicable data from IbmPowerHmc resource pools') do
+      ResourcePool.in_my_region.where(:type => %w[ManageIQ::Providers::IbmPowerHmc::InfraManager::ProcessorResourcePool]).update_all(
+        :cpu_shares  => nil,
+        :cpu_reserve => nil,
+        :cpu_limit   => nil
+      )
+    end
+  end
+
+  def down
+    remove_column :resource_pools, :cpu_cores_available
+    remove_column :resource_pools, :cpu_cores_reserve
+    remove_column :resource_pools, :cpu_cores_limit
+  end
+end

--- a/spec/migrations/20231018141450_add_cpu_cores_columns_to_resource_pools_spec.rb
+++ b/spec/migrations/20231018141450_add_cpu_cores_columns_to_resource_pools_spec.rb
@@ -1,0 +1,91 @@
+require_migration
+
+describe AddCpuCoresColumnsToResourcePools do
+  let(:resource_pools_stub) { migration_stub(:ResourcePool) }
+
+  migration_context :up do
+    it "Removes non-applicable data only from Power resource pools" do
+      ibm_cloud_power_vs_resource_pool = resource_pools_stub.create(
+        :type               => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ResourcePool",
+        :cpu_shares         => 1,
+        :cpu_reserve        => 2,
+        :cpu_limit          => 3,
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+
+      ibm_power_hmc_processor_resource_pool = resource_pools_stub.create(
+        :type               => "ManageIQ::Providers::IbmPowerHmc::InfraManager::ProcessorResourcePool",
+        :cpu_shares         => 1,
+        :cpu_reserve        => 2,
+        :cpu_limit          => -1,
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+
+      migrate
+
+      expect(ibm_cloud_power_vs_resource_pool.reload).to have_attributes(
+        :cpu_shares         => nil,
+        :cpu_reserve        => nil,
+        :cpu_limit          => nil,
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+
+      expect(ibm_power_hmc_processor_resource_pool.reload).to have_attributes(
+        :cpu_shares         => nil,
+        :cpu_reserve        => nil,
+        :cpu_limit          => nil,
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+    end
+
+    it "Does not change non-Power resource pools" do
+      vmware_resource_pool = resource_pools_stub.create(
+        :type               => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool",
+        :cpu_shares         => 1,
+        :cpu_reserve        => 2,
+        :cpu_limit          => 3,
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+
+      migrate
+
+      expect(vmware_resource_pool).to have_attributes(
+        :type               => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool",
+        :cpu_shares         => 1,
+        :cpu_reserve        => 2,
+        :cpu_limit          => 3,  # rand(-1..65536) ?
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+    end
+  end
+
+  migration_context :down do
+    it "Does not change non-Power resource pools" do
+      vmware_resource_pool = resource_pools_stub.create(
+        :type               => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool",
+        :cpu_shares         => 1,
+        :cpu_reserve        => 2,
+        :cpu_limit          => 3,
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+
+      migrate
+
+      expect(vmware_resource_pool).to have_attributes(
+        :type               => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool",
+        :cpu_shares         => 1,
+        :cpu_reserve        => 2,
+        :cpu_limit          => 3,  # rand(-1..65536) ?
+        :cpu_reserve_expand => true,
+        :is_default         => false
+      )
+    end
+  end
+end


### PR DESCRIPTION
Proposing this instead of #675 

Fixes https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/issues/108

Related to:
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/474
- https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/147

The resource_pools table schema follows VMware resource pools. Because of this the 'cpu_reserve', 'cpu_limit', and 'cpu_shares' columns are all integers (representing units of Hz).

When IbmCloud::PowerVirtualServers and IbmPowerHmc providers used resource_pools to store information about Shared Processor Pools they stored CPU core shares in these 'cpu_*' columns (even though they are not in Hz). Since there is a unit mis-match the best way to store both in the same table is to create new columns 'cpu_core_*' (note the data type is float since fractional core counts are allowed).
