### PR TITLE
Allow rails 7 gems in gemspec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
         - '3.1'
         rails-version:
         - '6.1'
+        - '7.0'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,12 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-case ENV['TEST_RAILS_VERSION']
-when "6.0"
-  # Default local bundling to use 6.0 for generating migrations
-  gem "rails",  "~>6.0.4"
-else
-  gem "rails",  "~>6.1.6"
-end
+minimum_version =
+  case ENV.fetch('TEST_RAILS_VERSION', nil)
+  when "7.0"
+    "~>7.0.8"
+  else
+    # Default local bundling to use this version for generating migrations
+    "~>6.1.4"
+  end
+gem "rails", minimum_version

--- a/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
+++ b/db/migrate/20180606155924_move_ansible_container_secrets_into_database.rb
@@ -14,14 +14,26 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
     update_authentications
   end
 
-  def self.read_token(file)
-    File.read(file)
-  end
-
   private
 
+  def token_file
+    if Rails.env.test? && ENV['TOKEN_FILE']
+      ENV['TOKEN_FILE']
+    else
+      TOKEN_FILE
+    end
+  end
+
+  def ca_cert_file
+    if Rails.env.test? && ENV['CA_CERT_FILE']
+      ENV['CA_CERT_FILE']
+    else
+      CA_CERT_FILE
+    end
+  end
+
   def containerized?
-    File.exist?(TOKEN_FILE) && File.exist?(CA_CERT_FILE)
+    File.exist?(token_file) && File.exist?(ca_cert_file)
   end
 
   def update_authentications
@@ -92,8 +104,8 @@ class MoveAnsibleContainerSecretsIntoDatabase < ActiveRecord::Migration[5.0]
   def request_params
     {
       'Accept'         => "application/json",
-      'Authorization'  => "Bearer #{self.class.read_token(TOKEN_FILE)}",
-      :ssl_ca_cert     => CA_CERT_FILE,
+      'Authorization'  => "Bearer #{File.read(token_file)}",
+      :ssl_ca_cert     => ca_cert_file,
       :ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER
     }
   end

--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ancestry"
-  spec.add_dependency "activerecord-id_regions", "~> 0.3.2"
+  spec.add_dependency "activerecord-id_regions", "~> 0.4.0"
   spec.add_dependency "linux_admin",             ">= 2.0", "< 4"
   spec.add_dependency "manageiq-password",       ">= 1.2.0", "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"
   spec.add_dependency "pg"
-  spec.add_dependency "rails",                   ">=6.0.4", "<7.0"
+  spec.add_dependency "rails",                   ">=6.0.4", "<7.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rspec"

--- a/spec/migrations/20180316164826_update_switch_types_spec.rb
+++ b/spec/migrations/20180316164826_update_switch_types_spec.rb
@@ -12,8 +12,8 @@ describe UpdateSwitchTypes do
                                             :type => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch")
 
       host_stub.create!(:type => "ManageIQ::Providers::Vmware::InfraManager::HostEsx").tap do |host|
-        host.host_switches.create!(:host => host, :switch => dvswitch)
-        host.host_switches.create!(:host => host, :switch => host_switch)
+        host.host_switches.create!(:host_id => host.id, :switch_id => dvswitch.id)
+        host.host_switches.create!(:host_id => host.id, :switch_id => host_switch.id)
       end
 
       migrate

--- a/spec/migrations/20180712122000_remove_host_provisioning_spec.rb
+++ b/spec/migrations/20180712122000_remove_host_provisioning_spec.rb
@@ -7,9 +7,9 @@ describe RemoveHostProvisioning do
     let(:miq_approval_stub) { migration_stub :MiqApproval }
 
     it 'only removes Host Provision request instances' do
-      miq_request_stub.create!(:type => 'MiqProvisionRequest', :miq_approvals => [miq_approval_stub.create!])
-      miq_request_stub.create!(:type => 'MiqHostProvisionRequest', :miq_approvals => [miq_approval_stub.create!])
-      miq_request_stub.create!(:type => 'ServiceTemplateProvisionRequest', :miq_approvals => [miq_approval_stub.create!])
+      miq_request_stub.create!(:type => 'MiqProvisionRequest', :miq_approval_ids => [miq_approval_stub.create!.id])
+      miq_request_stub.create!(:type => 'MiqHostProvisionRequest', :miq_approval_ids => [miq_approval_stub.create!.id])
+      miq_request_stub.create!(:type => 'ServiceTemplateProvisionRequest', :miq_approval_ids => [miq_approval_stub.create!.id])
 
       miq_request_task_stub.create!(:type => 'MiqProvision')
       miq_request_task_stub.create!(:type => 'MiqHostProvision')

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -44,8 +44,8 @@ describe AddConversionHostIdToMiqRequestTasks do
       host = host_stub.create!
       conversion_host = conversion_host_stub.create!(:resource => host)
       task = task_stub.create!(
-        :type            => 'ServiceTemplateTransformationPlanTask',
-        :conversion_host => conversion_host
+        :type               => 'ServiceTemplateTransformationPlanTask',
+        :conversion_host_id => conversion_host.id
       )
 
       migrate

--- a/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
+++ b/spec/migrations/20181001131632_add_conversion_host_id_to_miq_request_tasks_spec.rb
@@ -35,7 +35,7 @@ describe AddConversionHostIdToMiqRequestTasks do
 
       expect(task.options).to eq(:dummy_key => 'dummy_value')
       expect(conversion_host_stub.find_by(:resource => host)).not_to be_nil
-      expect(task.conversion_host).to eq(conversion_host_stub.find_by(:resource => host))
+      expect(task.conversion_host.id).to eq(conversion_host_stub.find_by(:resource => host).id)
     end
   end
 

--- a/spec/migrations/20181016140921_migrate_orch_stacks_to_have_ownership_concept_spec.rb
+++ b/spec/migrations/20181016140921_migrate_orch_stacks_to_have_ownership_concept_spec.rb
@@ -5,12 +5,12 @@ describe MigrateOrchStacksToHaveOwnershipConcept do
   let(:ems) { migration_stub(:ExtManagementSystem) }
   let(:service) { migration_stub(:Service) }
   let(:tenant) { migration_stub(:Tenant).create! }
-  let(:group) { migration_stub(:MiqGroup).create!(:tenant => tenant) }
+  let(:group) { migration_stub(:MiqGroup).create!(:tenant_id => tenant.id) }
   let!(:user) { migration_stub(:User).create!(:userid => "admin", :miq_groups => [group], :current_group => group) }
 
   migration_context :up do
     it "sets owner, tenant, and group from the user if neither the ems and service exist" do
-      stack = orchestration_stack.create!(:ext_management_system => nil)
+      stack = orchestration_stack.create!(:ems_id => nil)
       expect(orchestration_stack.count).to eq(1)
 
       migrate
@@ -20,8 +20,8 @@ describe MigrateOrchStacksToHaveOwnershipConcept do
     end
 
     it "sets owner, tenant, and group from the ems if the ems exists and the service doesn't" do
-      ext_ms = ems.create!(:tenant => tenant)
-      stack = orchestration_stack.create!(:ext_management_system => ext_ms)
+      ext_ms = ems.create!(:tenant_id => tenant.id)
+      stack = orchestration_stack.create!(:ems_id => ext_ms.id)
       expect(orchestration_stack.count).to eq(1)
 
       migrate
@@ -42,7 +42,7 @@ describe MigrateOrchStacksToHaveOwnershipConcept do
 
     it "sets owner, tenant, and group from the service if the service exists and ems doesn't" do
       svc = service.create!(:tenant_id => tenant.id, :miq_group_id => group.id)
-      stack = orchestration_stack.create!(:direct_services => [svc])
+      stack = orchestration_stack.create!(:direct_service_ids => [svc.id])
       expect(orchestration_stack.count).to eq(1)
 
       migrate
@@ -52,9 +52,9 @@ describe MigrateOrchStacksToHaveOwnershipConcept do
     end
 
     it "sets owner, tenant, and group from the service if the service and ems exists" do
-      ext_ms = ems.create!(:tenant => tenant)
+      ext_ms = ems.create!(:tenant_id => tenant.id)
       svc = service.create!(:tenant_id => tenant.id, :miq_group_id => group.id)
-      stack = orchestration_stack.create!(:direct_services => [svc], :ext_management_system => ext_ms)
+      stack = orchestration_stack.create!(:direct_service_ids => [svc.id], :ems_id => ext_ms.id)
       expect(orchestration_stack.count).to eq(1)
 
       migrate

--- a/spec/migrations/20190201173316_add_missing_ems_id_to_switch_spec.rb
+++ b/spec/migrations/20190201173316_add_missing_ems_id_to_switch_spec.rb
@@ -44,41 +44,40 @@ describe AddMissingEmsIdToSwitch do
 
       # Hosts
       host_esx          = host_stub.create!(:type                  => "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
-                                            :ext_management_system => vmware_ems)
+                                            :ems_id => vmware_ems.id)
       host_esx_archived = host_stub.create!(:type                  => "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
-                                            :ext_management_system => nil)
+                                            :ems_id => nil)
 
       host_redhat = host_stub.create!(:type                  => "ManageIQ::Providers::Redhat::InfraManager::Host",
-                                      :ext_management_system => redhat_ems)
+                                      :ems_id => redhat_ems.id)
 
       # Switches
       dvswitch               = switch_stub.create!(:name => "DVS", :uid_ems => "dvswitch-1", :shared => true,
                                                    :type => "ManageIQ::Providers::Vmware::InfraManager::DistributedVirtualSwitch")
-      dvswitch_without_assoc = switch_stub.create!(:name                  => "DVS", :uid_ems => "dvswitch-3", :shared => true,
-                                                   :host                  => host_esx,
-                                                   :ext_management_system => vmware_ems,
-                                                   :type                  => "ManageIQ::Providers::Vmware::InfraManager::DistributedVirtualSwitch")
-      dvswitch_archived    = switch_stub.create!(:name                  => "DVS", :uid_ems => "dvswitch-1", :shared => true,
-                                                 :ext_management_system => vmware_ems,
-                                                 :type                  => "ManageIQ::Providers::Vmware::InfraManager::DistributedVirtualSwitch")
+      dvswitch_without_assoc = switch_stub.create!(:name    => "DVS", :uid_ems => "dvswitch-3", :shared => true,
+                                                   :host_id => host_esx.id,
+                                                   :ems_id  => vmware_ems.id,
+                                                   :type    => "ManageIQ::Providers::Vmware::InfraManager::DistributedVirtualSwitch")
+      dvswitch_archived    = switch_stub.create!(:name      => "DVS", :uid_ems => "dvswitch-1", :shared => true,
+                                                 :ems_id    => vmware_ems.id,
+                                                 :type      => "ManageIQ::Providers::Vmware::InfraManager::DistributedVirtualSwitch")
       host_switch          = switch_stub.create!(:name => "vSwitch0", :uid_ems => "vSwitch0", :shared => false,
                                                  :type => "ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch")
-      host_switch_archived = switch_stub.create!(:name                  => "vSwitch0", :uid_ems => "vSwitch0",
-                                                 :type                  => "ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch")
+      host_switch_archived = switch_stub.create!(:name      => "vSwitch0", :uid_ems => "vSwitch0",
+                                                 :type      => "ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch")
       redhat_switch        = switch_stub.create!(:name => "vSwitch0", :uid_ems => "vSwitch0")
