### PR TITLE
Allow the rails method to be called and change the result only when called from the migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,6 @@ jobs:
       run: bin/setup
     - name: Run tests
       run: bundle exec rake
-      continue-on-error: ${{ matrix.rails-version == '7.2' || matrix.rails-version == '7.1'}}
     - name: Report code coverage
       if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.3' && matrix.rails-version == '7.0' }}
       continue-on-error: true

--- a/spec/migrations/20241017013023_reencrypt_password_scramsha_spec.rb
+++ b/spec/migrations/20241017013023_reencrypt_password_scramsha_spec.rb
@@ -9,9 +9,9 @@ describe ReencryptPasswordScramsha do
 
       username = ActiveRecord::Base.connection_db_config.configuration_hash[:username]
 
-      expect(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).exactly(10).times.and_call_original
-      expect(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).and_wrap_original do |original_method, *args, &block|
-        original_method.call(*args, &block).dup.tap { |i| i[:password] ||= "abc" }
+      allow(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).and_wrap_original do |original_method, *args, &block|
+        # set a value for any calls originating from the migration file, not from rails itself
+        original_method.call(*args, &block).dup.tap {|i| i[:password] ||= "abc" if caller_locations.any? {|loc| loc.path.include?("db/migrate/20241017013023_reencrypt_password_scramsha.rb")} }
       end
       expect(ActiveRecord::Base.connection).to receive(:execute).with(a_string_matching(/ALTER ROLE #{username} WITH PASSWORD \'SCRAM-SHA-256.*\'\;/))
 
@@ -23,9 +23,9 @@ describe ReencryptPasswordScramsha do
 
       username = ActiveRecord::Base.connection_db_config.configuration_hash[:username]
 
-      expect(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).exactly(10).times.and_call_original
-      expect(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).and_wrap_original do |original_method, *args, &block|
-        original_method.call(*args, &block).dup.tap { |i| i.delete(:password) }
+      allow(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).and_wrap_original do |original_method, *args, &block|
+        # set a value for any calls originating from the migration file, not from rails itself
+        original_method.call(*args, &block).dup.tap { |i| i.delete(:password) if caller_locations.any? {|loc| loc.path.include?("db/migrate/20241017013023_reencrypt_password_scramsha.rb")} }
       end
       expect(ActiveRecord::Base.connection).not_to receive(:execute).with(a_string_matching(/ALTER ROLE.*\'\;/))
 

--- a/spec/migrations/20241017013023_reencrypt_password_scramsha_spec.rb
+++ b/spec/migrations/20241017013023_reencrypt_password_scramsha_spec.rb
@@ -11,7 +11,7 @@ describe ReencryptPasswordScramsha do
 
       allow(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).and_wrap_original do |original_method, *args, &block|
         # set a value for any calls originating from the migration file, not from rails itself
-        original_method.call(*args, &block).dup.tap {|i| i[:password] ||= "abc" if caller_locations.any? {|loc| loc.path.include?("db/migrate/20241017013023_reencrypt_password_scramsha.rb")} }
+        original_method.call(*args, &block).dup.tap { |i| i[:password] ||= "abc" if caller_locations.any? {|loc| loc.path.include?(migration_path)} }
       end
       expect(ActiveRecord::Base.connection).to receive(:execute).with(a_string_matching(/ALTER ROLE #{username} WITH PASSWORD \'SCRAM-SHA-256.*\'\;/))
 
@@ -25,7 +25,7 @@ describe ReencryptPasswordScramsha do
 
       allow(ActiveRecord::Base.connection_db_config).to receive(:configuration_hash).and_wrap_original do |original_method, *args, &block|
         # set a value for any calls originating from the migration file, not from rails itself
-        original_method.call(*args, &block).dup.tap { |i| i.delete(:password) if caller_locations.any? {|loc| loc.path.include?("db/migrate/20241017013023_reencrypt_password_scramsha.rb")} }
+        original_method.call(*args, &block).dup.tap { |i| i.delete(:password) if caller_locations.any? {|loc| loc.path.include?(migration_path)} }
       end
       expect(ActiveRecord::Base.connection).not_to receive(:execute).with(a_string_matching(/ALTER ROLE.*\'\;/))
 

--- a/spec/support/migration_name_helper.rb
+++ b/spec/support/migration_name_helper.rb
@@ -1,6 +1,8 @@
 def require_migration
-  spec_name = caller_locations.first.path
-  migration_name = spec_name.sub("spec/migrations", "db/migrate").sub("_spec.rb", ".rb")
+  require migration_path
+end
 
-  require migration_name
+def migration_path
+  spec_name = caller_locations.detect {|loc| loc.path.end_with?("_spec.rb")}.path
+  spec_name.sub("spec/migrations", "db/migrate").sub("_spec.rb", ".rb")
 end


### PR DESCRIPTION
In rails 7.0, it's called 10 times plus 1 more on the next line.  In rails 7.1+, it's called only once.  From a test perspective, we don't care if it's even called. We only care that the SQL query is executed with the scramsha password or not.

To change the username/password only in calls from the migration itself and not from
rails, we hack around the caller_locations to make the change only for the migration callers.

With this, I believe we can expect test success on rails 7.1 and 7.2.

It was added in 742841cf8954be1cb5843dca33945b5fc001cf8d but I think this change emphasizes what we really care about testing and removes an assertion on internals that we don't really have interest in testing.

Fixes #768

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
