### PR TITLE
Create Embedded ConfigurationScripts for Payloads

### DIFF
--- a/db/migrate/20260224155930_add_configuration_script_for_embedded_payloads.rb
+++ b/db/migrate/20260224155930_add_configuration_script_for_embedded_payloads.rb
@@ -1,0 +1,31 @@
+class AddConfigurationScriptForEmbeddedPayloads < ActiveRecord::Migration[8.0]
+  PAYLOAD_TO_SCRIPT_MAPPING = {
+    "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook"   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript",
+    "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template" => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScript"
+  }.freeze
+
+  class ConfigurationScriptBase < ActiveRecord::Base
+    include ActiveRecord::IdRegions
+
+    self.table_name = "configuration_scripts"
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Creating ConfigurationScripts for EmbeddedAutomation Payloads") do
+      ConfigurationScriptBase.in_my_region.where(:type => PAYLOAD_TO_SCRIPT_MAPPING.keys).each do |payload|
+        attrs = payload.attributes.slice("manager_id", "name")
+        attrs["type"]      = PAYLOAD_TO_SCRIPT_MAPPING[payload.type]
+        attrs["parent_id"] = payload.id
+
+        ConfigurationScriptBase.create!(attrs)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Deleting EmbeddedAutomation ConfigurationScripts") do
+      ConfigurationScriptBase.in_my_region.where(:type => PAYLOAD_TO_SCRIPT_MAPPING.values).delete_all
+    end
+  end
+end

--- a/spec/migrations/20260224155930_add_configuration_script_for_embedded_payloads_spec.rb
+++ b/spec/migrations/20260224155930_add_configuration_script_for_embedded_payloads_spec.rb
@@ -1,0 +1,57 @@
+require_migration
+
+# This is mostly necessary for data migrations, so feel free to delete this
+# file if you do no need it.
+describe AddConfigurationScriptForEmbeddedPayloads do
+  let(:configuration_script_base_stub) { migration_stub(:ConfigurationScriptBase) }
+
+  migration_context :up do
+    it "creates EmbeddedAnsible and EmbeddedTerraform ConfigurationScripts" do
+      embedded_ansible_playbook   = configuration_script_base_stub.create!(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook", :name => "playbook.yml")
+      embedded_terraform_template = configuration_script_base_stub.create!(:type => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template", :name => "template.yml")
+
+      migrate
+
+      expect(configuration_script_base_stub.count).to eq(4)
+
+      expect(configuration_script_base_stub.find_by(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript")).to have_attributes(
+        :name      => "playbook.yml",
+        :parent_id => embedded_ansible_playbook.id
+      )
+
+      expect(configuration_script_base_stub.find_by(:type => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScript")).to have_attributes(
+        :name      => "template.yml",
+        :parent_id => embedded_terraform_template.id
+      )
+    end
+
+    it "ignores other ConfigurationScriptPayloads" do
+      configuration_script_base_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook", :name => "playbook.yml")
+
+      migrate
+
+      expect(configuration_script_base_stub.count).to eq(1)
+    end
+  end
+
+  migration_context :down do
+    it "deletes EmbeddedAutomation ConfigurationScripts" do
+      configuration_script_base_stub.create!(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook", :name => "playbook.yml")
+      configuration_script_base_stub.create!(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript", :name => "playbook.yml")
+      configuration_script_base_stub.create!(:type => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template", :name => "template.yml")
+      configuration_script_base_stub.create!(:type => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScript", :name => "template.yml")
+
+      migrate
+
+      expect(configuration_script_base_stub.where(:type => ["ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript", "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScript"]).count).to be_zero
+    end
+
+    it "ignores other ConfigurationScripts" do
+      configuration_script_base_stub.create!(:type => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript", :name => "playbook.yml")
+
+      migrate
+
+      expect(configuration_script_base_stub.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
For each EmbeddedAutomation ConfigurationScriptPayload create an equivalent ConfigurationScript that can be ordered via the Service Catalog.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/116
- [x] https://github.com/ManageIQ/manageiq/pull/23731

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
