### PR TITLE
Rails 7.1+ migration context simplifies our code

### DIFF
--- a/spec/support/migration_helper.rb
+++ b/spec/support/migration_helper.rb
@@ -108,7 +108,7 @@ module Spec
       def migrate_to(version)
         suppress_migration_messages do
           migration_dir  = Rails.application.config.paths["db/migrate"]
-          ActiveRecord::MigrationContext.new(migration_dir, schema_migration).migrate(version)
+          ActiveRecord::MigrationContext.new(migration_dir).migrate(version)
         end
       end
 
@@ -125,24 +125,14 @@ module Spec
 
       def run_migrate
         migration_dir  = Rails.application.config.paths["db/migrate"]
-        context        = ActiveRecord::MigrationContext.new(migration_dir, schema_migration)
+        context        = ActiveRecord::MigrationContext.new(migration_dir)
 
         context.run(migration_direction, this_migration_version)
       end
 
-      def schema_migration
-        # Rails 7.2 refactored the schema_migration metadata and context to the pool
-        # https://www.github.com/rails/rails/pull/51162
-        if Rails.version >= "7.2"
-          ::ActiveRecord::Base.connection.pool.schema_migration
-        else
-          ::ActiveRecord::Base.connection.schema_migration
-        end
-      end
-
       def schema_migrations
         migration_dir  = Rails.application.config.paths["db/migrate"]
-        ActiveRecord::MigrationContext.new(migration_dir, schema_migration).migrations
+        ActiveRecord::MigrationContext.new(migration_dir).migrations
       end
 
       def migrations_and_index


### PR DESCRIPTION
See: https://www.github.com/rails/rails/commit/9ef79385d92876dd5944e9d5eabd2a25853eed7a

Basically, you only need to provide a schema_migration class if not using the default connection.
Since we are using the default connection, we can exclude this entirely.


Depends on:

- [x] https://github.com/ManageIQ/manageiq-schema/pull/798
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
