### PR TITLE
Add `MiqServer#capabilities` and move `has_vix_disk_lib`

### DIFF
--- a/db/migrate/20260122201231_add_capabilities_to_miq_servers.rb
+++ b/db/migrate/20260122201231_add_capabilities_to_miq_servers.rb
@@ -1,0 +1,5 @@
+class AddCapabilitiesToMiqServers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :miq_servers, :capabilities, :jsonb, :default => {}
+  end
+end

--- a/db/migrate/20260122202147_move_miq_servers_has_vix_disk_lib_to_capabilities.rb
+++ b/db/migrate/20260122202147_move_miq_servers_has_vix_disk_lib_to_capabilities.rb
@@ -1,0 +1,22 @@
+class MoveMiqServersHasVixDiskLibToCapabilities < ActiveRecord::Migration[7.2]
+  class MiqServer < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    say_with_time("Setting MiqServer capabilities.vix_disk_lib") do
+      MiqServer
+        .in_my_region
+        .update_all("capabilities = jsonb_set(capabilities, '{vix_disk_lib}', to_json(has_vix_disk_lib)::jsonb)")
+    end
+  end
+
+  def down
+    say_with_time("Setting MiqServer has_vix_disk_lib") do
+      MiqServer.in_my_region.each do |miq_server|
+        miq_server.has_vix_disk_lib = miq_server.capabilities["vix_disk_lib"]
+        miq_server.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20260123142226_drop_miq_server_has_vix_disk_lib.rb
+++ b/db/migrate/20260123142226_drop_miq_server_has_vix_disk_lib.rb
@@ -1,0 +1,5 @@
+class DropMiqServerHasVixDiskLib < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :miq_servers, :has_vix_disk_lib, :boolean
+  end
+end

--- a/spec/migrations/20260122202147_move_miq_servers_has_vix_disk_lib_to_capabilities_spec.rb
+++ b/spec/migrations/20260122202147_move_miq_servers_has_vix_disk_lib_to_capabilities_spec.rb
@@ -1,0 +1,42 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe MoveMiqServersHasVixDiskLibToCapabilities do
+  let(:miq_server_stub) { migration_stub(:MiqServer) }
+
+  migration_context :up do
+    let(:has_vix_disk_lib) { nil }
+    let!(:miq_server) { miq_server_stub.create!(:has_vix_disk_lib => has_vix_disk_lib) }
+
+    context "with has_vix_disk_lib=true" do
+      let(:has_vix_disk_lib) { true }
+
+      it "sets capabilities.vix_disk_lib" do
+        migrate
+
+        expect(miq_server.reload).to have_attributes(:capabilities => {"vix_disk_lib" => true})
+      end
+    end
+
+    context "with has_vix_disk_lib=false" do
+      let(:has_vix_disk_lib) { false }
+
+      it "sets capabilities.vix_disk_lib" do
+        migrate
+
+        expect(miq_server.reload).to have_attributes(:capabilities => {"vix_disk_lib" => false})
+      end
+    end
+  end
+
+  migration_context :down do
+    it "sets has_vix_disk_lib" do
+      miq_server = miq_server_stub.create!(:capabilities => {"vix_disk_lib" => true})
+
+      migrate
+
+      expect(miq_server.reload).to have_attributes(:has_vix_disk_lib => true)
+    end
+  end
+end


### PR DESCRIPTION
Add a `jsonb` `:capabilities` hash to `MiqServer` to replace columns like `:has_vix_disk_lib` and allow more extensibility.

Dependents:
* https://github.com/ManageIQ/manageiq/pull/23702
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/960

Cross-repo-test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1015
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
