### PR TITLE
Update AWX/AAP provider url to always include scheme

### DIFF
--- a/db/migrate/20260205150345_add_scheme_to_provider_url.rb
+++ b/db/migrate/20260205150345_add_scheme_to_provider_url.rb
@@ -1,0 +1,24 @@
+class AddSchemeToProviderUrl < ActiveRecord::Migration[7.2]
+  PROVIDER_TYPES = %w[ManageIQ::Providers::Awx::Provider ManageIQ::Providers::AnsibleTower::Provider].freeze
+
+  class Endpoint < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+  end
+
+  class Provider < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.inheritance_column = :_type_disabled
+  end
+
+  def change
+    say_with_time("Adding http:// scheme to Provider url") do
+      providers = Provider.in_my_region.where(:type => PROVIDER_TYPES)
+      Endpoint.in_my_region
+              .where(:resource_type => "Provider", :resource_id => providers)
+              .where.not(:url => nil)
+              .where.not("url LIKE ?", "%://%")
+              .update_all(["url = CONCAT(?, url)", "http://"])
+    end
+  end
+end

--- a/spec/migrations/20260205150345_add_scheme_to_provider_url_spec.rb
+++ b/spec/migrations/20260205150345_add_scheme_to_provider_url_spec.rb
@@ -1,0 +1,50 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe AddSchemeToProviderUrl do
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+  let(:provider_stub) { migration_stub(:Provider) }
+
+  migration_context :up do
+    let(:awx_provider) { provider_stub.create!(:type => "ManageIQ::Providers::Awx::Provider") }
+    let(:aap_provider) { provider_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::Provider") }
+
+    it "adds http to a url without a scheme" do
+      awx_endpoint = endpoint_stub.create!(:url => "192.168.122.10:3000", :resource_type => "Provider", :resource_id => awx_provider.id)
+      aap_endpoint = endpoint_stub.create!(:url => "192.168.122.20:3000", :resource_type => "Provider", :resource_id => aap_provider.id)
+
+      migrate
+
+      expect(awx_endpoint.reload.url).to eq("http://192.168.122.10:3000")
+      expect(aap_endpoint.reload.url).to eq("http://192.168.122.20:3000")
+    end
+
+    it "doesn't add http to a url with a scheme" do
+      awx_endpoint = endpoint_stub.create!(:url => "https://192.168.122.10:3000", :resource_type => "Provider", :resource_id => awx_provider.id)
+      aap_endpoint = endpoint_stub.create!(:url => "ftp://192.168.122.20:3000", :resource_type => "Provider", :resource_id => aap_provider.id)
+
+      migrate
+
+      expect(awx_endpoint.reload.url).to eq("https://192.168.122.10:3000")
+      expect(aap_endpoint.reload.url).to eq("ftp://192.168.122.20:3000")
+    end
+
+    it "doesn't update nil urls" do
+      awx_endpoint = endpoint_stub.create!(:url => nil, :resource_type => "Provider", :resource_id => awx_provider.id)
+
+      migrate
+
+      expect(awx_endpoint.reload.url).to be_nil
+    end
+
+    it "doesn't update other providers" do
+      foreman_provider = provider_stub.create!(:type => "ManageIQ::Providers::Foreman::Provider")
+      foreman_endpoint = endpoint_stub.create!(:url => "192.168.122.10:3000", :resource_type => "Provider", :resource_id => foreman_provider.id)
+
+      migrate
+
+      expect(foreman_endpoint.reload.url).to eq("192.168.122.10:3000")
+    end
+  end
+end


### PR DESCRIPTION
The AWX/AAP Provider code allows a partial url without the scheme, and at runtime prepends `http://` if it doesn't start with `https://`: `url = "http://#{url}" unless url =~ %r{\Ahttps?:\/\/}`

This looks for any `url` columns in the `AWX` or `AnsibleTower` providers that doesn't have a scheme and adds `http://` (just like the old runtime code would do).

This allows us to parse the `url` with `URI(url)` without having to dynamically add a scheme, as well as use the DDF url validator.

Required for:
* https://github.com/ManageIQ/manageiq-providers-awx/pull/50
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
