### PR TITLE
Update resource pool feature identifiers to infrastructure-specific

### DIFF
--- a/db/migrate/20240516101409_updateresourcepoolidentifierstomiqproductfeatures.rb
+++ b/db/migrate/20240516101409_updateresourcepoolidentifierstomiqproductfeatures.rb
@@ -1,0 +1,35 @@
+class Updateresourcepoolidentifierstomiqproductfeatures < ActiveRecord::Migration[6.1]
+  class MiqProductFeature < ActiveRecord::Base; end
+
+  FEATURE_MAPPING_UPDATE = {
+    'resource_pool'           => 'resource_pool_infra',
+    'resource_pool_view'      => 'resource_pool_infra_view',
+    'resource_pool_show_list' => 'resource_pool_infra_show_list',
+    'resource_pool_show'      => 'resource_pool_infra_show',
+    'resource_pool_control'   => 'resource_pool_infra_control',
+    'resource_pool_tag'       => 'resource_pool_infra_tag',
+    'resource_pool_protect'   => 'resource_pool_infra_protect',
+    'resource_pool_admin'     => 'resource_pool_infra_admin',
+    'resource_pool_delete'    => 'resource_pool_infra_delete'
+  }.freeze
+
+  def up
+    return if MiqProductFeature.none?
+
+    say_with_time('Updating resource_pool features to resource_pool_infra') do
+      FEATURE_MAPPING_UPDATE.each do |from, to|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+
+  def down
+    return if MiqProductFeature.none?
+
+    say_with_time('Reverting resource_pool_infra features back to resource_pool') do
+      FEATURE_MAPPING_UPDATE.each do |to, from|
+        MiqProductFeature.find_by(:identifier => from)&.update!(:identifier => to)
+      end
+    end
+  end
+end

--- a/spec/migrations/20240516101409_updateresourcepoolidentifierstomiqproductfeatures_spec.rb
+++ b/spec/migrations/20240516101409_updateresourcepoolidentifierstomiqproductfeatures_spec.rb
@@ -1,0 +1,39 @@
+require_migration
+
+describe Updateresourcepoolidentifierstomiqproductfeatures do
+  let(:miq_product_feature) { migration_stub(:MiqProductFeature) }
+
+  before do
+    %w[resource_pool resource_pool_view resource_pool_show_list resource_pool_show resource_pool_control resource_pool_tag resource_pool_protect resource_pool_admin resource_pool_delete].each do |identifier|
+      miq_product_feature.create!(:identifier => identifier)
+    end
+  end
+
+  migration_context :up do
+    it "updates existing resource_pool features to resource_pool_infra" do
+      migrate
+
+      described_class::FEATURE_MAPPING_UPDATE.each do |old_identifier, new_identifier|
+        expect(miq_product_feature.exists?(:identifier => old_identifier)).to be_falsy
+        expect(miq_product_feature.exists?(:identifier => new_identifier)).to be_truthy
+      end
+    end
+  end
+
+  migration_context :down do
+    before do
+      described_class::FEATURE_MAPPING_UPDATE.each do |_old_identifier, new_identifier|
+        miq_product_feature.create!(:identifier => new_identifier)
+      end
+    end
+
+    it "reverts resource_pool_infra features back to resource_pool" do
+      migrate
+
+      described_class::FEATURE_MAPPING_UPDATE.each do |old_identifier, new_identifier|
+        expect(miq_product_feature.exists?(:identifier => new_identifier)).to be_falsy
+        expect(miq_product_feature.exists?(:identifier => old_identifier)).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dependent PR for enabling Resource Pool feature under Clouds section(Compute > Clouds > Resource Pools)


- manageiq Core changes
https://github.com/ManageIQ/manageiq/pull/22879

- manageiq-ui-classic changes
https://github.com/ManageIQ/manageiq-ui-classic/pull/8929

- manageiq-schema changes
https://github.com/ManageIQ/manageiq-schema/pull/718

- manageiq-api changes
https://github.com/ManageIQ/manageiq-api/pull/1248