### PR TITLE
Warnings should go to STDERR, fix 7.0 typo

### DIFF
--- a/lib/manageiq/schema/schema_statements.rb
+++ b/lib/manageiq/schema/schema_statements.rb
@@ -76,7 +76,7 @@ module ManageIQ
           SQL
         end
       else
-        puts "\e[33mWarning: If rails 7.0 is no longer supported, this patch for rails 8's inherited_table_names can be deleted :-) #{__FILE__}:#{__LINE__}\e[0m"
+        STDERR.puts "\e[33mWarning: If rails 7.x is no longer supported, this patch for rails 8's inherited_table_names can be deleted :-) #{__FILE__}:#{__LINE__}\e[0m"
       end
 
       def change_miq_metric_sequence(table, inherit_from)


### PR DESCRIPTION
Brandon noticed the rpm build is failing when trying to parse: bundle exec rake evm:plugins:list[json]

See:
https://github.com/ManageIQ/manageiq-rpm_build/blob/f95513f443233faf3de789e89186519c61b9055e/lib/manageiq/rpm_build/generate_core.rb#L102

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
