### PR TITLE
Bump the rails gem minimum for CVEs

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-password",       ">= 1.2.0", "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"
   spec.add_dependency "pg"
-  spec.add_dependency "rails",                   ">=7.0.8", "<8.0"
+  spec.add_dependency "rails",                   ">=7.0.8.5", "<8.0"
 
   spec.add_development_dependency "manageiq-style", ">= 1.5.2"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
This is mostly for Mend, but it also enforces the minimum secure version.