### PR TITLE
Add mem/proc attributes to hardwares

### DIFF
--- a/db/migrate/20260804060955_add_mem_proc_attributes_to_hardwares.rb
+++ b/db/migrate/20260804060955_add_mem_proc_attributes_to_hardwares.rb
@@ -1,0 +1,8 @@
+class AddMemProcAttributesToHardwares < ActiveRecord::Migration[8.0]
+  def change
+    add_column :hardwares, :memory_mb_configured, :integer
+    add_column :hardwares, :cpu_configured_cores, :integer
+    add_column :hardwares, :memory_mb_available, :integer
+    add_column :hardwares, :cpu_available_cores, :integer
+  end
+end


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->
Currently hardware table stores only Installed Memory and Installed Processor values. The existing attributes are

memory_mb - > The total physical memory present in the Physical Host (Installed Memory)
cpu_total_cores - > The total physical cores present in the Physical Host (Installed Procs)

Adding 4 more values related to processor and memory.

memory_mb_configured -> Portion of installed memory that is licensed (Configured Memory)
cpu_configured_cores -> Portion of installed cores that is licensed (Configured Procs)
memory_mb_available -> Configured memory that is currently free and can be assigned to VMs (Available Memory)
cpu_available_cores -> Configured proc that is currently free and can be assigned to VMs (Available Procs)

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
@miq-bot add-label enhancement