### PR TITLE
Drop tenant use_config_for_attributes

### DIFF
--- a/db/migrate/20250603164430_update_tenant_name.rb
+++ b/db/migrate/20250603164430_update_tenant_name.rb
@@ -1,0 +1,22 @@
+class UpdateTenantName < ActiveRecord::Migration[7.0]
+  class SettingsChange < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  class Tenant < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def change
+    say_with_time("Updating root tenant's name from settings") do
+      sc = SettingsChange.in_my_region.find_by(:key => "/server/company")
+      Tenant.in_my_region.find_by(:ancestry => nil, :use_config_for_attributes => true)&.update(:name => sc&.value || "My Company", :use_config_for_attributes => false)
+      SettingsChange.in_my_region.where(:key => "/server/company").destroy_all
+    end
+  end
+
+  def revert
+    # no real way to revert
+    # the record remains as :use_config_for_attributes => false, and Tenant.root.name is used
+  end
+end

--- a/db/migrate/20250603164519_drop_tenant_use_config_for_attributes.rb
+++ b/db/migrate/20250603164519_drop_tenant_use_config_for_attributes.rb
@@ -1,0 +1,5 @@
+class DropTenantUseConfigForAttributes < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :tenants, :use_config_for_attributes, :boolean
+  end
+end

--- a/spec/migrations/20250603164430_update_tenant_name_spec.rb
+++ b/spec/migrations/20250603164430_update_tenant_name_spec.rb
@@ -1,0 +1,53 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe UpdateTenantName do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+  let(:tenant_stub) { migration_stub(:Tenant) }
+
+  migration_context :up do
+    it "doesn't update tenant name if it is not use_config_for_attributes" do
+      rt = tenant_stub.create(:ancestry => nil, :name => "GoodName", :use_config_for_attributes => false)
+      chld = tenant_stub.create(:ancestry => rt.id.to_s, :name => "GoodName2", :use_config_for_attributes => false)
+
+      expect(settings_change_stub.count).to eq(0)
+      settings_change_stub.create(:key => "/server/company", :value => "BadName")
+      settings_change_stub.create(:key => "/server/other", :value => "Other")
+
+      migrate
+
+      expect(settings_change_stub.count).to eq(1)
+      expect(rt.reload.name).to eq("GoodName")
+      expect(rt.use_config_for_attributes).to eq(false)
+      expect(chld.reload.name).to eq("GoodName2")
+    end
+
+    it "updates tenant name if it is use_config_for_attributes" do
+      rt = tenant_stub.create(:ancestry => nil, :name => nil, :use_config_for_attributes => true)
+      chld = tenant_stub.create(:ancestry => rt.id.to_s, :name => "GoodName2", :use_config_for_attributes => false)
+
+      expect(settings_change_stub.count).to eq(0)
+      settings_change_stub.create(:key => "/server/company", :value => "GoodName")
+      settings_change_stub.create(:key => "/server/other", :value => "Other")
+
+      migrate
+
+      expect(settings_change_stub.count).to eq(1)
+      expect(rt.reload.name).to eq("GoodName")
+      expect(rt.use_config_for_attributes).to eq(false)
+      expect(chld.reload.name).to eq("GoodName2")
+    end
+
+    it "updates tenant name to default if it is use_config_for_attributes but no name is in settings" do
+      rt = tenant_stub.create(:ancestry => nil, :name => nil, :use_config_for_attributes => true)
+      chld = tenant_stub.create(:ancestry => rt.id.to_s, :name => "GoodName2", :use_config_for_attributes => false)
+
+      migrate
+
+      expect(rt.reload.name).to eq("My Company")
+      expect(rt.use_config_for_attributes).to eq(false)
+      expect(chld.reload.name).to eq("GoodName2")
+    end
+  end
+end


### PR DESCRIPTION
no longer using SettingsChanges for the root tenant name

part of https://github.com/ManageIQ/manageiq/pull/23463
