### PR TITLE
Add indexes for Physical Infrastructure and Container Inventory references to EventStreams

### DIFF
--- a/db/migrate/20260526142316_add_physical_infra_indexes_to_event_streams.rb
+++ b/db/migrate/20260526142316_add_physical_infra_indexes_to_event_streams.rb
@@ -1,0 +1,8 @@
+class AddPhysicalInfraIndexesToEventStreams < ActiveRecord::Migration[8.0]
+  def change
+    add_index :event_streams, :physical_server_id
+    add_index :event_streams, :physical_chassis_id
+    add_index :event_streams, :physical_switch_id
+    add_index :event_streams, :physical_storage_id
+  end
+end

--- a/db/migrate/20260526193354_add_container_inventory_indexes_to_event_streams.rb
+++ b/db/migrate/20260526193354_add_container_inventory_indexes_to_event_streams.rb
@@ -1,0 +1,8 @@
+class AddContainerInventoryIndexesToEventStreams < ActiveRecord::Migration[8.0]
+  def change
+    add_index :event_streams, :container_group_id
+    add_index :event_streams, :container_id
+    add_index :event_streams, :container_node_id
+    add_index :event_streams, :container_replicator_id
+  end
+end

--- a/spec/automated_review/foreign_key_columns_have_indexes_spec.rb
+++ b/spec/automated_review/foreign_key_columns_have_indexes_spec.rb
@@ -109,10 +109,6 @@ describe "foreign key (*_id) columns" do
       disks.backing_id
       disks.storage_profile_id
       entitlements.miq_user_role_id
-      event_streams.container_group_id
-      event_streams.container_id
-      event_streams.container_node_id
-      event_streams.container_replicator_id
       event_streams.dest_ems_cluster_id
       event_streams.group_id
       event_streams.target_id

--- a/spec/automated_review/foreign_key_columns_have_indexes_spec.rb
+++ b/spec/automated_review/foreign_key_columns_have_indexes_spec.rb
@@ -115,10 +115,6 @@ describe "foreign key (*_id) columns" do
       event_streams.container_replicator_id
       event_streams.dest_ems_cluster_id
       event_streams.group_id
-      event_streams.physical_chassis_id
-      event_streams.physical_server_id
-      event_streams.physical_storage_id
-      event_streams.physical_switch_id
       event_streams.target_id
       event_streams.tenant_id
       event_streams.user_id


### PR DESCRIPTION
The `event_streams` table has a number of references to physical infrastructure inventory via foreign key but was missing indexes for these references.

`db/schema.rb` after `db:migrate`:
```
    t.index ["physical_chassis_id"], name: "index_event_streams_on_physical_chassis_id"
    t.index ["physical_server_id"], name: "index_event_streams_on_physical_server_id"
    t.index ["physical_storage_id"], name: "index_event_streams_on_physical_storage_id"
    t.index ["physical_switch_id"], name: "index_event_streams_on_physical_switch_id"
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
