### PR TITLE
Remove Openstack NetworkManager metrics worker records

### DIFF
--- a/db/migrate/20240214165402_remove_openstack_network_manager_metrics_collector_workers.rb
+++ b/db/migrate/20240214165402_remove_openstack_network_manager_metrics_collector_workers.rb
@@ -1,0 +1,11 @@
+class RemoveOpenstackNetworkManagerMetricsCollectorWorkers < ActiveRecord::Migration[6.1]
+  class MiqWorker < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Deleting all Openstack NetworkManager MetricsCollectorWorker records") do
+      MiqWorker.where(:type => "ManageIQ::Providers::Openstack::NetworkManager::MetricsCollectorWorker").delete_all
+    end
+  end
+end

--- a/spec/migrations/20240214165402_remove_openstack_network_manager_metrics_collector_workers_spec.rb
+++ b/spec/migrations/20240214165402_remove_openstack_network_manager_metrics_collector_workers_spec.rb
@@ -1,0 +1,26 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe RemoveOpenstackNetworkManagerMetricsCollectorWorkers do
+  let(:miq_worker) { migration_stub(:MiqWorker) }
+
+  migration_context :up do
+    it "deletes Openstack NetworkManager MetricsCollectorWorker workers" do
+      miq_worker.create!(:type => "ManageIQ::Providers::Openstack::NetworkManager::MetricsCollectorWorker")
+
+      migrate
+
+      expect(miq_worker.count).to eq(0)
+    end
+
+    it "doesn't impact other workers" do
+      miq_worker.create!(:type => "ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker")
+      miq_worker.create!(:type => "ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker")
+
+      migrate
+
+      expect(miq_worker.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This worker class was removed in https://github.com/ManageIQ/manageiq-providers-openstack/pull/548, we should delete any leftover worker records.

Fixes https://github.com/ManageIQ/manageiq/issues/22891

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
