### PR TITLE
[WIP] Set manager_ref to file path for embedded ConfigurationScripts

### DIFF
--- a/db/migrate/20231114152200_set_manager_ref_embedded_configuration_scripts.rb
+++ b/db/migrate/20231114152200_set_manager_ref_embedded_configuration_scripts.rb
@@ -1,0 +1,19 @@
+class SetManagerRefEmbeddedConfigurationScripts < ActiveRecord::Migration[6.1]
+  class ConfigurationScript < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  EMBEDDED_CONFIGURATION_SCRIPT_TYPES = %w[
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook
+    ManageIQ::Providers::Workflows::AutomationManager::Workflow
+  ].freeze
+
+  def up
+    ConfigurationScript.in_my_region.where(:type => EMBEDDED_CONFIGURATION_SCRIPT_TYPES).update_all("manager_ref = name")
+  end
+
+  def down
+    ConfigurationScript.in_my_region.where(:type => EMBEDDED_CONFIGURATION_SCRIPT_TYPES).update_all(:manager_ref => nil)
+  end
+end

--- a/spec/migrations/20231114152200_set_manager_ref_embedded_configuration_scripts_spec.rb
+++ b/spec/migrations/20231114152200_set_manager_ref_embedded_configuration_scripts_spec.rb
@@ -1,0 +1,49 @@
+require_migration
+
+describe SetManagerRefEmbeddedConfigurationScripts do
+  let(:configuration_script_stub) { migration_stub(:ConfigurationScript) }
+
+  migration_context :up do
+    it "sets the manager_ref for embedded type configuration_scripts" do
+      embedded_ansible_playbook  = configuration_script_stub.create!(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook", :name => "project/my_playbook.yaml")
+      mbedded_workflows_workflow = configuration_script_stub.create!(:type => "ManageIQ::Providers::Workflows::AutomationManager::Workflow", :name => "workflows/my_workflow.yaml")
+
+      migrate
+
+      expect(embedded_ansible_playbook.reload.manager_ref).to eq("project/my_playbook.yaml")
+      expect(mbedded_workflows_workflow.reload.manager_ref).to eq("workflows/my_workflow.yaml")
+    end
+
+    it "doesn't impact non-embedded configuration_scripts" do
+      ansible_tower_playbook = configuration_script_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook", :name => "project/my_playbook.yaml", :manager_ref => "123")
+      awx_playbook           = configuration_script_stub.create!(:type => "ManageIQ::Providers::Awx::AutomationManager::Playbook", :name => "project/my_playbook.yaml", :manager_ref => "123")
+
+      migrate
+
+      expect(ansible_tower_playbook.reload.manager_ref).to eq("123")
+      expect(awx_playbook.reload.manager_ref).to eq("123")
+    end
+  end
+
+  migration_context :down do
+    it "sets the manager_ref back to nil for embedded type configuration_scripts" do
+      embedded_ansible_playbook  = configuration_script_stub.create!(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook", :name => "project/my_playbook.yaml")
+      mbedded_workflows_workflow = configuration_script_stub.create!(:type => "ManageIQ::Providers::Workflows::AutomationManager::Workflow", :name => "workflows/my_workflow.yaml")
+
+      migrate
+
+      expect(embedded_ansible_playbook.reload.manager_ref).to be_nil
+      expect(mbedded_workflows_workflow.reload.manager_ref).to be_nil
+    end
+
+    it "doesn't impact non-embedded configuration_scripts" do
+      ansible_tower_playbook = configuration_script_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook", :name => "project/my_playbook.yaml", :manager_ref => "123")
+      awx_playbook           = configuration_script_stub.create!(:type => "ManageIQ::Providers::Awx::AutomationManager::Playbook", :name => "project/my_playbook.yaml", :manager_ref => "123")
+
+      migrate
+
+      expect(ansible_tower_playbook.reload.manager_ref).to eq("123")
+      expect(awx_playbook.reload.manager_ref).to eq("123")
+    end
+  end
+end


### PR DESCRIPTION
The manager_ref is typically used to track the "unique" attribute of an object, for ansible_tower/awx the manager_ref is the job_template.id but for embedded_ansible the manager_ref was nil and the name was set to the file path.

Embedded Workflows copied this behavior, but it would be preferable to match how the "external" automation managers operate and also open up the `:name` column for a more user friendly name.