### PR TITLE
Fix rack CVE-2025-46727

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,5 @@ minimum_version =
     "~>7.0.8"
   end
 gem "rails", minimum_version
+# security fix for indirect dependencies
+gem "rack", ">=2.2.14" # CVE-2025-46727 https://github.com/advisories/GHSA-gjh7-p2fx-99vx


### PR DESCRIPTION
Fixes Rack issue. This is brought in by actionpack and a few others.

Since this gem is not used individually, and this dependency will be declared in manageiq (core), this is declaration just for the CI systems

I consider this a secondary gem and managiq core as the primary gemfile.
For that reason, I added it to the Gemfile

Technically, the gemspec does declare rails as a runtime dependency, so that then declares rack as a runtime dependency. So it could be argued that this change needs to be made in the gemspec. But again, I consider this a secondary dependency and wanted to avoid the churn in the gemspec.