### PR TITLE
Remove Kubernetes/Openshift Monitoring Managers

### DIFF
--- a/db/migrate/20240301175100_remove_kubernetes_monitoring_manager.rb
+++ b/db/migrate/20240301175100_remove_kubernetes_monitoring_manager.rb
@@ -1,0 +1,39 @@
+class RemoveKubernetesMonitoringManager < ActiveRecord::Migration[6.1]
+  class Endpoint < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  class ExtManagementSystem < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiqWorker < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+    self.inheritance_column = :_type_disabled
+  end
+
+  class SettingsChange < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  MONITORING_MANAGER_CLASSES = %w[ManageIQ::Providers::Kubernetes::MonitoringManager ManageIQ::Providers::Openshift::MonitoringManager].freeze
+
+  def up
+    say_with_time("Removing Kubernetes and OpenShift MonitoringManagers") do
+      Endpoint.in_my_region.where(:role => "prometheus_alerts").delete_all
+      ExtManagementSystem.in_my_region.where(:type => MONITORING_MANAGER_CLASSES).delete_all
+    end
+
+    say_with_time("Removing MonitoringManager EventCatcher MiqWorker records") do
+      worker_classes = MONITORING_MANAGER_CLASSES.map { |ems_class| "#{ems_class}::EventCatcher" }
+
+      MiqWorker.in_my_region.where(:type => worker_classes).delete_all
+    end
+
+    say_with_time("Removing settings for monitoring managers") do
+      SettingsChange.in_my_region.where("key LIKE ?", "/ems/ems_kubernetes/ems_monitoring/%").delete_all
+      SettingsChange.in_my_region.where("key LIKE ?", "/workers/worker_base/event_catcher/event_catcher_prometheus/%").delete_all
+    end
+  end
+end

--- a/spec/migrations/20240301175100_remove_kubernetes_monitoring_manager_spec.rb
+++ b/spec/migrations/20240301175100_remove_kubernetes_monitoring_manager_spec.rb
@@ -1,0 +1,78 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe RemoveKubernetesMonitoringManager do
+  let(:endpoint_stub)        { migration_stub(:Endpoint) }
+  let(:ems_stub)             { migration_stub(:ExtManagementSystem) }
+  let(:miq_worker_stub)      { migration_stub(:MiqWorker) }
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "deletes kubernetes monitoring managers" do
+      container_manager = ems_stub.create!(:type => "ManageIQ::Providers::Kubernetes::ContainerManager")
+      _alerts_manager   = ems_stub.create!(:type => "ManageIQ::Providers::Kubernetes::MonitoringManager", :parent_ems_id => container_manager.id)
+      _default_endpoint = endpoint_stub.create!(:resource_type => "ExtManagementSystem", :resource_id => container_manager.id, :role => "default")
+      _alerts_endpoint  = endpoint_stub.create!(:resource_type => "ExtManagementSystem", :resource_id => container_manager.id, :role => "prometheus_alerts")
+
+      migrate
+
+      expect(ems_stub.count).to      eq(1)
+      expect(endpoint_stub.count).to eq(1)
+    end
+
+    it "deletes openshift monitoring managers" do
+      container_manager = ems_stub.create!(:type => "ManageIQ::Providers::Openshift::ContainerManager")
+      _alerts_manager   = ems_stub.create!(:type => "ManageIQ::Providers::Openshift::MonitoringManager", :parent_ems_id => container_manager.id)
+      _default_endpoint = endpoint_stub.create!(:resource_type => "ExtManagementSystem", :resource_id => container_manager.id, :role => "default")
+      _alerts_endpoint  = endpoint_stub.create!(:resource_type => "ExtManagementSystem", :resource_id => container_manager.id, :role => "prometheus_alerts")
+
+      migrate
+
+      expect(ems_stub.count).to      eq(1)
+      expect(endpoint_stub.count).to eq(1)
+    end
+
+    it "doesn't impact other EMS types" do
+      ems_stub.create!(:type => "ManageIQ::Providers::MonitoringManager")
+      ems_stub.create!(:type => "ManageIQ::Providers::InfraManager")
+
+      migrate
+
+      expect(ems_stub.count).to eq(2)
+    end
+
+    it "deletes kubernetes monitoring manager event_catchers" do
+      miq_worker_stub.create!(:type => "ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher")
+
+      migrate
+
+      expect(miq_worker_stub.count).to eq(0)
+    end
+
+    it "deletes openshift monitoring manager event_catchers" do
+      miq_worker_stub.create!(:type => "ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher")
+
+      migrate
+
+      expect(miq_worker_stub.count).to eq(0)
+    end
+
+    it "doesn't impact other worker types" do
+      miq_worker_stub.create!(:type => "ManageIQ::Providers::InfraManager::EventCatcher")
+
+      migrate
+
+      expect(miq_worker_stub.count).to eq(1)
+    end
+
+    it "deletes ems_monitoring settings changes" do
+      settings_change_stub.create!(:key => "/ems/ems_kubernetes/ems_monitoring/alerts_collection/open_timeout", :value => "--- 20.seconds\n")
+      settings_change_stub.create!(:key => "/workers/worker_base/event_catcher/event_catcher_prometheus/poll", :value => "--- 20.seconds\n")
+
+      migrate
+
+      expect(settings_change_stub.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
The Prometheus Alert Buffer Monitoring manager was only available on Openshift v3 which MIQ no longer supports for a few releases now.
This cleans up any records associated with the prometheus alert buffer monitoring manager.

TODO:
- [x] Specs
- [x] ExtManagementSystem records
- [x] Endpoints
- [x] ~~EmsEvents~~ (Tied to the parent_ems_id)
- [x] SettingsChanges
- [x] ~~MiqQueue~~ entries (Queued with the parent_ems_id)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
