### PR TITLE
[WIP] Add `ServerRole#default` to replace Settings.server.role

### DIFF
--- a/db/migrate/20260202175159_add_default_to_server_roles.rb
+++ b/db/migrate/20260202175159_add_default_to_server_roles.rb
@@ -1,5 +1,5 @@
 class AddDefaultToServerRoles < ActiveRecord::Migration[7.2]
   def change
-    add_column :server_roles, :default, :boolean, :default => false
+    add_column :server_roles, :default, :boolean, :default => false, :null => false
   end
 end

--- a/db/migrate/20260202175159_add_default_to_server_roles.rb
+++ b/db/migrate/20260202175159_add_default_to_server_roles.rb
@@ -1,0 +1,5 @@
+class AddDefaultToServerRoles < ActiveRecord::Migration[7.2]
+  def change
+    add_column :server_roles, :default, :boolean, :default => false
+  end
+end

--- a/db/migrate/20260202175309_set_default_on_existing_server_role_records.rb
+++ b/db/migrate/20260202175309_set_default_on_existing_server_role_records.rb
@@ -9,8 +9,10 @@ class SetDefaultOnExistingServerRoleRecords < ActiveRecord::Migration[7.2]
   end
 
   def up
-    # All new server_role records will default to false so we only need
-    # to set specific ones to true here
-    ServerRole.in_my_region.where(:name => DEFAULT_ROLES).update_all(:default => true)
+    say_with_time("Setting default on server roles") do
+      # All new server_role records will default to false so we only need
+      # to set specific ones to true here
+      ServerRole.in_my_region.where(:name => DEFAULT_ROLES).update_all(:default => true)
+    end
   end
 end

--- a/db/migrate/20260202175309_set_default_on_existing_server_role_records.rb
+++ b/db/migrate/20260202175309_set_default_on_existing_server_role_records.rb
@@ -1,0 +1,16 @@
+class SetDefaultOnExistingServerRoleRecords < ActiveRecord::Migration[7.2]
+  DEFAULT_ROLES = %w[automate database_operations event reporting scheduler
+                     smartstate ems_operations ems_inventory ems_metrics_collector
+                     ems_metrics_coordinator ems_metrics_processor notifier
+                     user_interface remote_console web_services].freeze
+
+  class ServerRole < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  def up
+    # All new server_role records will default to false so we only need
+    # to set specific ones to true here
+    ServerRole.in_my_region.where(:name => DEFAULT_ROLES).update_all(:default => true)
+  end
+end

--- a/spec/migrations/20260202175309_set_default_on_existing_server_role_records_spec.rb
+++ b/spec/migrations/20260202175309_set_default_on_existing_server_role_records_spec.rb
@@ -1,0 +1,17 @@
+require_migration
+
+describe SetDefaultOnExistingServerRoleRecords do
+  let(:server_roles_stub) { migration_stub(:ServerRole) }
+
+  migration_context :up do
+    it "sets default on existing server roles" do
+      automate_role  = server_roles_stub.create!(:name => "automate")
+      git_owner_role = server_roles_stub.create!(:name => "git_owner")
+
+      migrate
+
+      expect(automate_role.reload).to be_default
+      expect(git_owner_role.reload).not_to be_default
+    end
+  end
+end


### PR DESCRIPTION
Add a `:default` column to `ServerRole` so that we do not need to use `Settings.server.role` to indicate if a role should be enabled by default or not.

This allows for plugins to bring default server roles.

Dependents:
* https://github.com/ManageIQ/manageiq/pull/23717
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/114
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
