### PR TITLE
Fix OrchestrationStack#configuration_script reference

### DIFF
--- a/db/migrate/20240105173129_add_orchestration_stack_configuration_script.rb
+++ b/db/migrate/20240105173129_add_orchestration_stack_configuration_script.rb
@@ -1,0 +1,5 @@
+class AddOrchestrationStackConfigurationScript < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :orchestration_stacks, :configuration_script, :type => :bigint, :index => true
+  end
+end

--- a/db/migrate/20240108211241_fix_orchestration_stack_configuration_script_reference.rb
+++ b/db/migrate/20240108211241_fix_orchestration_stack_configuration_script_reference.rb
@@ -1,0 +1,22 @@
+class FixOrchestrationStackConfigurationScriptReference < ActiveRecord::Migration[6.1]
+  class OrchestrationStack < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  TYPES = %w[ManageIQ::Providers::Awx::AutomationManager::Job ManageIQ::Providers::AnsibleTower::AutomationManager::Job].freeze
+
+  def up
+    say_with_time("Fixing OrchestrationStack#configuration_script foreign key") do
+      OrchestrationStack.in_my_region.where(:type => TYPES).update_all('configuration_script_id = orchestration_template_id')
+      OrchestrationStack.in_my_region.where(:type => TYPES).update_all(:orchestration_template_id => nil)
+    end
+  end
+
+  def down
+    say_with_time("Resetting OrchestrationStack#configuration_script foreign key") do
+      OrchestrationStack.in_my_region.where(:type => TYPES).update_all('orchestration_template_id = configuration_script_id')
+      OrchestrationStack.in_my_region.where(:type => TYPES).update_all(:configuration_script_id => nil)
+    end
+  end
+end

--- a/spec/migrations/20240108211241_fix_orchestration_stack_configuration_script_reference_spec.rb
+++ b/spec/migrations/20240108211241_fix_orchestration_stack_configuration_script_reference_spec.rb
@@ -1,0 +1,84 @@
+require_migration
+
+class FixOrchestrationStackConfigurationScriptReference
+  class ConfigurationScriptBase < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.table_name         = "configuration_scripts"
+    self.inheritance_column = :_type_disabled
+  end
+
+  class OrchestrationTemplate < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+end
+
+describe FixOrchestrationStackConfigurationScriptReference do
+  let(:configuration_script_base_stub) { migration_stub(:ConfigurationScriptBase) }
+  let(:orchestration_stack_stub)       { migration_stub(:OrchestrationStack) }
+  let(:orchestration_template_stub)    { migration_stub(:OrchestrationTemplate) }
+
+  migration_context :up do
+    it "fixes AWX and AnsibleTower Jobs" do
+      job_template = configuration_script_base_stub.create!(:type => "ConfigurationScript")
+
+      awx_job   = orchestration_stack_stub.create!(:type => "ManageIQ::Providers::Awx::AutomationManager::Job",          :orchestration_template_id => job_template.id)
+      tower_job = orchestration_stack_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job", :orchestration_template_id => job_template.id)
+
+      migrate
+
+      awx_job.reload
+      tower_job.reload
+
+      expect(awx_job.configuration_script_id).to   eq(job_template.id)
+      expect(awx_job.orchestration_template_id).to be_nil
+
+      expect(tower_job.configuration_script_id).to   eq(job_template.id)
+      expect(tower_job.orchestration_template_id).to be_nil
+    end
+
+    it "doesn't impact other Orchestration Stacks" do
+      cloud_template = orchestration_template_stub.create!
+      cloud_stack    = orchestration_stack_stub.create!(:type => "ManageIQ::Providers::CloudManager::OrchestrationStack", :orchestration_template_id => cloud_template.id)
+
+      migrate
+
+      cloud_stack.reload
+
+      expect(cloud_stack.orchestration_template_id).to eq(cloud_template.id)
+      expect(cloud_stack.configuration_script_id).to   be_nil
+    end
+  end
+
+  migration_context :down do
+    it "resets AWX and AnsibleTower Jobs" do
+      job_template = configuration_script_base_stub.create!(:type => "ConfigurationScript")
+
+      awx_job   = orchestration_stack_stub.create!(:type => "ManageIQ::Providers::Awx::AutomationManager::Job",          :configuration_script_id => job_template.id)
+      tower_job = orchestration_stack_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::AutomationManager::Job", :configuration_script_id => job_template.id)
+
+      migrate
+
+      awx_job.reload
+      tower_job.reload
+
+      expect(awx_job.configuration_script_id).to   be_nil
+      expect(awx_job.orchestration_template_id).to eq(job_template.id)
+
+      expect(tower_job.configuration_script_id).to   be_nil
+      expect(tower_job.orchestration_template_id).to eq(job_template.id)
+    end
+
+    it "doesn't impact other Orchestration Stacks" do
+      cloud_template = orchestration_template_stub.create!
+      cloud_stack    = orchestration_stack_stub.create!(:type => "ManageIQ::Providers::CloudManager::OrchestrationStack", :orchestration_template_id => cloud_template.id)
+
+      migrate
+
+      cloud_stack.reload
+
+      expect(cloud_stack.orchestration_template_id).to eq(cloud_template.id)
+      expect(cloud_stack.configuration_script_id).to   be_nil
+    end
+  end
+end


### PR DESCRIPTION
There are some `OrchestrationStack` types (AWX and AnsibleTower Jobs) which were using `orchestration_template_id` to reference a configuration_script.  This was causing issues with the other side of the relationship, namely if there was an `OrchestrationTemplate` with the same ID as the `ConfigurationScript` then that template would think it had active stacks and could not be deleted.

There is already a `OrchestrationStack#configuration_script_base_id` but that is used to track the `Playbook` aka the `ConfigurationScriptPayload` where this is used to track the `JobTemplate` which is a running `ConfigurationScript`.  Ideally I would have named these `configuration_script_payload_id` and `configuration_script_id` so it was obvious that the existing one is for the payload but I didn't want to get into renaming columns/indexes/etc... right now.

Dependents:
* https://github.com/ManageIQ/manageiq-providers-awx/pull/22
* https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/302

https://github.com/ManageIQ/manageiq/issues/22813