-      physical_switch      = switch_stub.create!(:name                  => "Physical Switch", :uid_ems => "switch-1",
-                                                 :type                  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
-                                                 :ext_management_system => lenovo_ems)
-      physical_switch1     = switch_stub.create!(:name                  => "Physical Switch", :uid_ems => "switch-1",
-                                                 :type                  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
-                                                 :ext_management_system => nil)
-
+      physical_switch      = switch_stub.create!(:name      => "Physical Switch", :uid_ems => "switch-1",
+                                                 :type      => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
+                                                 :ems_id => lenovo_ems.id)
+      physical_switch1     = switch_stub.create!(:name      => "Physical Switch", :uid_ems => "switch-1",
+                                                 :type      => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
+                                                 :ems_id => nil)
       # Host -> switches mapping
-      host_esx.host_switches.create!(:host => host_esx, :switch => dvswitch)
-      host_esx.host_switches.create!(:host => host_esx, :switch => host_switch)
-      host_esx_archived.host_switches.create!(:host => host_esx_archived, :switch => host_switch_archived)
-      host_esx_archived.host_switches.create!(:host => host_esx_archived, :switch => dvswitch_archived)
-      host_redhat.host_switches.create!(:host => host_redhat, :switch => redhat_switch)
+      host_esx.host_switches.create!(:host_id => host_esx.id, :switch_id => dvswitch.id)
+      host_esx.host_switches.create!(:host_id => host_esx.id, :switch_id => host_switch.id)
+      host_esx_archived.host_switches.create!(:host_id => host_esx_archived.id, :switch_id => host_switch_archived.id)
+      host_esx_archived.host_switches.create!(:host_id => host_esx_archived.id, :switch_id => dvswitch_archived.id)
+      host_redhat.host_switches.create!(:host_id => host_redhat.id, :switch_id => redhat_switch.id)
 
       migrate
 

--- a/spec/migrations/20190201173316_add_missing_ems_id_to_switch_spec.rb
+++ b/spec/migrations/20190201173316_add_missing_ems_id_to_switch_spec.rb
@@ -34,6 +34,7 @@ describe AddMissingEmsIdToSwitch do
   let(:switch_stub) { migration_stub(:Switch) }
   let(:host_stub) { migration_stub(:Host) }
   let(:ems_stub) { migration_stub(:ExtManagementSystem) }
+  let(:host_switch_stub) { migration_stub(:HostSwitch) }
 
   migration_context :up do
     it "migrates a series of representative rows" do
@@ -73,11 +74,11 @@ describe AddMissingEmsIdToSwitch do
                                                  :type      => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
                                                  :ems_id => nil)
       # Host -> switches mapping
-      host_esx.host_switches.create!(:host_id => host_esx.id, :switch_id => dvswitch.id)
-      host_esx.host_switches.create!(:host_id => host_esx.id, :switch_id => host_switch.id)
-      host_esx_archived.host_switches.create!(:host_id => host_esx_archived.id, :switch_id => host_switch_archived.id)
-      host_esx_archived.host_switches.create!(:host_id => host_esx_archived.id, :switch_id => dvswitch_archived.id)
-      host_redhat.host_switches.create!(:host_id => host_redhat.id, :switch_id => redhat_switch.id)
+      host_switch_stub.create!(:host_id => host_esx.id, :switch_id => dvswitch.id)
+      host_switch_stub.create!(:host_id => host_esx.id, :switch_id => host_switch.id)
+      host_switch_stub.create!(:host_id => host_esx_archived.id, :switch_id => host_switch_archived.id)
+      host_switch_stub.create!(:host_id => host_esx_archived.id, :switch_id => dvswitch_archived.id)
+      host_switch_stub.create!(:host_id => host_redhat.id, :switch_id => redhat_switch.id)
 
       migrate
 

--- a/spec/migrations/20190708192323_fix_unserializable_notification_options_spec.rb
+++ b/spec/migrations/20190708192323_fix_unserializable_notification_options_spec.rb
@@ -6,7 +6,7 @@ describe FixUnserializableNotificationOptions do
 
   migration_context :up do
     it "fixes options[:subject] classes that don't exist" do
-      notification1 = notification_stub.create!(:notification_type => notification_type_stub.create!)
+      notification1 = notification_stub.create!(:notification_type_id => notification_type_stub.create!.id)
       notification1.update(
         :options =>
           <<~OPTIONS
@@ -35,7 +35,7 @@ describe FixUnserializableNotificationOptions do
     end
 
     it "Sets options[:subject] where the record no longer exists" do
-      notification1 = notification_stub.create!(:notification_type => notification_type_stub.create!)
+      notification1 = notification_stub.create!(:notification_type_id => notification_type_stub.create!.id)
       notification1.update(
         :options =>
           <<~OPTIONS

--- a/spec/migrations/20190729170013_split_storages_per_ems_spec.rb
+++ b/spec/migrations/20190729170013_split_storages_per_ems_spec.rb
@@ -36,7 +36,7 @@ describe SplitStoragesPerEms do
 
         it "host is still linked to the storage" do
           migrate
-          expect(host.reload.storages.first).to eq(storage_stub.first)
+          expect(host.reload.storages.first.id).to eq(storage_stub.first.id)
         end
       end
 
@@ -62,8 +62,8 @@ describe SplitStoragesPerEms do
           migrate
 
           storage = storage_stub.first
-          expect(host_1.reload.storages.first).to eq(storage)
-          expect(host_2.reload.storages.first).to eq(storage)
+          expect(host_1.reload.storages.first.id).to eq(storage.id)
+          expect(host_2.reload.storages.first.id).to eq(storage.id)
         end
       end
 
@@ -150,7 +150,7 @@ describe SplitStoragesPerEms do
 
         it "links hosts to the old storage" do
           migrate
-          expect(host.reload.host_storages.first.storage).to eq(storage)
+          expect(host.reload.host_storages.first.storage.id).to eq(storage.id)
         end
 
         it "sets the ems_ref" do

--- a/spec/migrations/20191118161319_subclass_resource_pools_spec.rb
+++ b/spec/migrations/20191118161319_subclass_resource_pools_spec.rb
@@ -11,7 +11,7 @@ describe SubclassResourcePools do
       end
 
       resource_pools = emss.map do |ems|
-        resource_pool_stub.create!(:ext_management_system => ems)
+        resource_pool_stub.create!(:ems_id => ems.id)
       end
 
       migrate
@@ -23,7 +23,7 @@ describe SubclassResourcePools do
 
     it "doesn't migrate resource pools from other providers" do
       ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AnotherManager::InfraManager")
-      respool = resource_pool_stub.create!(:ext_management_system => ems)
+      respool = resource_pool_stub.create!(:ems_id => ems.id)
 
       migrate
 
@@ -38,7 +38,7 @@ describe SubclassResourcePools do
       end
 
       resource_pools = emss.map do |ems|
-        resource_pool_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::ResourcePool")
+        resource_pool_stub.create!(:ems_id => ems.id, :type => "#{ems.type}::ResourcePool")
       end
 
       migrate
@@ -50,7 +50,7 @@ describe SubclassResourcePools do
 
     it "doesn't migrate resource pools from other providers" do
       ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AnotherManager::InfraManager")
-      respool = resource_pool_stub.create!(:ext_management_system => ems)
+      respool = resource_pool_stub.create!(:ems_id => ems.id)
 
       migrate
 

--- a/spec/migrations/20191118191722_subclass_ems_folders_spec.rb
+++ b/spec/migrations/20191118191722_subclass_ems_folders_spec.rb
@@ -10,9 +10,9 @@ describe SubclassEmsFolders do
         ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
       end
 
-      folders          = emss.map { |ems| ems_folder_stub.create!(:ext_management_system => ems) }
-      datacenters      = emss.map { |ems| ems_folder_stub.create!(:ext_management_system => ems, :type => "Datacenter") }
-      storage_clusters = emss.map { |ems| ems_folder_stub.create!(:ext_management_system => ems, :type => "StorageCluster") }
+      folders          = emss.map { |ems| ems_folder_stub.create!(:ems_id => ems.id) }
+      datacenters      = emss.map { |ems| ems_folder_stub.create!(:ems_id => ems.id, :type => "Datacenter") }
+      storage_clusters = emss.map { |ems| ems_folder_stub.create!(:ems_id => ems.id, :type => "StorageCluster") }
 
       migrate
 
@@ -24,7 +24,7 @@ describe SubclassEmsFolders do
     it "doesn't migrate an unrelated folder" do
       ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AutomationManager")
       inventory_group = ems_folder_stub.create!(
-        :ext_management_system => ems,
+        :ems_id => ems.id,
         :type                  => "ManageIQ::Providers::AutomationManager::InventoryGroup"
       )
 
@@ -41,10 +41,10 @@ describe SubclassEmsFolders do
       end
 
       folders = emss.map do |ems|
-        ems_folder_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::Folder")
+        ems_folder_stub.create!(:ems_id => ems.id, :type => "#{ems.type}::Folder")
       end
       datacenters = emss.map do |ems|
-        ems_folder_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::Datacenter")
+        ems_folder_stub.create!(:ems_id => ems.id, :type => "#{ems.type}::Datacenter")
       end
 
       migrate
@@ -56,7 +56,7 @@ describe SubclassEmsFolders do
     it "doesn't migrate an unrelated folder" do
       ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AutomationManager")
       inventory_group = ems_folder_stub.create!(
-        :ext_management_system => ems,
+        :ems_id => ems.id,
         :type                  => "ManageIQ::Providers::AutomationManager::InventoryGroup"
       )
 

--- a/spec/migrations/20191210163518_subclass_storages_spec.rb
+++ b/spec/migrations/20191210163518_subclass_storages_spec.rb
@@ -11,7 +11,7 @@ describe SubclassStorages do
       end
 
       storages = emss.map do |ems|
-        storage_stub.create!(:ext_management_system => ems)
+        storage_stub.create!(:ems_id => ems.id)
       end
 
       migrate
@@ -23,7 +23,7 @@ describe SubclassStorages do
 
     it "doesn't migrate storages from other providers" do
       ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AnotherManager::InfraManager")
-      storage = storage_stub.create!(:ext_management_system => ems)
+      storage = storage_stub.create!(:ems_id => ems.id)
 
       migrate
 
@@ -38,7 +38,7 @@ describe SubclassStorages do
       end
 
       storages = emss.map do |ems|
-        storage_stub.create!(:ext_management_system => ems, :type => "#{ems.type}::Storage")
+        storage_stub.create!(:ems_id => ems.id, :type => "#{ems.type}::Storage")
       end
 
       migrate
@@ -50,7 +50,7 @@ describe SubclassStorages do
 
     it "doesn't migrate storages from other providers" do
       ems = ext_management_system_stub.create!(:type => "ManageIQ::Providers::AnotherManager::InfraManager")
-      storage = storage_stub.create!(:ext_management_system => ems)
+      storage = storage_stub.create!(:ems_id => ems.id)
 
       migrate
 

--- a/spec/migrations/20201103143405_fix_google_cloud_volume_sti_spec.rb
+++ b/spec/migrations/20201103143405_fix_google_cloud_volume_sti_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FixGoogleCloudVolumeSti do
   migration_context :up do
     it "Fixes the STI class of Google Cloud Volumes" do
       gce = ems_stub.create!(:type => "ManageIQ::Providers::Google::CloudManager")
-      volume = volume_stub.create!(:ext_management_system => gce, :type => nil)
+      volume = volume_stub.create!(:ems_id => gce.id, :type => nil)
 
       migrate
 
@@ -17,7 +17,7 @@ RSpec.describe FixGoogleCloudVolumeSti do
     it "Doesn't impact non-Google Cloud volumes" do
       osp = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
       volume = volume_stub.create!(
-        :ext_management_system => osp,
+        :ems_id => osp.id,
         :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
       )
 
@@ -31,7 +31,7 @@ RSpec.describe FixGoogleCloudVolumeSti do
     it "Fixes the STI class of Google Cloud Volumes" do
       gce = ems_stub.create!(:type => "ManageIQ::Providers::Google::CloudManager")
       volume = volume_stub.create!(
-        :ext_management_system => gce,
+        :ems_id => gce.id,
         :type                  => "ManageIQ::Providers::Google::CloudManager::CloudVolume"
       )
 
@@ -43,7 +43,7 @@ RSpec.describe FixGoogleCloudVolumeSti do
     it "Doesn't impact non-Google Cloud volumes" do
       osp = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::CloudManager")
       volume = volume_stub.create!(
-        :ext_management_system => osp,
+        :ems_id => osp.id,
         :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
       )
 

--- a/spec/migrations/20201105124938_fix_openstack_cloud_volume_sti_types_spec.rb
+++ b/spec/migrations/20201105124938_fix_openstack_cloud_volume_sti_types_spec.rb
@@ -13,20 +13,20 @@ RSpec.describe FixOpenstackCloudVolumeStiTypes do
       cinder = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager", :parent_ems_id => osp.id)
 
       cloud_volume = cloud_volume_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
       )
       cloud_volume_snapshot = cloud_volume_snapshot_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot"
       )
       cloud_volume_backup = cloud_volume_backup_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
       )
       cloud_volume_type = cloud_volume_type_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType"
       )
 
       migrate
