### PR TITLE
Add payload validity attributes to configuration_scripts

### DIFF
--- a/db/migrate/20231108172936_add_valid_to_configuration_scripts.rb
+++ b/db/migrate/20231108172936_add_valid_to_configuration_scripts.rb
@@ -1,6 +1,6 @@
 class AddValidToConfigurationScripts < ActiveRecord::Migration[6.1]
   def change
-    add_column :configuration_scripts, :payload_valid, :boolean
+    add_column :configuration_scripts, :payload_valid, :boolean, :default => true
     add_column :configuration_scripts, :payload_error, :string
   end
 end

--- a/db/migrate/20231108172936_add_valid_to_configuration_scripts.rb
+++ b/db/migrate/20231108172936_add_valid_to_configuration_scripts.rb
@@ -1,0 +1,6 @@
+class AddValidToConfigurationScripts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :configuration_scripts, :payload_valid, :boolean
+    add_column :configuration_scripts, :payload_error, :string
+  end
+end


### PR DESCRIPTION
Add columns to store if the payload of a configuration_script is valid or not, and if not what the error is to help the user fix their scripts.