### PR TITLE
Remove default from config_scripts payload_valid

### DIFF
--- a/db/migrate/20231114173829_remove_default_from_configuration_scripts_payload_valid.rb
+++ b/db/migrate/20231114173829_remove_default_from_configuration_scripts_payload_valid.rb
@@ -1,0 +1,9 @@
+class RemoveDefaultFromConfigurationScriptsPayloadValid < ActiveRecord::Migration[6.1]
+  def up
+    change_column_default :configuration_scripts, :payload_valid, nil
+  end
+
+  def down
+    change_column_default :configuration_scripts, :payload_valid, true
+  end
+end


### PR DESCRIPTION
Only set payload_valid if it was checked otherwise leave it as `nil`

https://github.com/ManageIQ/manageiq-providers-workflows/pull/59#issuecomment-1810299583