@@ -44,20 +44,20 @@ RSpec.describe FixOpenstackCloudVolumeStiTypes do
       cinder = ems_stub.create!(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager", :parent_ems_id => osp.id)
 
       cloud_volume = cloud_volume_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume"
       )
       cloud_volume_snapshot = cloud_volume_snapshot_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot"
       )
       cloud_volume_backup = cloud_volume_backup_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup"
       )
       cloud_volume_type = cloud_volume_type_stub.create!(
-        :ext_management_system => cinder,
-        :type                  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType"
+        :ems_id => cinder.id,
+        :type   => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType"
       )
 
       migrate

--- a/spec/migrations/20210315161241_update_automation_provider_user_roles_spec.rb
+++ b/spec/migrations/20210315161241_update_automation_provider_user_roles_spec.rb
@@ -39,10 +39,10 @@ describe UpdateAutomationProviderUserRoles do
       migrate
       user_role.reload
 
-      expect(user_role.miq_product_features).not_to include(automation_manager)
-      expect(user_role.miq_product_features).to include(ems_automation)
-      expect(user_role.miq_product_features).to include(automation_manager_configured_system)
-      expect(user_role.miq_product_features).to include(configuration_script)
+      expect(user_role.miq_product_feature_ids).not_to include(automation_manager.id)
+      expect(user_role.miq_product_feature_ids).to include(ems_automation.id)
+      expect(user_role.miq_product_feature_ids).to include(automation_manager_configured_system.id)
+      expect(user_role.miq_product_feature_ids).to include(configuration_script.id)
     end
   end
 
@@ -85,10 +85,10 @@ describe UpdateAutomationProviderUserRoles do
       migrate
       user_role.reload
 
-      expect(user_role.miq_product_features).to include(automation_manager)
-      expect(user_role.miq_product_features).not_to include(ems_automation)
-      expect(user_role.miq_product_features).not_to include(automation_manager_configured_system)
-      expect(user_role.miq_product_features).not_to include(configuration_script)
+      expect(user_role.miq_product_feature_ids).to include(automation_manager.id)
+      expect(user_role.miq_product_feature_ids).not_to include(ems_automation.id)
+      expect(user_role.miq_product_feature_ids).not_to include(automation_manager_configured_system.id)
+      expect(user_role.miq_product_feature_ids).not_to include(configuration_script.id)
     end
   end
 end

--- a/spec/migrations/20210315161241_update_automation_provider_user_roles_spec.rb
+++ b/spec/migrations/20210315161241_update_automation_provider_user_roles_spec.rb
@@ -30,11 +30,11 @@ describe UpdateAutomationProviderUserRoles do
         :feature_type => "node",
         :identifier   => "automation_manager"
       )
-      user_role = user_role_stub.create!(:miq_product_features => [automation_manager], :read_only => false)
+      user_role = user_role_stub.create!(:miq_product_feature_ids => [automation_manager.id], :read_only => false)
 
-      expect(user_role.miq_product_features).not_to include(ems_automation)
-      expect(user_role.miq_product_features).not_to include(automation_manager_configured_system)
-      expect(user_role.miq_product_features).not_to include(configuration_script)
+      expect(user_role.miq_product_feature_ids).not_to include(ems_automation.id)
+      expect(user_role.miq_product_feature_ids).not_to include(automation_manager_configured_system.id)
+      expect(user_role.miq_product_feature_ids).not_to include(configuration_script.id)
 
       migrate
       user_role.reload
@@ -75,12 +75,12 @@ describe UpdateAutomationProviderUserRoles do
         :feature_type => "node",
         :identifier   => "automation_manager"
       )
-      user_role = user_role_stub.create!(:miq_product_features => [ems_automation, automation_manager_configured_system, configuration_script], :read_only => false)
+      user_role = user_role_stub.create!(:miq_product_feature_ids => [ems_automation.id, automation_manager_configured_system.id, configuration_script.id], :read_only => false)
 
-      expect(user_role.miq_product_features).to include(ems_automation)
-      expect(user_role.miq_product_features).to include(automation_manager_configured_system)
-      expect(user_role.miq_product_features).to include(configuration_script)
-      expect(user_role.miq_product_features).not_to include(automation_manager)
+      expect(user_role.miq_product_feature_ids).to include(ems_automation.id)
+      expect(user_role.miq_product_feature_ids).to include(automation_manager_configured_system.id)
+      expect(user_role.miq_product_feature_ids).to include(configuration_script.id)
+      expect(user_role.miq_product_feature_ids).not_to include(automation_manager.id)
 
       migrate
       user_role.reload

--- a/spec/migrations/20210601125525_ensure_ems_storage_features_spec.rb
+++ b/spec/migrations/20210601125525_ensure_ems_storage_features_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe EnsureEmsStorageFeatures do
 
     it "adds ems_storage* feature if ems_block_storage* feature is enabled" do
       user_role = user_role_stub.create!(
-        :miq_product_features => [ems_block_storage_view],
+        :miq_product_feature_ids => [ems_block_storage_view.id],
         :read_only            => false
       )
 
@@ -44,7 +44,7 @@ RSpec.describe EnsureEmsStorageFeatures do
 
     it "adds ems_storage* feature if ems_object_storage* feature is enabled" do
       user_role = user_role_stub.create!(
-        :miq_product_features => [ems_object_storage_view],
+        :miq_product_feature_ids => [ems_object_storage_view.id],
         :read_only            => false
       )
 
@@ -55,7 +55,7 @@ RSpec.describe EnsureEmsStorageFeatures do
 
     it "doesn't duplicate if ems_storage* feature already enabled" do
       user_role = user_role_stub.create!(
-        :miq_product_features => [ems_block_storage_view, ems_object_storage_view, ems_storage_view],
+        :miq_product_feature_ids => [ems_block_storage_view.id, ems_object_storage_view.id, ems_storage_view.id],
         :read_only            => false
       )
 
@@ -75,7 +75,7 @@ RSpec.describe EnsureEmsStorageFeatures do
       )
 
       user_role = user_role_stub.create!(
-        :miq_product_features => [ems_cloud_view],
+        :miq_product_feature_ids => [ems_cloud_view.id],
         :read_only            => false
       )
 

--- a/spec/migrations/20210601125525_ensure_ems_storage_features_spec.rb
+++ b/spec/migrations/20210601125525_ensure_ems_storage_features_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EnsureEmsStorageFeatures do
 
       migrate
 
-      expect(user_role.reload.miq_product_features).to include(ems_storage_view)
+      expect(user_role.reload.miq_product_feature_ids).to include(ems_storage_view.id)
     end
 
     it "adds ems_storage* feature if ems_object_storage* feature is enabled" do
@@ -50,7 +50,7 @@ RSpec.describe EnsureEmsStorageFeatures do
 
       migrate
 
-      expect(user_role.reload.miq_product_features).to include(ems_storage_view)
+      expect(user_role.reload.miq_product_feature_ids).to include(ems_storage_view.id)
     end
 
     it "doesn't duplicate if ems_storage* feature already enabled" do
@@ -59,11 +59,11 @@ RSpec.describe EnsureEmsStorageFeatures do
         :read_only            => false
       )
 
-      expect(user_role.miq_product_features).to match_array([ems_storage_view, ems_object_storage_view, ems_block_storage_view])
+      expect(user_role.miq_product_feature_ids).to match_array([ems_storage_view.id, ems_object_storage_view.id, ems_block_storage_view.id])
 
       migrate
 
-      expect(user_role.reload.miq_product_features).to match_array([ems_storage_view, ems_object_storage_view, ems_block_storage_view])
+      expect(user_role.reload.miq_product_feature_ids).to match_array([ems_storage_view.id, ems_object_storage_view.id, ems_block_storage_view.id])
     end
 
     it "skips user roles without any ems_(block|object)_storage* features" do
@@ -81,7 +81,7 @@ RSpec.describe EnsureEmsStorageFeatures do
 
       migrate
 
-      expect(user_role.reload.miq_product_features).to match_array([ems_cloud_view])
+      expect(user_role.reload.miq_product_feature_ids).to match_array([ems_cloud_view.id])
     end
   end
 end

--- a/spec/migrations/20210625185428_fix_vpc_flavors_sti_spec.rb
+++ b/spec/migrations/20210625185428_fix_vpc_flavors_sti_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FixVpcFlavorsSti do
   migration_context :up do
     it "fixes VPC flavors' STI class" do
       vpc_manager = ems_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager")
-      flavor      = flavor_stub.create!(:ext_management_system => vpc_manager)
+      flavor      = flavor_stub.create!(:ems_id => vpc_manager.id)
 
       migrate
 
@@ -16,7 +16,7 @@ RSpec.describe FixVpcFlavorsSti do
 
     it "doesn't impact other flavors" do
       aws_manager = ems_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager")
-      flavor      = flavor_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::Flavor", :ext_management_system => aws_manager)
+      flavor      = flavor_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::Flavor", :ems_id => aws_manager.id)
 
       migrate
 
@@ -27,7 +27,7 @@ RSpec.describe FixVpcFlavorsSti do
   migration_context :down do
     it "resets VPC flavors' STI class" do
       vpc_manager = ems_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager")
-      flavor      = flavor_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Flavor", :ext_management_system => vpc_manager)
+      flavor      = flavor_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Flavor", :ems_id => vpc_manager.id)
 
       migrate
 
@@ -36,7 +36,7 @@ RSpec.describe FixVpcFlavorsSti do
 
     it "doesn't impact other flavors" do
       aws_manager = ems_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager")
-      flavor      = flavor_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::Flavor", :ext_management_system => aws_manager)
+      flavor      = flavor_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::Flavor", :ems_id => aws_manager.id)
 
       migrate
 

