### PR TITLE
Unlock concurrent-ruby for rails 7.1+

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ancestry"
   spec.add_dependency "activerecord-id_regions", "~> 0.6.0"
-  spec.add_dependency "concurrent-ruby",         "< 1.3.5" # Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 7.0, and rails-core doesn't
-                                                           # plan to ship a new 7.0 to fix it. See https://github.com/rails/rails/pull/54264
   spec.add_dependency "manageiq-password",       ">= 1.2.0", "< 2"
   spec.add_dependency "more_core_extensions",    ">= 3.5", "< 5"
   spec.add_dependency "pg"


### PR DESCRIPTION
This was locked down in https://github.com/ManageIQ/manageiq/pull/23310 for rails 7 and then subsequently unlocked by https://github.com/ManageIQ/manageiq/commit/ba9550606fa2d34c9a63f5434dd4f54e6de6038c in https://github.com/ManageIQ/manageiq/pull/23225 for rails 7.1 but this was left.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
