### PR TITLE
Remove code for unsupported rails versions

### DIFF
--- a/spec/support/migration_helper.rb
+++ b/spec/support/migration_helper.rb
@@ -107,15 +107,9 @@ module Spec
 
       def migrate_to(version)
         suppress_migration_messages do
-          if ActiveRecord::VERSION::STRING >= "6.0.0"
-            migration_dir  = Rails.application.config.paths["db/migrate"]
-            migration_conn = ::ActiveRecord::Base.connection.schema_migration
-            ActiveRecord::MigrationContext.new(migration_dir, migration_conn).migrate(version)
-          elsif ActiveRecord::VERSION::STRING >= "5.2.0"
-            ActiveRecord::MigrationContext.new('db/migrate').migrate(version)
-          else
-            ActiveRecord::Migrator.migrate('db/migrate', version)
-          end
+          migration_dir  = Rails.application.config.paths["db/migrate"]
+          migration_conn = ::ActiveRecord::Base.connection.schema_migration
+          ActiveRecord::MigrationContext.new(migration_dir, migration_conn).migrate(version)
         end
       end
 
@@ -131,29 +125,17 @@ module Spec
       end
 
       def run_migrate
-        if ActiveRecord::VERSION::STRING >= "6.0.0"
-          migration_dir  = Rails.application.config.paths["db/migrate"]
-          migration_conn = ::ActiveRecord::Base.connection.schema_migration
-          context        = ActiveRecord::MigrationContext.new(migration_dir, migration_conn)
+        migration_dir  = Rails.application.config.paths["db/migrate"]
+        migration_conn = ::ActiveRecord::Base.connection.schema_migration
+        context        = ActiveRecord::MigrationContext.new(migration_dir, migration_conn)
 
-          context.run(migration_direction, this_migration_version)
-        elsif ActiveRecord::VERSION::STRING >= "5.2.0"
-          ActiveRecord::MigrationContext.new('db/migrate').run(migration_direction, this_migration_version)
-        else
-          described_class.migrate(migration_direction)
-        end
+        context.run(migration_direction, this_migration_version)
       end
 
       def schema_migrations
-        if ActiveRecord::VERSION::STRING >= "6.0.0"
-          migration_dir  = Rails.application.config.paths["db/migrate"]
-          migration_conn = ::ActiveRecord::Base.connection.schema_migration
-          ActiveRecord::MigrationContext.new(migration_dir, migration_conn).migrations
-        elsif ActiveRecord::VERSION::STRING >= "5.2.0"
-          ActiveRecord::MigrationContext.new('db/migrate').migrations
-        else
-          ActiveRecord::Migrator.migrations('db/migrate')
-        end
+        migration_dir  = Rails.application.config.paths["db/migrate"]
+        migration_conn = ::ActiveRecord::Base.connection.schema_migration
+        ActiveRecord::MigrationContext.new(migration_dir, migration_conn).migrations
       end
 
       def migrations_and_index


### PR DESCRIPTION
We already dropped support for rails 6 and lower so these conditionals are not needed.

Discovered when working on rails 7 support in:
https://github.com/ManageIQ/manageiq-schema/pull/715

NOTE1: Hiding whitespace helps. 
NOTE2: This is completely standalone from #715.  