--- a/spec/migrations/20211003124407_fix_openstack_swift_model_sti_spec.rb
+++ b/spec/migrations/20211003124407_fix_openstack_swift_model_sti_spec.rb
@@ -9,8 +9,8 @@ describe FixOpenstackSwiftModelSti do
     it "fixes OpenStack Swift models' STI class" do
       swift_manager = ems_stub.create(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
 
-      cloud_object_store_container = cloud_object_store_container_stub.create(:ext_management_system => swift_manager, :type => nil)
-      cloud_object_store_object    = cloud_object_store_object_stub.create(:ext_management_system => swift_manager, :type => nil)
+      cloud_object_store_container = cloud_object_store_container_stub.create(:ems_id => swift_manager.id, :type => nil)
+      cloud_object_store_object    = cloud_object_store_object_stub.create(:ems_id => swift_manager.id, :type => nil)
 
       migrate
 
@@ -23,8 +23,8 @@ describe FixOpenstackSwiftModelSti do
     it "resets OpenStack Swift models' STI class" do
       swift_manager = ems_stub.create(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
 
-      cloud_object_store_container = cloud_object_store_container_stub.create(:ext_management_system => swift_manager, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreContainer")
-      cloud_object_store_object    = cloud_object_store_object_stub.create(:ext_management_system => swift_manager, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreObject")
+      cloud_object_store_container = cloud_object_store_container_stub.create(:ems_id => swift_manager.id, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreContainer")
+      cloud_object_store_object    = cloud_object_store_object_stub.create(:ems_id => swift_manager.id, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreObject")
 
       migrate
 

--- a/spec/migrations/20211110155755_set_vpc_availability_zones_sti_spec.rb
+++ b/spec/migrations/20211110155755_set_vpc_availability_zones_sti_spec.rb
@@ -7,7 +7,7 @@ describe SetVpcAvailabilityZonesSti do
   migration_context :up do
     it "fixes VPC availability zones' STI class" do
       vpc_manager       = ems_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager")
-      availability_zone = availability_zone_stub.create!(:ext_management_system => vpc_manager)
+      availability_zone = availability_zone_stub.create!(:ems_id => vpc_manager.id)
 
       migrate
 
@@ -16,7 +16,7 @@ describe SetVpcAvailabilityZonesSti do
 
     it "doesn't impact other availability_zones" do
       aws_manager       = ems_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager")
-      availability_zone = availability_zone_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone", :ext_management_system => aws_manager)
+      availability_zone = availability_zone_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone", :ems_id => aws_manager.id)
 
       migrate
 
@@ -27,7 +27,7 @@ describe SetVpcAvailabilityZonesSti do
   migration_context :down do
     it "resets VPC availability_zones' STI class" do
       vpc_manager       = ems_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager")
-      availability_zone = availability_zone_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::AvailabilityZone", :ext_management_system => vpc_manager)
+      availability_zone = availability_zone_stub.create!(:type => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::AvailabilityZone", :ems_id => vpc_manager.id)
 
       migrate
 
@@ -36,7 +36,7 @@ describe SetVpcAvailabilityZonesSti do
 
     it "doesn't impact other availability_zones" do
       aws_manager       = ems_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager")
-      availability_zone = availability_zone_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone", :ext_management_system => aws_manager)
+      availability_zone = availability_zone_stub.create!(:type => "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone", :ems_id => aws_manager.id)
 
       migrate
 

--- a/spec/migrations/20211213210056_fix_power_vc_cloud_tenant_sti_spec.rb
+++ b/spec/migrations/20211213210056_fix_power_vc_cloud_tenant_sti_spec.rb
@@ -9,7 +9,7 @@ describe FixPowerVcCloudTenantSti do
   migration_context :up do
     it "fixes IbmPowerVc CloudTenant STI classes" do
       ibm_powervc_manager = ems_stub.create(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager")
-      cloud_tenant        = cloud_tenant_stub.create(:ext_management_system => ibm_powervc_manager, :type => "ManageIQ::Providers::Openstack::CloudManager::CloudTenant")
+      cloud_tenant        = cloud_tenant_stub.create(:ems_id => ibm_powervc_manager.id, :type => "ManageIQ::Providers::Openstack::CloudManager::CloudTenant")
 
       migrate
 
@@ -18,7 +18,7 @@ describe FixPowerVcCloudTenantSti do
 
     it "doesn't impact other CloudTenants" do
       awesome_cloud_manager = ems_stub.create(:type => "ManageIQ::Providers::AwesomeCloud::CloudManager")
-      cloud_tenant          = cloud_tenant_stub.create(:ext_management_system => awesome_cloud_manager, :type => "ManageIQ::Providers::AwesomeCloud::CloudManager::CloudTenant")
+      cloud_tenant          = cloud_tenant_stub.create(:ems_id => awesome_cloud_manager.id, :type => "ManageIQ::Providers::AwesomeCloud::CloudManager::CloudTenant")
 
       migrate
 
@@ -29,7 +29,7 @@ describe FixPowerVcCloudTenantSti do
   migration_context :down do
     it "resets IbmPowerVc CloudTenant STI classes" do
       ibm_powervc_manager = ems_stub.create(:type => "ManageIQ::Providers::IbmPowerVc::CloudManager")
-      cloud_tenant        = cloud_tenant_stub.create(:ext_management_system => ibm_powervc_manager, :type => "ManageIQ::Providers::IbmPowerVc::CloudManager::CloudTenant")
+      cloud_tenant        = cloud_tenant_stub.create(:ems_id => ibm_powervc_manager.id, :type => "ManageIQ::Providers::IbmPowerVc::CloudManager::CloudTenant")
 
       migrate
 
@@ -38,7 +38,7 @@ describe FixPowerVcCloudTenantSti do
 
     it "doesn't impact other CloudTenants" do
       awesome_cloud_manager = ems_stub.create(:type => "ManageIQ::Providers::AwesomeCloud::CloudManager")
-      cloud_tenant          = cloud_tenant_stub.create(:ext_management_system => awesome_cloud_manager, :type => "ManageIQ::Providers::AwesomeCloud::CloudManager::CloudTenant")
+      cloud_tenant          = cloud_tenant_stub.create(:ems_id => awesome_cloud_manager.id, :type => "ManageIQ::Providers::AwesomeCloud::CloudManager::CloudTenant")
 
       migrate
 

--- a/spec/migrations/20220111170303_fix_child_container_manager_sti_spec.rb
+++ b/spec/migrations/20220111170303_fix_child_container_manager_sti_spec.rb
@@ -13,10 +13,10 @@ describe FixChildContainerManagerSti do
     it "fixes STI class for EKS providers" do
       eks = ext_management_system_stub.create(:type => "ManageIQ::Providers::Amazon::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => eks)
-      service_instance       = service_instance_stub.create(:ext_management_system => eks)
-      service_offering       = service_offering_stub.create(:ext_management_system => eks)
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => eks)
+      container_template_stub.create(:ems_id => eks.id)
+      service_instance_stub.create(:ems_id => eks.id)
+      service_offering_stub.create(:ems_id => eks.id)
+      service_parameters_set_stub.create(:ems_id => eks.id)
 
       migrate
 
@@ -29,10 +29,10 @@ describe FixChildContainerManagerSti do
     it "fixes STI class for AKS providers" do
       aks = ext_management_system_stub.create(:type => "ManageIQ::Providers::Azure::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => aks)
-      service_instance       = service_instance_stub.create(:ext_management_system => aks)
-      service_offering       = service_offering_stub.create(:ext_management_system => aks)
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => aks)
+      container_template_stub.create(:ems_id => aks.id)
+      service_instance_stub.create(:ems_id => aks.id)
+      service_offering_stub.create(:ems_id => aks.id)
+      service_parameters_set_stub.create(:ems_id => aks.id)
 
       migrate
 
@@ -45,10 +45,10 @@ describe FixChildContainerManagerSti do
     it "fixes STI class for GKE providers" do
       gke = ext_management_system_stub.create(:type => "ManageIQ::Providers::Google::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => gke)
-      service_instance       = service_instance_stub.create(:ext_management_system => gke)
-      service_offering       = service_offering_stub.create(:ext_management_system => gke)
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => gke)
+      container_template_stub.create(:ems_id => gke.id)
+      service_instance_stub.create(:ems_id => gke.id)
+      service_offering_stub.create(:ems_id => gke.id)
+      service_parameters_set_stub.create(:ems_id => gke.id)
 
       migrate
 
@@ -61,10 +61,10 @@ describe FixChildContainerManagerSti do
     it "fixes STI class for IKS providers" do
       iks = ext_management_system_stub.create(:type => "ManageIQ::Providers::IbmCloud::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => iks)
-      service_instance       = service_instance_stub.create(:ext_management_system => iks)
-      service_offering       = service_offering_stub.create(:ext_management_system => iks)
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => iks)
+      container_template_stub.create(:ems_id => iks.id)
+      service_instance_stub.create(:ems_id => iks.id)
+      service_offering_stub.create(:ems_id => iks.id)
+      service_parameters_set_stub.create(:ems_id => iks.id)
 
       migrate
 
@@ -77,10 +77,10 @@ describe FixChildContainerManagerSti do
     it "fixes STI class for OKE providers" do
       oke = ext_management_system_stub.create(:type => "ManageIQ::Providers::OracleCloud::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => oke)
-      service_instance       = service_instance_stub.create(:ext_management_system => oke)
-      service_offering       = service_offering_stub.create(:ext_management_system => oke)
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => oke)
+      container_template_stub.create(:ems_id => oke.id)
+      service_instance_stub.create(:ems_id => oke.id)
+      service_offering_stub.create(:ems_id => oke.id)
+      service_parameters_set_stub.create(:ems_id => oke.id)
 
       migrate
 
@@ -93,10 +93,10 @@ describe FixChildContainerManagerSti do
     it "fixes STI class for Tanzu providers" do
       tanzu = ext_management_system_stub.create(:type => "ManageIQ::Providers::Vmware::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => tanzu)
-      service_instance       = service_instance_stub.create(:ext_management_system => tanzu)
-      service_offering       = service_offering_stub.create(:ext_management_system => tanzu)
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => tanzu)
+      container_template_stub.create(:ems_id => tanzu.id)
+      service_instance_stub.create(:ems_id => tanzu.id)
+      service_offering_stub.create(:ems_id => tanzu.id)
+      service_parameters_set_stub.create(:ems_id => tanzu.id)
 
       migrate
 
@@ -111,10 +111,10 @@ describe FixChildContainerManagerSti do
     it "resets STI class for EKS providers" do
       eks = ext_management_system_stub.create(:type => "ManageIQ::Providers::Amazon::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => eks, :type => "ManageIQ::Providers::Amazon::ContainerManager::ContainerTemplate")
-      service_instance       = service_instance_stub.create(:ext_management_system => eks, :type => "ManageIQ::Providers::Amazon::ContainerManager::ServiceInstance")
-      service_offering       = service_offering_stub.create(:ext_management_system => eks, :type => "ManageIQ::Providers::Amazon::ContainerManager::ServiceOffering")
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => eks, :type => "ManageIQ::Providers::Amazon::ContainerManager::ServiceParametersSet")
+      container_template_stub.create(:ems_id => eks.id, :type => "ManageIQ::Providers::Amazon::ContainerManager::ContainerTemplate")
+      service_instance_stub.create(:ems_id => eks.id, :type => "ManageIQ::Providers::Amazon::ContainerManager::ServiceInstance")
+      service_offering_stub.create(:ems_id => eks.id, :type => "ManageIQ::Providers::Amazon::ContainerManager::ServiceOffering")
+      service_parameters_set_stub.create(:ems_id => eks.id, :type => "ManageIQ::Providers::Amazon::ContainerManager::ServiceParametersSet")
 
       migrate
 
@@ -127,10 +127,10 @@ describe FixChildContainerManagerSti do
     it "resets STI class for AKS providers" do
       aks = ext_management_system_stub.create(:type => "ManageIQ::Providers::Azure::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => aks, :type => "ManageIQ::Providers::Azure::ContainerManager::ContainerTemplate")
-      service_instance       = service_instance_stub.create(:ext_management_system => aks, :type => "ManageIQ::Providers::Azure::ContainerManager::ServiceInstance")
-      service_offering       = service_offering_stub.create(:ext_management_system => aks, :type => "ManageIQ::Providers::Azure::ContainerManager::ServiceOffering")
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => aks, :type => "ManageIQ::Providers::Azure::ContainerManager::ServiceParametersSet")
+      container_template_stub.create(:ems_id => aks.id, :type => "ManageIQ::Providers::Azure::ContainerManager::ContainerTemplate")
+      service_instance_stub.create(:ems_id => aks.id, :type => "ManageIQ::Providers::Azure::ContainerManager::ServiceInstance")
+      service_offering_stub.create(:ems_id => aks.id, :type => "ManageIQ::Providers::Azure::ContainerManager::ServiceOffering")
+      service_parameters_set_stub.create(:ems_id => aks.id, :type => "ManageIQ::Providers::Azure::ContainerManager::ServiceParametersSet")
 
       migrate
 
@@ -143,10 +143,10 @@ describe FixChildContainerManagerSti do
     it "resets STI class for GKE providers" do
       gke = ext_management_system_stub.create(:type => "ManageIQ::Providers::Google::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => gke, :type => "ManageIQ::Providers::Google::ContainerManager::ContainerTemplate")
-      service_instance       = service_instance_stub.create(:ext_management_system => gke, :type => "ManageIQ::Providers::Google::ContainerManager::ServiceInstance")
-      service_offering       = service_offering_stub.create(:ext_management_system => gke, :type => "ManageIQ::Providers::Google::ContainerManager::ServiceOffering")
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => gke, :type => "ManageIQ::Providers::Google::ContainerManager::ServiceParametersSet")
+      container_template_stub.create(:ems_id => gke.id, :type => "ManageIQ::Providers::Google::ContainerManager::ContainerTemplate")
+      service_instance_stub.create(:ems_id => gke.id, :type => "ManageIQ::Providers::Google::ContainerManager::ServiceInstance")
+      service_offering_stub.create(:ems_id => gke.id, :type => "ManageIQ::Providers::Google::ContainerManager::ServiceOffering")
+      service_parameters_set_stub.create(:ems_id => gke.id, :type => "ManageIQ::Providers::Google::ContainerManager::ServiceParametersSet")
 
       migrate
 
@@ -159,10 +159,10 @@ describe FixChildContainerManagerSti do
     it "resets STI class for IKS providers" do
       iks = ext_management_system_stub.create(:type => "ManageIQ::Providers::IbmCloud::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => iks, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ContainerTemplate")
-      service_instance       = service_instance_stub.create(:ext_management_system => iks, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ServiceInstance")
-      service_offering       = service_offering_stub.create(:ext_management_system => iks, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ServiceOffering")
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => iks, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ServiceParametersSet")
+      container_template_stub.create(:ems_id => iks.id, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ContainerTemplate")
+      service_instance_stub.create(:ems_id => iks.id, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ServiceInstance")
+      service_offering_stub.create(:ems_id => iks.id, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ServiceOffering")
+      service_parameters_set_stub.create(:ems_id => iks.id, :type => "ManageIQ::Providers::IbmCloud::ContainerManager::ServiceParametersSet")
 
       migrate
 
@@ -175,10 +175,10 @@ describe FixChildContainerManagerSti do
     it "resets STI class for OKE providers" do
       oke = ext_management_system_stub.create(:type => "ManageIQ::Providers::OracleCloud::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => oke, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ContainerTemplate")
-      service_instance       = service_instance_stub.create(:ext_management_system => oke, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ServiceInstance")
-      service_offering       = service_offering_stub.create(:ext_management_system => oke, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ServiceOffering")
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => oke, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ServiceParametersSet")
+      container_template_stub.create(:ems_id => oke.id, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ContainerTemplate")
+      service_instance_stub.create(:ems_id => oke.id, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ServiceInstance")
+      service_offering_stub.create(:ems_id => oke.id, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ServiceOffering")
+      service_parameters_set_stub.create(:ems_id => oke.id, :type => "ManageIQ::Providers::OracleCloud::ContainerManager::ServiceParametersSet")
 
       migrate
 
@@ -191,10 +191,10 @@ describe FixChildContainerManagerSti do
     it "resets STI class for Tanzu providers" do
       tanzu = ext_management_system_stub.create(:type => "ManageIQ::Providers::Vmware::ContainerManager")
 
-      container_template     = container_template_stub.create(:ext_management_system => tanzu, :type => "ManageIQ::Providers::Vmware::ContainerManager::ContainerTemplate")
-      service_instance       = service_instance_stub.create(:ext_management_system => tanzu, :type => "ManageIQ::Providers::Vmware::ContainerManager::ServiceInstance")
-      service_offering       = service_offering_stub.create(:ext_management_system => tanzu, :type => "ManageIQ::Providers::Vmware::ContainerManager::ServiceOffering")
-      service_parameters_set = service_parameters_set_stub.create(:ext_management_system => tanzu, :type => "ManageIQ::Providers::Vmware::ContainerManager::ServiceParametersSet")
+      container_template_stub.create(:ems_id => tanzu.id, :type => "ManageIQ::Providers::Vmware::ContainerManager::ContainerTemplate")
+      service_instance_stub.create(:ems_id => tanzu.id, :type => "ManageIQ::Providers::Vmware::ContainerManager::ServiceInstance")
+      service_offering_stub.create(:ems_id => tanzu.id, :type => "ManageIQ::Providers::Vmware::ContainerManager::ServiceOffering")
+      service_parameters_set_stub.create(:ems_id => tanzu.id, :type => "ManageIQ::Providers::Vmware::ContainerManager::ServiceParametersSet")
 
       migrate
 

--- a/spec/migrations/20220111170303_fix_child_container_manager_sti_spec.rb
+++ b/spec/migrations/20220111170303_fix_child_container_manager_sti_spec.rb
@@ -20,10 +20,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     eq("ManageIQ::Providers::Amazon::ContainerManager::ContainerTemplate")
-      expect(service_instance.reload.type).to       eq("ManageIQ::Providers::Amazon::ContainerManager::ServiceInstance")
-      expect(service_offering.reload.type).to       eq("ManageIQ::Providers::Amazon::ContainerManager::ServiceOffering")
-      expect(service_parameters_set.reload.type).to eq("ManageIQ::Providers::Amazon::ContainerManager::ServiceParametersSet")
+      expect(container_template_stub.first.type).to     eq("ManageIQ::Providers::Amazon::ContainerManager::ContainerTemplate")
+      expect(service_instance_stub.first.type).to       eq("ManageIQ::Providers::Amazon::ContainerManager::ServiceInstance")
+      expect(service_offering_stub.first.type).to       eq("ManageIQ::Providers::Amazon::ContainerManager::ServiceOffering")
+      expect(service_parameters_set_stub.first.type).to eq("ManageIQ::Providers::Amazon::ContainerManager::ServiceParametersSet")
     end
 
     it "fixes STI class for AKS providers" do
@@ -36,10 +36,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     eq("ManageIQ::Providers::Azure::ContainerManager::ContainerTemplate")
-      expect(service_instance.reload.type).to       eq("ManageIQ::Providers::Azure::ContainerManager::ServiceInstance")
-      expect(service_offering.reload.type).to       eq("ManageIQ::Providers::Azure::ContainerManager::ServiceOffering")
-      expect(service_parameters_set.reload.type).to eq("ManageIQ::Providers::Azure::ContainerManager::ServiceParametersSet")
+      expect(container_template_stub.first.type).to     eq("ManageIQ::Providers::Azure::ContainerManager::ContainerTemplate")
+      expect(service_instance_stub.first.type).to       eq("ManageIQ::Providers::Azure::ContainerManager::ServiceInstance")
+      expect(service_offering_stub.first.type).to       eq("ManageIQ::Providers::Azure::ContainerManager::ServiceOffering")
+      expect(service_parameters_set_stub.first.type).to eq("ManageIQ::Providers::Azure::ContainerManager::ServiceParametersSet")
     end
 
     it "fixes STI class for GKE providers" do
@@ -52,10 +52,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     eq("ManageIQ::Providers::Google::ContainerManager::ContainerTemplate")
-      expect(service_instance.reload.type).to       eq("ManageIQ::Providers::Google::ContainerManager::ServiceInstance")
-      expect(service_offering.reload.type).to       eq("ManageIQ::Providers::Google::ContainerManager::ServiceOffering")
-      expect(service_parameters_set.reload.type).to eq("ManageIQ::Providers::Google::ContainerManager::ServiceParametersSet")
+      expect(container_template_stub.first.type).to     eq("ManageIQ::Providers::Google::ContainerManager::ContainerTemplate")
+      expect(service_instance_stub.first.type).to       eq("ManageIQ::Providers::Google::ContainerManager::ServiceInstance")
+      expect(service_offering_stub.first.type).to       eq("ManageIQ::Providers::Google::ContainerManager::ServiceOffering")
+      expect(service_parameters_set_stub.first.type).to eq("ManageIQ::Providers::Google::ContainerManager::ServiceParametersSet")
     end
 
     it "fixes STI class for IKS providers" do
@@ -68,10 +68,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     eq("ManageIQ::Providers::IbmCloud::ContainerManager::ContainerTemplate")
-      expect(service_instance.reload.type).to       eq("ManageIQ::Providers::IbmCloud::ContainerManager::ServiceInstance")
-      expect(service_offering.reload.type).to       eq("ManageIQ::Providers::IbmCloud::ContainerManager::ServiceOffering")
-      expect(service_parameters_set.reload.type).to eq("ManageIQ::Providers::IbmCloud::ContainerManager::ServiceParametersSet")
+      expect(container_template_stub.first.type).to     eq("ManageIQ::Providers::IbmCloud::ContainerManager::ContainerTemplate")
+      expect(service_instance_stub.first.type).to       eq("ManageIQ::Providers::IbmCloud::ContainerManager::ServiceInstance")
+      expect(service_offering_stub.first.type).to       eq("ManageIQ::Providers::IbmCloud::ContainerManager::ServiceOffering")
+      expect(service_parameters_set_stub.first.type).to eq("ManageIQ::Providers::IbmCloud::ContainerManager::ServiceParametersSet")
     end
 
     it "fixes STI class for OKE providers" do
@@ -84,10 +84,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     eq("ManageIQ::Providers::OracleCloud::ContainerManager::ContainerTemplate")
-      expect(service_instance.reload.type).to       eq("ManageIQ::Providers::OracleCloud::ContainerManager::ServiceInstance")
-      expect(service_offering.reload.type).to       eq("ManageIQ::Providers::OracleCloud::ContainerManager::ServiceOffering")
-      expect(service_parameters_set.reload.type).to eq("ManageIQ::Providers::OracleCloud::ContainerManager::ServiceParametersSet")
+      expect(container_template_stub.first.type).to     eq("ManageIQ::Providers::OracleCloud::ContainerManager::ContainerTemplate")
+      expect(service_instance_stub.first.type).to       eq("ManageIQ::Providers::OracleCloud::ContainerManager::ServiceInstance")
+      expect(service_offering_stub.first.type).to       eq("ManageIQ::Providers::OracleCloud::ContainerManager::ServiceOffering")
+      expect(service_parameters_set_stub.first.type).to eq("ManageIQ::Providers::OracleCloud::ContainerManager::ServiceParametersSet")
     end
 
     it "fixes STI class for Tanzu providers" do
@@ -100,10 +100,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     eq("ManageIQ::Providers::Vmware::ContainerManager::ContainerTemplate")
-      expect(service_instance.reload.type).to       eq("ManageIQ::Providers::Vmware::ContainerManager::ServiceInstance")
-      expect(service_offering.reload.type).to       eq("ManageIQ::Providers::Vmware::ContainerManager::ServiceOffering")
-      expect(service_parameters_set.reload.type).to eq("ManageIQ::Providers::Vmware::ContainerManager::ServiceParametersSet")
+      expect(container_template_stub.first.type).to     eq("ManageIQ::Providers::Vmware::ContainerManager::ContainerTemplate")
+      expect(service_instance_stub.first.type).to       eq("ManageIQ::Providers::Vmware::ContainerManager::ServiceInstance")
+      expect(service_offering_stub.first.type).to       eq("ManageIQ::Providers::Vmware::ContainerManager::ServiceOffering")
+      expect(service_parameters_set_stub.first.type).to eq("ManageIQ::Providers::Vmware::ContainerManager::ServiceParametersSet")
     end
   end
 
@@ -118,10 +118,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     be_nil
-      expect(service_instance.reload.type).to       be_nil
-      expect(service_offering.reload.type).to       be_nil
-      expect(service_parameters_set.reload.type).to be_nil
+      expect(container_template_stub.first.type).to     be_nil
+      expect(service_instance_stub.first.type).to       be_nil
+      expect(service_offering_stub.first.type).to       be_nil
+      expect(service_parameters_set_stub.first.type).to be_nil
     end
 
     it "resets STI class for AKS providers" do
@@ -134,10 +134,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     be_nil
-      expect(service_instance.reload.type).to       be_nil
-      expect(service_offering.reload.type).to       be_nil
-      expect(service_parameters_set.reload.type).to be_nil
+      expect(container_template_stub.first.type).to     be_nil
+      expect(service_instance_stub.first.type).to       be_nil
+      expect(service_offering_stub.first.type).to       be_nil
+      expect(service_parameters_set_stub.first.type).to be_nil
     end
 
     it "resets STI class for GKE providers" do
@@ -150,10 +150,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     be_nil
-      expect(service_instance.reload.type).to       be_nil
-      expect(service_offering.reload.type).to       be_nil
-      expect(service_parameters_set.reload.type).to be_nil
+      expect(container_template_stub.first.type).to     be_nil
+      expect(service_instance_stub.first.type).to       be_nil
+      expect(service_offering_stub.first.type).to       be_nil
+      expect(service_parameters_set_stub.first.type).to be_nil
     end
 
     it "resets STI class for IKS providers" do
@@ -166,10 +166,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     be_nil
-      expect(service_instance.reload.type).to       be_nil
-      expect(service_offering.reload.type).to       be_nil
-      expect(service_parameters_set.reload.type).to be_nil
+      expect(container_template_stub.first.type).to     be_nil
+      expect(service_instance_stub.first.type).to       be_nil
+      expect(service_offering_stub.first.type).to       be_nil
+      expect(service_parameters_set_stub.first.type).to be_nil
     end
 
     it "resets STI class for OKE providers" do
@@ -182,10 +182,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     be_nil
-      expect(service_instance.reload.type).to       be_nil
-      expect(service_offering.reload.type).to       be_nil
-      expect(service_parameters_set.reload.type).to be_nil
+      expect(container_template_stub.first.type).to     be_nil
+      expect(service_instance_stub.first.type).to       be_nil
+      expect(service_offering_stub.first.type).to       be_nil
+      expect(service_parameters_set_stub.first.type).to be_nil
     end
 
     it "resets STI class for Tanzu providers" do
@@ -198,10 +198,10 @@ describe FixChildContainerManagerSti do
 
       migrate
 
-      expect(container_template.reload.type).to     be_nil
-      expect(service_instance.reload.type).to       be_nil
-      expect(service_offering.reload.type).to       be_nil
-      expect(service_parameters_set.reload.type).to be_nil
+      expect(container_template_stub.first.type).to     be_nil
+      expect(service_instance_stub.first.type).to       be_nil
+      expect(service_offering_stub.first.type).to       be_nil
+      expect(service_parameters_set_stub.first.type).to be_nil
     end
   end
 end

--- a/spec/migrations/20220111175349_fix_autosde_sti_class_spec.rb
+++ b/spec/migrations/20220111175349_fix_autosde_sti_class_spec.rb
@@ -10,8 +10,8 @@ describe FixAutosdeStiClass do
   migration_context :up do
     it "fixes AutoSDE class names" do
       autosde = ems_stub.create(:type => "ManageIQ::Providers::Autosde::StorageManager")
-      storage_resource = storage_resource_stub.create(:ext_management_system => autosde)
-      storage_service = storage_service_stub.create(:ext_management_system => autosde)
+      storage_resource = storage_resource_stub.create(:ems_id => autosde.id)
+      storage_service = storage_service_stub.create(:ems_id => autosde.id)
 
       migrate
 
@@ -23,8 +23,8 @@ describe FixAutosdeStiClass do
   migration_context :down do
     it "resets AutoSDE class names" do
       autosde = ems_stub.create(:type => "ManageIQ::Providers::Autosde::StorageManager")
-      storage_resource = storage_resource_stub.create(:ext_management_system => autosde, :type => "ManageIQ::Providers::Autosde::StorageManager::StorageResource")
-      storage_service = storage_service_stub.create(:ext_management_system => autosde, :type => "ManageIQ::Providers::Autosde::StorageManager::StorageService")
+      storage_resource = storage_resource_stub.create(:ems_id => autosde.id, :type => "ManageIQ::Providers::Autosde::StorageManager::StorageResource")
+      storage_service = storage_service_stub.create(:ems_id => autosde.id, :type => "ManageIQ::Providers::Autosde::StorageManager::StorageService")
 
       migrate
 

--- a/spec/migrations/20220111181113_fix_azure_stack_az_flavor_sti_class_spec.rb
+++ b/spec/migrations/20220111181113_fix_azure_stack_az_flavor_sti_class_spec.rb
@@ -11,8 +11,8 @@ describe FixAzureStackAzFlavorStiClass do
     it "fixes AzureStack AvailabilityZone and Flavor STI classes" do
       azure_stack = ems_stub.create(:type => "ManageIQ::Providers::AzureStack::CloudManager")
 
-      az     = az_stub.create(:ext_management_system => azure_stack)
-      flavor = flavor_stub.create(:ext_management_system => azure_stack)
+      az     = az_stub.create(:ems_id => azure_stack.id)
+      flavor = flavor_stub.create(:ems_id => azure_stack.id)
 
       migrate
 
@@ -25,8 +25,8 @@ describe FixAzureStackAzFlavorStiClass do
     it "resets AzureStack AvailabilityZone and Flavor STI classes" do
       azure_stack = ems_stub.create(:type => "ManageIQ::Providers::AzureStack::CloudManager")
 
-      az     = az_stub.create(:ext_management_system => azure_stack, :type => "ManageIQ::Providers::AzureStack::CloudManager::AvailabilityZone")
-      flavor = flavor_stub.create(:ext_management_system => azure_stack, :type => "ManageIQ::Providers::AzureStack::CloudManager::Flavor")
+      az     = az_stub.create(:ems_id => azure_stack.id, :type => "ManageIQ::Providers::AzureStack::CloudManager::AvailabilityZone")
+      flavor = flavor_stub.create(:ems_id => azure_stack.id, :type => "ManageIQ::Providers::AzureStack::CloudManager::Flavor")
 
       migrate
 

--- a/spec/migrations/20220111184931_fix_ibm_cic_stack_sti_class_spec.rb
+++ b/spec/migrations/20220111184931_fix_ibm_cic_stack_sti_class_spec.rb
@@ -9,7 +9,7 @@ describe FixIbmCicStackStiClass do
   migration_context :up do
     it "Fixes IBM CIC OrchestrationStack STI class" do
       ibm_cic = ems_stub.create(:type => "ManageIQ::Providers::IbmCic::CloudManager")
-      stack   = stack_stub.create(:ext_management_system => ibm_cic)
+      stack   = stack_stub.create(:ems_id => ibm_cic.id)
 
       migrate
 
@@ -20,7 +20,7 @@ describe FixIbmCicStackStiClass do
   migration_context :down do
     it "Resets IBM CIC OrchestrationStack STI class" do
       ibm_cic = ems_stub.create(:type => "ManageIQ::Providers::IbmCic::CloudManager")
-      stack   = stack_stub.create(:ext_management_system => ibm_cic, :type => "ManageIQ::Providers::IbmCic::CloudManager::OrchestrationStack")
+      stack   = stack_stub.create(:ems_id => ibm_cic.id, :type => "ManageIQ::Providers::IbmCic::CloudManager::OrchestrationStack")
 
       migrate
 

--- a/spec/migrations/20220111190357_fix_ibm_power_hmc_host_sti_class_spec.rb
+++ b/spec/migrations/20220111190357_fix_ibm_power_hmc_host_sti_class_spec.rb
@@ -9,7 +9,7 @@ describe FixIbmPowerHmcHostStiClass do
   migration_context :up do
     it "Fixes IBM Power HMC Host STI class" do
       hmc  = ems_stub.create(:type => "ManageIQ::Providers::IbmPowerHmc::InfraManager")
-      host = host_stub.create(:ext_management_system => hmc)
+      host = host_stub.create(:ems_id => hmc.id)
 
       migrate
 
@@ -20,7 +20,7 @@ describe FixIbmPowerHmcHostStiClass do
   migration_context :down do
     it "Resets IBM Power HMC Host STI class" do
       hmc  = ems_stub.create(:type => "ManageIQ::Providers::IbmPowerHmc::InfraManager")
-      host = host_stub.create(:ext_management_system => hmc, :type => "ManageIQ::Providers::IbmPowerHmc::InfraManager::Host")
+      host = host_stub.create(:ems_id => hmc.id, :type => "ManageIQ::Providers::IbmPowerHmc::InfraManager::Host")
 
       migrate
 

--- a/spec/migrations/20220111192206_fix_kubevirt_host_storage_sti_classes_spec.rb
+++ b/spec/migrations/20220111192206_fix_kubevirt_host_storage_sti_classes_spec.rb
@@ -10,8 +10,8 @@ describe FixKubevirtHostStorageStiClasses do
   migration_context :up do
     it "Fixes Kubevirt STI classes" do
       kubevirt = ems_stub.create(:type => "ManageIQ::Providers::Kubevirt::InfraManager")
-      host     = host_stub.create(:ext_management_system => kubevirt)
-      storage  = storage_stub.create(:ext_management_system => kubevirt)
+      host     = host_stub.create(:ems_id => kubevirt.id)
+      storage  = storage_stub.create(:ems_id => kubevirt.id)
 
       migrate
 
@@ -23,8 +23,8 @@ describe FixKubevirtHostStorageStiClasses do
   migration_context :down do
     it "Resets Kubevirt STI classes" do
       kubevirt = ems_stub.create(:type => "ManageIQ::Providers::Kubevirt::InfraManager")
-      host     = host_stub.create(:ext_management_system => kubevirt, :type => "ManageIQ::Providers::Kubevirt::InfraManager::Host")
-      storage  = storage_stub.create(:ext_management_system => kubevirt, :type => "ManageIQ::Providers::Kubevirt::InfraManager::Storage")
+      host     = host_stub.create(:ems_id => kubevirt.id, :type => "ManageIQ::Providers::Kubevirt::InfraManager::Host")
+      storage  = storage_stub.create(:ems_id => kubevirt.id, :type => "ManageIQ::Providers::Kubevirt::InfraManager::Storage")
       migrate
 
       expect(host.reload.type).to be_nil

--- a/spec/migrations/20220111194436_fix_oracle_cloud_sti_classes_spec.rb
+++ b/spec/migrations/20220111194436_fix_oracle_cloud_sti_classes_spec.rb
@@ -12,8 +12,8 @@ describe FixOracleCloudStiClasses do
       oracle_cloud   = ems_stub.create(:type => "ManageIQ::Providers::OracleCloud::CloudManager")
       oracle_network = ems_stub.create(:type => "ManageIQ::Providers::OracleCloud::NetworkManager")
 
-      cloud_tenant  = cloud_tenant_stub.create(:ext_management_system => oracle_cloud)
-      load_balancer = load_balancer_stub.create(:ext_management_system => oracle_network)
+      cloud_tenant  = cloud_tenant_stub.create(:ems_id => oracle_cloud.id)
+      load_balancer = load_balancer_stub.create(:ems_id => oracle_network.id)
 
       migrate
 
@@ -27,8 +27,8 @@ describe FixOracleCloudStiClasses do
       oracle_cloud   = ems_stub.create(:type => "ManageIQ::Providers::OracleCloud::CloudManager")
       oracle_network = ems_stub.create(:type => "ManageIQ::Providers::OracleCloud::NetworkManager")
 
-      cloud_tenant  = cloud_tenant_stub.create(:ext_management_system => oracle_cloud, :type => "ManageIQ::Providers::OracleCloud::CloudManager::CloudTenant")
-      load_balancer = load_balancer_stub.create(:ext_management_system => oracle_network, :type => "ManageIQ::Providers::OracleCloud::NetworkManager::LoadBalancer")
+      cloud_tenant  = cloud_tenant_stub.create(:ems_id => oracle_cloud.id, :type => "ManageIQ::Providers::OracleCloud::CloudManager::CloudTenant")
+      load_balancer = load_balancer_stub.create(:ems_id => oracle_network.id, :type => "ManageIQ::Providers::OracleCloud::NetworkManager::LoadBalancer")
 
       migrate
 

--- a/spec/migrations/20220111201543_fix_vcloud_network_sti_classes_spec.rb
+++ b/spec/migrations/20220111201543_fix_vcloud_network_sti_classes_spec.rb
@@ -15,12 +15,12 @@ describe FixVcloudNetworkStiClasses do
     it "Fixes vCloud Network STI classes" do
       vcloud_network = ems_stub.create(:type => "ManageIQ::Providers::Vmware::NetworkManager")
 
-      load_balancer              = load_balancer_stub.create(:ext_management_system => vcloud_network)
-      load_balancer_health_check = load_balancer_health_check_stub.create(:ext_management_system => vcloud_network)
-      load_balancer_listener     = load_balancer_listener_stub.create(:ext_management_system => vcloud_network)
-      load_balancer_pool         = load_balancer_pool_stub.create(:ext_management_system => vcloud_network)
-      load_balancer_pool_member  = load_balancer_pool_member_stub.create(:ext_management_system => vcloud_network)
-      secrity_group              = security_group_stub.create(:ext_management_system => vcloud_network)
+      load_balancer              = load_balancer_stub.create(:ems_id => vcloud_network.id)
+      load_balancer_health_check = load_balancer_health_check_stub.create(:ems_id => vcloud_network.id)
+      load_balancer_listener     = load_balancer_listener_stub.create(:ems_id => vcloud_network.id)
+      load_balancer_pool         = load_balancer_pool_stub.create(:ems_id => vcloud_network.id)
+      load_balancer_pool_member  = load_balancer_pool_member_stub.create(:ems_id => vcloud_network.id)
+      secrity_group              = security_group_stub.create(:ems_id => vcloud_network.id)
 
       migrate
 
@@ -37,12 +37,12 @@ describe FixVcloudNetworkStiClasses do
     it "Resets vCloud Network STI classes" do
       vcloud_network = ems_stub.create(:type => "ManageIQ::Providers::Vmware::NetworkManager")
 
-      load_balancer              = load_balancer_stub.create(:ext_management_system => vcloud_network, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancer")
-      load_balancer_health_check = load_balancer_health_check_stub.create(:ext_management_system => vcloud_network, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerHealthCheck")
-      load_balancer_listener     = load_balancer_listener_stub.create(:ext_management_system => vcloud_network, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerListener")
-      load_balancer_pool         = load_balancer_pool_stub.create(:ext_management_system => vcloud_network, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerPool")
-      load_balancer_pool_member  = load_balancer_pool_member_stub.create(:ext_management_system => vcloud_network, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerPoolMember")
-      secrity_group              = security_group_stub.create(:ext_management_system => vcloud_network, :type => "ManageIQ::Providers::Vmware::NetworkManager::SecurityGroup")
+      load_balancer              = load_balancer_stub.create(:ems_id => vcloud_network.id, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancer")
+      load_balancer_health_check = load_balancer_health_check_stub.create(:ems_id => vcloud_network.id, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerHealthCheck")
+      load_balancer_listener     = load_balancer_listener_stub.create(:ems_id => vcloud_network.id, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerListener")
+      load_balancer_pool         = load_balancer_pool_stub.create(:ems_id => vcloud_network.id, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerPool")
+      load_balancer_pool_member  = load_balancer_pool_member_stub.create(:ems_id => vcloud_network.id, :type => "ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerPoolMember")
+      secrity_group              = security_group_stub.create(:ems_id => vcloud_network.id, :type => "ManageIQ::Providers::Vmware::NetworkManager::SecurityGroup")
 
       migrate
 

--- a/spec/migrations/20220111213134_fix_ibm_cloud_sti_classes_spec.rb
+++ b/spec/migrations/20220111213134_fix_ibm_cloud_sti_classes_spec.rb
@@ -16,9 +16,9 @@ describe FixIbmCloudStiClasses do
       power_cloud   = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager")
       power_network = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager")
 
-      availabiity_zone = availabiity_zone_stub.create(:ext_management_system => power_cloud)
-      flavor           = flavor_stub.create(:ext_management_system => power_cloud)
-      load_balancer    = load_balancer_stub.create(:ext_management_system => power_network)
+      availabiity_zone = availabiity_zone_stub.create(:ems_id => power_cloud.id)
+      flavor           = flavor_stub.create(:ems_id => power_cloud.id)
+      load_balancer    = load_balancer_stub.create(:ems_id => power_network.id)
 
       migrate
 
@@ -30,7 +30,7 @@ describe FixIbmCloudStiClasses do
     it "Fixes IBM VPC STI classes" do
       vpc_network = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager")
 
-      network_port = network_port_stub.create(:ext_management_system => vpc_network)
+      network_port = network_port_stub.create(:ems_id => vpc_network.id)
 
       migrate
 
@@ -40,8 +40,8 @@ describe FixIbmCloudStiClasses do
     it "Fixes IBM Cloud Object Storage" do
       ibm_object_storage = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager")
 
-      cloud_object_store_container = cloud_object_store_container_stub.create(:ext_management_system => ibm_object_storage)
-      cloud_object_store_object    = cloud_object_store_object_stub.create(:ext_management_system => ibm_object_storage)
+      cloud_object_store_container = cloud_object_store_container_stub.create(:ems_id => ibm_object_storage.id)
+      cloud_object_store_object    = cloud_object_store_object_stub.create(:ems_id => ibm_object_storage.id)
 
       migrate
 
@@ -55,9 +55,9 @@ describe FixIbmCloudStiClasses do
       power_cloud   = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager")
       power_network = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager")
 
-      availabiity_zone = availabiity_zone_stub.create(:ext_management_system => power_cloud, :type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AvailabilityZone")
-      flavor           = flavor_stub.create(:ext_management_system => power_cloud, :type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Flavor")
-      load_balancer    = load_balancer_stub.create(:ext_management_system => power_network, :type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::LoadBalancer")
+      availabiity_zone = availabiity_zone_stub.create(:ems_id => power_cloud.id, :type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AvailabilityZone")
+      flavor           = flavor_stub.create(:ems_id => power_cloud.id, :type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Flavor")
+      load_balancer    = load_balancer_stub.create(:ems_id => power_network.id, :type => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::LoadBalancer")
 
       migrate
 
@@ -69,7 +69,7 @@ describe FixIbmCloudStiClasses do
     it "Resets IBM VPC STI Classes" do
       vpc_network = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager")
 
-      network_port = network_port_stub.create(:ext_management_system => vpc_network, :type => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager::NetworkPort")
+      network_port = network_port_stub.create(:ems_id => vpc_network.id, :type => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager::NetworkPort")
 
       migrate
 
@@ -79,8 +79,8 @@ describe FixIbmCloudStiClasses do
     it "Resets IBM Cloud Object Storage" do
       ibm_object_storage = ems_stub.create(:type => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager")
 
-      cloud_object_store_container = cloud_object_store_container_stub.create(:ext_management_system => ibm_object_storage, :type => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager::CloudObjectStoreContainer")
-      cloud_object_store_object    = cloud_object_store_object_stub.create(:ext_management_system => ibm_object_storage, :type => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager::CloudObjectStoreObject")
+      cloud_object_store_container = cloud_object_store_container_stub.create(:ems_id => ibm_object_storage.id, :type => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager::CloudObjectStoreContainer")
+      cloud_object_store_object    = cloud_object_store_object_stub.create(:ems_id => ibm_object_storage.id, :type => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager::CloudObjectStoreObject")
 
       migrate
 

--- a/spec/migrations/20220112163326_fix_openstack_sti_classes_spec.rb
+++ b/spec/migrations/20220112163326_fix_openstack_sti_classes_spec.rb
@@ -16,13 +16,13 @@ describe FixOpenstackStiClasses do
       cinder = ems_stub.create(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager")
       swift  = ems_stub.create(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
 
-      cloud_volume          = cloud_volume_stub.create(:ext_management_system => cinder)
-      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ext_management_system => cinder)
-      cloud_volume_type     = cloud_volume_type_stub.create(:ext_management_system => cinder)
-      cloud_volume_backup   = cloud_volume_backup_stub.create(:ext_management_system => cinder)
+      cloud_volume          = cloud_volume_stub.create(:ems_id => cinder.id)
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ems_id => cinder.id)
+      cloud_volume_type     = cloud_volume_type_stub.create(:ems_id => cinder.id)
+      cloud_volume_backup   = cloud_volume_backup_stub.create(:ems_id => cinder.id)
 
-      cloud_object_store_object    = cloud_object_store_object_stub.create(:ext_management_system => swift)
-      cloud_object_store_container = cloud_object_store_container_stub.create(:ext_management_system => swift)
+      cloud_object_store_object    = cloud_object_store_object_stub.create(:ems_id => swift.id)
+      cloud_object_store_container = cloud_object_store_container_stub.create(:ems_id => swift.id)
 
       migrate
 
@@ -41,13 +41,13 @@ describe FixOpenstackStiClasses do
       cinder = ems_stub.create(:type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager")
       swift  = ems_stub.create(:type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager")
 
-      cloud_volume          = cloud_volume_stub.create(:ext_management_system => cinder, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume")
-      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ext_management_system => cinder, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot")
-      cloud_volume_type     = cloud_volume_type_stub.create(:ext_management_system => cinder, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType")
-      cloud_volume_backup   = cloud_volume_backup_stub.create(:ext_management_system => cinder, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup")
+      cloud_volume          = cloud_volume_stub.create(:ems_id => cinder.id, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume")
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ems_id => cinder.id, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot")
+      cloud_volume_type     = cloud_volume_type_stub.create(:ems_id => cinder.id, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType")
+      cloud_volume_backup   = cloud_volume_backup_stub.create(:ems_id => cinder.id, :type => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup")
 
-      cloud_object_store_object    = cloud_object_store_object_stub.create(:ext_management_system => swift, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreObject")
-      cloud_object_store_container = cloud_object_store_container_stub.create(:ext_management_system => swift, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreContainer")
+      cloud_object_store_object    = cloud_object_store_object_stub.create(:ems_id => swift.id, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreObject")
+      cloud_object_store_container = cloud_object_store_container_stub.create(:ems_id => swift.id, :type => "ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreContainer")
 
       migrate
 

--- a/spec/migrations/20220520105024_update_service_user_roles_spec.rb
+++ b/spec/migrations/20220520105024_update_service_user_roles_spec.rb
@@ -10,7 +10,7 @@ describe UpdateServiceUserRoles do
     let!(:service_accord) { product_feature_stub.create!(:feature_type => "node", :identifier => "service_accord") }
 
     it "does nothing to roles without service_accord" do
-      user_role = user_role_stub.create!(:miq_product_features => [other], :read_only => false)
+      user_role = user_role_stub.create!(:miq_product_feature_ids => [other.id], :read_only => false)
 
       migrate
       user_role.reload
@@ -19,7 +19,7 @@ describe UpdateServiceUserRoles do
     end
 
     it "converts service_accord to service" do
-      user_role = user_role_stub.create!(:miq_product_features => [service_accord], :read_only => false)
+      user_role = user_role_stub.create!(:miq_product_feature_ids => [service_accord.id], :read_only => false)
 
       migrate
       user_role.reload
@@ -28,7 +28,7 @@ describe UpdateServiceUserRoles do
     end
 
     it "converts service_accord to service without duplicate" do
-      user_role = user_role_stub.create!(:miq_product_features => [other, service, service_accord], :read_only => false)
+      user_role = user_role_stub.create!(:miq_product_feature_ids => [other.id, service.id, service_accord.id], :read_only => false)
 
       migrate
       user_role.reload
@@ -37,7 +37,7 @@ describe UpdateServiceUserRoles do
     end
 
     it "leaves service alone" do
-      user_role = user_role_stub.create!(:miq_product_features => [other, service], :read_only => false)
+      user_role = user_role_stub.create!(:miq_product_feature_ids => [other.id, service.id], :read_only => false)
 
       migrate
       user_role.reload

--- a/spec/migrations/20220520105024_update_service_user_roles_spec.rb
+++ b/spec/migrations/20220520105024_update_service_user_roles_spec.rb
@@ -15,7 +15,7 @@ describe UpdateServiceUserRoles do
       migrate
       user_role.reload
 
-      expect(user_role.miq_product_features).to match_array([other])
+      expect(user_role.miq_product_feature_ids).to match_array([other.id])
     end
 
     it "converts service_accord to service" do
@@ -24,7 +24,7 @@ describe UpdateServiceUserRoles do
       migrate
       user_role.reload
 
-      expect(user_role.miq_product_features).to match_array([service])
+      expect(user_role.miq_product_feature_ids).to match_array([service.id])
     end
 
     it "converts service_accord to service without duplicate" do
@@ -33,7 +33,7 @@ describe UpdateServiceUserRoles do
       migrate
       user_role.reload
 
-      expect(user_role.miq_product_features).to match_array([other, service])
+      expect(user_role.miq_product_feature_ids).to match_array([other.id, service.id])
     end
 
     it "leaves service alone" do
@@ -42,7 +42,7 @@ describe UpdateServiceUserRoles do
       migrate
       user_role.reload
 
-      expect(user_role.miq_product_features).to match_array([other, service])
+      expect(user_role.miq_product_feature_ids).to match_array([other.id, service.id])
     end
   end
 end

--- a/spec/migrations/20220809152005_fix_ibm_power_vc_sti_classes_spec.rb
+++ b/spec/migrations/20220809152005_fix_ibm_power_vc_sti_classes_spec.rb
@@ -20,14 +20,14 @@ describe FixIbmPowerVcStiClasses do
 
       network_manager = ems_stub.create(:type => ibm_power_vc_network_klass)
 
-      cloud_network         = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{openstack_network_klass}::CloudNetwork")
-      cloud_network_public  = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{openstack_network_klass}::CloudNetwork::Public")
-      cloud_network_private = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{openstack_network_klass}::CloudNetwork::Private")
-      cloud_subnet          = cloud_subnet_stub.create(:ext_management_system => network_manager)
-      floating_ip           = floating_ip_stub.create(:ext_management_system => network_manager)
-      network_port          = network_port_stub.create(:ext_management_system => network_manager)
-      network_router        = network_router_stub.create(:ext_management_system => network_manager)
-      security_group        = security_group_stub.create(:ext_management_system => network_manager)
+      cloud_network         = cloud_network_stub.create(:ems_id => network_manager.id, :type => "#{openstack_network_klass}::CloudNetwork")
+      cloud_network_public  = cloud_network_stub.create(:ems_id => network_manager.id, :type => "#{openstack_network_klass}::CloudNetwork::Public")
+      cloud_network_private = cloud_network_stub.create(:ems_id => network_manager.id, :type => "#{openstack_network_klass}::CloudNetwork::Private")
+      cloud_subnet          = cloud_subnet_stub.create(:ems_id => network_manager.id)
+      floating_ip           = floating_ip_stub.create(:ems_id => network_manager.id)
+      network_port          = network_port_stub.create(:ems_id => network_manager.id)
+      network_router        = network_router_stub.create(:ems_id => network_manager.id)
+      security_group        = security_group_stub.create(:ems_id => network_manager.id)
 
       migrate
 
@@ -46,10 +46,10 @@ describe FixIbmPowerVcStiClasses do
 
       cinder_manager = ems_stub.create(:type => ibm_power_vc_cinder_klass)
 
-      cloud_volume          = cloud_volume_stub.create(:ext_management_system => cinder_manager)
-      cloud_volume_backup   = cloud_volume_backup_stub.create(:ext_management_system => cinder_manager)
-      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ext_management_system => cinder_manager)
-      cloud_volume_type     = cloud_volume_type_stub.create(:ext_management_system => cinder_manager)
+      cloud_volume          = cloud_volume_stub.create(:ems_id => cinder_manager.id)
+      cloud_volume_backup   = cloud_volume_backup_stub.create(:ems_id => cinder_manager.id)
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ems_id => cinder_manager.id)
+      cloud_volume_type     = cloud_volume_type_stub.create(:ems_id => cinder_manager.id)
 
       migrate
 
@@ -67,14 +67,14 @@ describe FixIbmPowerVcStiClasses do
 
       network_manager = ems_stub.create(:type => ibm_power_vc_network_klass)
 
-      cloud_network         = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudNetwork")
-      cloud_network_public  = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudNetwork::Public")
-      cloud_network_private = cloud_network_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudNetwork::Private")
-      cloud_subnet          = cloud_subnet_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::CloudSubnet")
-      floating_ip           = floating_ip_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::FloatingIp")
-      network_port          = network_port_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::NetworkPort")
-      network_router        = network_router_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::NetworkRouter")
-      security_group        = security_group_stub.create(:ext_management_system => network_manager, :type => "#{ibm_power_vc_network_klass}::SecurityGroup")
+      cloud_network         = cloud_network_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::CloudNetwork")
+      cloud_network_public  = cloud_network_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::CloudNetwork::Public")
+      cloud_network_private = cloud_network_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::CloudNetwork::Private")
+      cloud_subnet          = cloud_subnet_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::CloudSubnet")
+      floating_ip           = floating_ip_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::FloatingIp")
+      network_port          = network_port_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::NetworkPort")
+      network_router        = network_router_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::NetworkRouter")
+      security_group        = security_group_stub.create(:ems_id => network_manager.id, :type => "#{ibm_power_vc_network_klass}::SecurityGroup")
 
       migrate
 
@@ -94,10 +94,10 @@ describe FixIbmPowerVcStiClasses do
 
       cinder_manager = ems_stub.create(:type => ibm_power_vc_cinder_klass)
 
-      cloud_volume = cloud_volume_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolume")
-      cloud_volume_backup = cloud_volume_backup_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeBackup")
-      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeSnapshot")
-      cloud_volume_type = cloud_volume_type_stub.create(:ext_management_system => cinder_manager, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeType")
+      cloud_volume = cloud_volume_stub.create(:ems_id => cinder_manager.id, :type => "#{ibm_power_vc_cinder_klass}::CloudVolume")
+      cloud_volume_backup = cloud_volume_backup_stub.create(:ems_id => cinder_manager.id, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeBackup")
+      cloud_volume_snapshot = cloud_volume_snapshot_stub.create(:ems_id => cinder_manager.id, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeSnapshot")
+      cloud_volume_type = cloud_volume_type_stub.create(:ems_id => cinder_manager.id, :type => "#{ibm_power_vc_cinder_klass}::CloudVolumeType")
 
       migrate
 

--- a/spec/migrations/20221107195522_move_existing_iso_datastore_records_spec.rb
+++ b/spec/migrations/20221107195522_move_existing_iso_datastore_records_spec.rb
@@ -12,7 +12,7 @@ describe MoveExistingIsoDatastoreRecords do
         ext_management_system_stub.create!(:type => "ManageIQ::Providers::#{vendor}::InfraManager")
       end
 
-      emss.each { |ems| datastore_stub.create!(:ext_management_system => ems) }
+      emss.each { |ems| datastore_stub.create!(:ems_id => ems.id) }
 
       migrate
 
@@ -27,7 +27,7 @@ describe MoveExistingIsoDatastoreRecords do
       end
 
       emss.each do |ems|
-        datastore = datastore_stub.create!(:ext_management_system => ems)
+        datastore = datastore_stub.create!(:ems_id => ems.id)
         iso_image_stub.create!(:iso_datastore_id => datastore.id)
       end
 


### PR DESCRIPTION
Allow rails 7 gems in gemspec

Depends on:

- [x] https://github.com/ManageIQ/activerecord-id_regions/pull/33
- [x] New id_regions release (0.4.0)
- [x] Extracted backward compatible changes: https://github.com/ManageIQ/manageiq-schema/pull/735
- [x] Fix failures creating associations in migration specs due to ActiveRecord::AssociationTypeMismatch errors.  Rails 7 only. (associations classes not matching stub models)
- [x] Fix "secrets" related test failures with rails 7 (mock/stubs on stub models)
- [x] Cleanup ENV stubbing 20180606155924_move_ansible_container_secrets_into_database (workaround inability to mock/stub stub models).

The commits should be reviewable one by one.

Rails 7 changed the way migrations are run.  The migration class
constant is now removed and the file is reloaded between migrations.

This means tests should not use expect/allow on migration stub classes
as the constant stubbed is not the same constant the migration is run against.

Additionally, comparisons of objects created before the migration with ones
after will also not work.  In that case, you can assert by id or other
attributes instead of comparing objects.

Rails also checks association classes are correct and will also not match
expectations.  For example, instead of using host to create or query
the host association, use host_id instead.  This also works with has_manys
such as miq_product_feature_ids.

See https://github.com/rails/rails/pull/42198