### PR TITLE
Add guid column to MiqEnterprise

### DIFF
--- a/db/migrate/20240320144936_add_guid_to_miq_enterprise.rb
+++ b/db/migrate/20240320144936_add_guid_to_miq_enterprise.rb
@@ -1,0 +1,17 @@
+class AddGuidToMiqEnterprise < ActiveRecord::Migration[6.1]
+  class MiqEnterprise < ActiveRecord::Base; end
+
+  def up
+    say_with_time("Creating guids for MiqEnterprise objects") do
+      add_column :miq_enterprises, :guid, :string
+
+      MiqEnterprise.all.each { |miq_enterprise| miq_enterprise.update!(:guid => SecureRandom.uuid) }
+    end
+  end
+
+  def down
+    say_with_time("Removing guids from MiqEnterprise objects") do
+      remove_column :miq_enterprises, :guid
+    end
+  end
+end

--- a/spec/migrations/20240320144936_add_guid_to_miq_enterprise_spec.rb
+++ b/spec/migrations/20240320144936_add_guid_to_miq_enterprise_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe AddGuidToMiqEnterprise do
+  let(:miq_enterprise_stub) { migration_stub(:MiqEnterprise) }
+
+  migration_context :up do
+    it "adds a guid column and value to MiqEnterprise" do
+      miq_enterprise = miq_enterprise_stub.create!
+
+      migrate
+
+      expect(miq_enterprise.reload.guid).to be_guid
+    end
+  end
+
+  migration_context :down do
+    it "removes guid column from MiqEnterprise" do
+      miq_enterprise = miq_enterprise_stub.create!(:name => "test", :description => "test enterprise", :guid => SecureRandom.uuid)
+
+      migrate
+
+      expect(miq_enterprise.reload).to have_attributes(:name => "test", :description => "test enterprise")
+    end
+  end
+end


### PR DESCRIPTION
We need a way to determine an "instance ID" for appliances. One way is to add a GUID to MiqEnterprise since this considered to be a root object

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_labels enhancement, radjabov/yes?